### PR TITLE
Feature isOn logic fix with unit tests

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		231FB2292910F78D0035546E /* json.json in Resources */ = {isa = PBXBuildFile; fileRef = 84391F2628016C85003309DC /* json.json */; };
 		84095C792817EC7800ADDF19 /* JsonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C772817EAB700ADDF19 /* JsonManager.swift */; };
 		84095C8C281823BC00ADDF19 /* LoggingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C8A281822B900ADDF19 /* LoggingManager.swift */; };
 		84095C902818245700ADDF19 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C8E2818245100ADDF19 /* Formatter.swift */; };
@@ -368,6 +369,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				231FB2292910F78D0035546E /* json.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GrowthBookTests/Source/json.json
+++ b/GrowthBookTests/Source/json.json
@@ -1699,6 +1699,23 @@
           }
         ],
         [
+          "uses custom values - json (Bug: when json value is given, feature.isOn gives false, Expected: when feature value is non-null, valid json, feature.isOn should give true)",
+          {
+            "features": {
+              "feature": {
+                "defaultValue": { "isJSON" : true }
+              }
+            }
+          },
+          "feature",
+          {
+            "value": { "isJSON" : true },
+            "on": true,
+            "off": false,
+            "source": "defaultValue"
+          }
+        ],
+        [
           "force rules",
           {
             "features": {

--- a/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
@@ -83,7 +83,7 @@ class FeatureEvaluator {
     private func prepareResult(value: JSON?, source: FeatureSource, experiment: Experiment? = nil, result: ExperimentResult? = nil) -> FeatureResult {
         var isFalse = false
         if let value = value {
-            isFalse = value.stringValue == "false" || value.stringValue.isEmpty || value.stringValue == "0"
+            isFalse = value.stringValue == "false" || value.stringValue == "0" || (value.stringValue.isEmpty && value.dictionary == nil && value.array == nil)
         }
         return FeatureResult(value: value, isOn: !isFalse, source: source.rawValue, experiment: experiment, result: result)
     }


### PR DESCRIPTION
### Bug:
if feature value is a json or array then feature.isOn flag returns false all the time

### Expected:
if feature value is non-null valid json or non-null array then feature.isOn flag should return true

### Fix:
When setting isOn flag in `prepareResult` function, we should check dictionary and array values as well. 

Main reason is, `SwiftyJSON` does not give json string if json type is dictionary or array, it returns empty string