### PR TITLE
Remove refreshHandler parameter from GrowthBook and make its refreshCache() method asynchronous

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */; };
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
+		84C0976128AA50F400A9D290 /* MockCachingLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C0976028AA50F400A9D290 /* MockCachingLayer.swift */; };
 		84CDE32B2812F359008B3E6F /* GrowthBook.h in Headers */ = {isa = PBXBuildFile; fileRef = 84CDE32A2812F359008B3E6F /* GrowthBook.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84CDE3332812F454008B3E6F /* GrowthBookSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F627F845EB0072BFDC /* GrowthBookSDK.swift */; };
 		84CDE3342812F454008B3E6F /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F827F845EB0072BFDC /* NetworkClient.swift */; };
@@ -90,6 +91,7 @@
 		846280E7280DBE9C00C83CDE /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		84628147280F2AC400C83CDE /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		849114BD280DA71E00C0B9A5 /* GrowthBookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowthBookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		84C0976028AA50F400A9D290 /* MockCachingLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCachingLayer.swift; sourceTree = "<group>"; };
 		84CDE3282812F359008B3E6F /* GrowthBook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GrowthBook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84CDE32A2812F359008B3E6F /* GrowthBook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook.h; sourceTree = "<group>"; };
 		84F51E9627F419B000994D1C /* GrowthBook_IOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook_IOS.h; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				84391F1827FD7C30003309DC /* UtilsTests.swift */,
 				84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */,
 				84391F1C27FD89F7003309DC /* MockNetworkClient.swift */,
+				84C0976028AA50F400A9D290 /* MockCachingLayer.swift */,
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
 			);
 			path = GrowthBookTests;
@@ -390,6 +393,7 @@
 				849114C9280DA73000C0B9A5 /* ExperimentRunTests.swift in Sources */,
 				849114CA280DA73100C0B9A5 /* FeatureValueTests.swift in Sources */,
 				849114CB280DA73100C0B9A5 /* TestHelper.swift in Sources */,
+				84C0976128AA50F400A9D290 /* MockCachingLayer.swift in Sources */,
 				849114CC280DA73100C0B9A5 /* UtilsTests.swift in Sources */,
 				849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,

--- a/GrowthBookTests/GrowthBookSDKBuilderTests.swift
+++ b/GrowthBookTests/GrowthBookSDKBuilderTests.swift
@@ -9,8 +9,7 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     func testSDKInitializationDefault() throws {
         let sdkInstance = GrowthBookBuilder(hostURL: testURL,
                                         attributes: testAttributes,
-                                        trackingCallback: { _, _ in },
-                                        refreshHandler: nil).initializer()
+                                        trackingCallback: { _, _ in }).initializer()
         
         XCTAssertTrue(sdkInstance.getGBContext().isEnabled)
         XCTAssertTrue(sdkInstance.getGBContext().hostURL == testURL)
@@ -25,8 +24,11 @@ class GrowthBookSDKBuilderTests: XCTestCase {
 
         let sdkInstance = GrowthBookBuilder(hostURL: testURL,
                                         attributes: testAttributes,
-                                        trackingCallback: { _, _ in },
-                                        refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in }).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
+                                        trackingCallback: { _, _ in })
+            .setEnabled(isEnabled: false)
+            .setForcedVariations(forcedVariations: variations)
+            .setQAMode(isEnabled: true)
+            .initializer()
 
         XCTAssertFalse(sdkInstance.getGBContext().isEnabled)
         XCTAssertTrue(sdkInstance.getGBContext().hostURL == testURL)
@@ -42,8 +44,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
 
         let sdkInstance = GrowthBookBuilder(hostURL: testURL,
                                         attributes: testAttributes,
-                                        trackingCallback: { _, _ in },
-                                        refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
+                                        trackingCallback: { _, _ in })
+            .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil))
+            .setEnabled(isEnabled: false)
+            .setForcedVariations(forcedVariations: variations)
+            .setQAMode(isEnabled: true)
+            .initializer()
 
         XCTAssertFalse(sdkInstance.getGBContext().isEnabled)
         XCTAssertTrue(sdkInstance.getGBContext().hostURL == testURL)
@@ -52,38 +58,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
         
     }
     
