### PR TITLE
Make cache path public

### DIFF
--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -10,14 +10,6 @@ public protocol CachingLayer: AnyObject {
 public class CachingManager: CachingLayer {
     static let shared = CachingManager()
 
-    func getData(fileName: String) -> Data? {
-        return getContent(fileName: fileName)
-    }
-
-    func putData(fileName: String, content: Data) {
-        saveContent(fileName: fileName, content: content)
-    }
-
     /// Save content in cache
     public func saveContent(fileName: String, content: Data) {
         let fileManager = FileManager.default
@@ -65,7 +57,7 @@ public class CachingManager: CachingLayer {
             true
         ).first else { return "" }
         // Append Folder name
-        let targetFolderPath = directoryPath + "GrowthBook-Cache"
+        let targetFolderPath = directoryPath + "/GrowthBook-Cache"
 
         let fileManager = FileManager.default
         // Check if folder exists

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -10,6 +10,14 @@ public protocol CachingLayer: AnyObject {
 public class CachingManager: CachingLayer {
     static let shared = CachingManager()
 
+    func getData(fileName: String) -> Data? {
+        return getContent(fileName: fileName)
+    }
+
+    func putData(fileName: String, content: Data) {
+        saveContent(fileName: fileName, content: content)
+    }
+
     /// Save content in cache
     public func saveContent(fileName: String, content: Data) {
         let fileManager = FileManager.default

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 /// Constants Class - GrowthBook
-enum Constants {
+public enum Constants {
     /// ID Attribute Key
-    static let idAttributeKey = "id"
+    public static let idAttributeKey = "id"
     /// Identifier for Caching Feature Data in Internal Storage File
-    static let featureCache = "FeatureCache"
+    public static let featureCache = "FeatureCache"
 }
 
 /// Type Alias for Feature in GrowthBook


### PR DESCRIPTION
What was done:

1. Cache path (and all Constants) was made **public** to let users set default values before config is loaded from the back end.
2. Fixed cache path.
