### PR TITLE
Fix tvOS Compatibility and Document Directory Access Issue

### DIFF
--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -60,7 +60,7 @@ public class CachingManager: CachingLayer {
     func getTargetFile(fileName: String) -> String {
         // Get Documents Directory Path
         guard let directoryPath = NSSearchPathForDirectoriesInDomains(
-            .documentDirectory,
+            .cachesDirectory,
             .userDomainMask,
             true
         ).first else { return "" }


### PR DESCRIPTION
Unfortunately, the current implementation doesn't fully work on tvOS because we don't have access to the document directory. You can refer to the documentation below for more information:

[Apple TV Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppleTV_PG/index.html#//apple_ref/doc/uid/TP40015241)

While it does work on the simulator, it encounters an error on real devices with the message: "CachingManager.swift:78 ERROR: Failed to create directory: You do not have permission to save the file 'GrowthBook-Cache' in the 'Documents' folder." at the initialization: 

```swift
GrowthBookBuilder(url: growthbookUrl,
                                  attributes: attributes,
                                  trackingCallback: { _, _ in }).initializer()
```

Regarding the impact on iOS and WatchOS, I'm not certain. However, since this is related to caching, I guess there shouldn't be a risk if the OS decides to clear this data.