-    func testSDKRefreshHandler() throws {
-        
-        var isRefreshed = false
-        let sdkInstance = GrowthBookBuilder(hostURL: testURL,
-                                        attributes: testAttributes,
-                                        trackingCallback: { _, _ in },
-                                        refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
-            isRefreshed = true
-        }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
-
-        XCTAssertTrue(isRefreshed)
-        
-        isRefreshed = false
-        
-        sdkInstance.refreshCache()
-        
-        XCTAssertTrue(isRefreshed)
-        
-    }
-    
     func testSDKFeaturesData() throws {
-        
-        var isRefreshed = false
-
         let sdkInstance = GrowthBookBuilder(hostURL: testURL,
                                         attributes: testAttributes,
-                                        trackingCallback: { _, _ in },
-                                        refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
-            isRefreshed = true
-        }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
-        
-        XCTAssertTrue(isRefreshed)
+                                        trackingCallback: { _, _ in })
+            .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil))
+            .initializer()
         
         XCTAssertTrue(sdkInstance.getFeatures().contains(where: {$0.key == "onboarding"}))
         XCTAssertFalse(sdkInstance.getFeatures().contains(where: {$0.key == "fwrfewrfe"}))
@@ -92,10 +72,8 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     func testSDKRunMethods() throws {
         let sdkInstance = GrowthBookBuilder(hostURL: testURL,
                                         attributes: testAttributes,
-                                        trackingCallback: { _, _ in },
-                                        refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
-
-        }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
+                                        trackingCallback: { _, _ in })
+            .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
         
         let featureValue = sdkInstance.evalFeature(id: "fwrfewrfe")
         XCTAssertTrue(featureValue.source == FeatureSource.unknownFeature.rawValue)

--- a/GrowthBookTests/MockCachingLayer.swift
+++ b/GrowthBookTests/MockCachingLayer.swift
@@ -1,0 +1,18 @@
+//
+//  MockCachingLayer.swift
+//  GrowthBookTests
+//
+//  Created by Viacheslav Karamov on 15/08/2022.
+//
+
+import Foundation
+@testable import GrowthBook
+
+class MockCachingLayer: CachingLayer {
+    func saveContent(fileName: String, content: Data) {
+    }
+    
+    func getContent(fileName: String) -> Data? {
+        Data()
+    }
+}

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -21,7 +21,7 @@ class FeaturesViewModel {
             let decoder = JSONDecoder()
             if let jsonPetitions = try? decoder.decode(FeaturesDataModel.self, from: json) {
                 if let features = jsonPetitions.features {
-                    completion(.success(features), true)
+                    completion(.success(features), false)
                 } else {
                     completion(.failure(.failedParsedData), false)
                     logger.error("Failed parsed local data")

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -110,7 +110,7 @@ public struct GrowthBookModel {
         if let features = features {
             gbContext.features = features
         } else {
-            refreshCacheInternal()
+            refreshCache(completion: nil)
         }
         // Logger setup. if we have logHandler we have to re-initialise logger
         logger.minLevel = logLevel
@@ -118,7 +118,19 @@ public struct GrowthBookModel {
 
     /// Manually Refresh Cache
     @objc public func refreshCache(completion: CacheRefreshHandler?) {
-        refreshCacheInternal(completion: completion)
+        featureVM.fetchFeatures(apiUrl: gbContext.hostURL) {[weak self] result, isRemote in
+            switch result {
+                case .success(let features):
+                    self?.gbContext.features = features
+                    if isRemote {
+                        completion?(true)
+                    }
+                case .failure:
+                    if isRemote {
+                        completion?(false)
+                    }
+            }
+        }
     }
 
     /// Get Context - Holding the complete data regarding cached features & attributes etc.
@@ -154,21 +166,5 @@ public struct GrowthBookModel {
     /// The setAttributes method replaces the Map of user attributes that are used to assign variations
     @objc public func setAttributes(attributes: Any) {
         gbContext.attributes = JSON(attributes)
-    }
-    
-    private func refreshCacheInternal(completion: CacheRefreshHandler? = nil) {
-        featureVM.fetchFeatures(apiUrl: gbContext.hostURL) {[weak self] result, isRemote in
-            switch result {
-                case .success(let features):
-                    self?.gbContext.features = features
-                    if isRemote {
-                        completion?(true)
-                    }
-                case .failure:
-                    if isRemote {
-                        completion?(false)
-                    }
-            }
-        }
     }
 }


### PR DESCRIPTION
As a user, I want to know when the cache is updated. At the same time, I want to receive one callback call each time the cache is updated. In the current implementation, if the RefreshCache() method is called almost at the same time that GrowthBook is created, the callback is called twice, which can cause problems when the client code uses DispatchGroup.
What was done:

- Removed `refreshHandler` parameter from GrowthBook and GrowthBookWrapper classes.
- Callback parameter added to `GrowthBook.refreshCache()`
- Removed `FeaturesFlowDelegate`
- FeaturesViewModel made internal
- Removed usage of CachingManager.shared in favour of the `CachingLayer` protocol.
- Updated tests.