### PR TITLE
Make SPM compile from source instead of using a binaryTarget

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,10 +20,10 @@ let package = Package(
         // no dependencies
     ],
     targets: [
-        .binaryTarget(
+        .target(
             name: "GrowthBook",
-    url: "https://github.com/growthbook/growthbook-swift/releases/download/1.0.0/GrowthBook.xcframework.zip",
-    checksum: "756609fcbf0f44a697cbe73304fbd3317495ea2080c89c7b240bd99a80ac57a6"
-        ),
+            dependencies: [],
+            path: "Sources/CommonMain"
+        )
     ]
 )


### PR DESCRIPTION
I was having difficulties adding the package as an SPM dependency, and upon further inspection found that SPM builds it fine from source. Using the package as a normal target instead of a binaryTarget is working fine for my projects now.