### PR TITLE
Feature: added version string compare

### DIFF
--- a/GrowthBookTests/Source/json.json
+++ b/GrowthBookTests/Source/json.json
@@ -449,6 +449,150 @@
           true
         ],
         [
+          "$veq     - pass",
+            {
+            "version": {
+               "$veq": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.3-rc.1"
+            },
+            true
+        ],
+        [
+          "$veq     - fail",
+            {
+            "version": {
+               "$veq": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1-    2-    3-rc-    2"
+            },
+            false
+        ],
+        [
+          "$vne     - pass",
+            {
+            "version": {
+               "$vne": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.3.4-rc.3"
+            },
+            true
+        ],
+        [
+          "$vne     - fail",
+            {
+            "version": {
+               "$vne": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.3-rc.1"
+            },
+            false
+        ],
+        [
+          "$vgt     - pass",
+            {
+            "version": {
+               "$vgt": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.4-rc.0"
+            },
+            true
+        ],
+        [
+          "$vgt     - fail",
+            {
+            "version": {
+               "$vgt": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.2-rc.0"
+            },
+            false
+        ],
+        [
+          "$vgte     - pass",
+            {
+            "version": {
+               "$vgte": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.3-rc.1"
+            },
+            true
+        ],
+        [
+          "$vgte     - fail",
+            {
+            "version": {
+               "$vgte": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.2-rc.1"
+            },
+            false
+        ],
+        [
+          "$vlt     - pass",
+            {
+            "version": {
+               "$vlt": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.2-rc.1"
+            },
+            true
+        ],
+        [
+          "$vlt     - fail",
+            {
+            "version": {
+               "$vlt": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.4-rc.1"
+            },
+            false
+        ],
+        [
+          "$vlte     - pass",
+            {
+            "version": {
+               "$vlte": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.3-rc.1"
+            },
+            true
+        ],
+        [
+          "$vlte     - fail",
+            {
+            "version": {
+               "$vlte": "v1.2.3-rc.1+build123"
+            }
+            },
+            {
+               "version": "1.2.4-rc.1"
+            },
+            false
+        ],
+        [
           "$eq     - fail",
           {
             "occupation": {

--- a/GrowthBookTests/UtilsTests.swift
+++ b/GrowthBookTests/UtilsTests.swift
@@ -198,4 +198,12 @@ class UtilsTests: XCTestCase {
 
         XCTAssertTrue(Utils.shared.getGBNameSpace(namespace: items) == nil)
     }
+    
+    func testPaddedVersionString() throws {
+        let startValue = "v1.2.3-rc.1+build123"
+        let expectedValue = "    1-    2-    3-rc-    1"
+        let endValue = Utils.shared.paddedVersionString(input: startValue)
+        
+        XCTAssertEqual(endValue, expectedValue)
+    }
 }

--- a/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
@@ -319,6 +319,30 @@ class ConditionEvaluator {
             let targetPrimitiveValue = conditionValue
             let sourcePrimitiveValue = attributeValue
             switch operatorKey {
+            case "$veq":
+                if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
+                    return Utils.shared.paddedVersionString(input: attributeString) == Utils.shared.paddedVersionString(input: conditionString)
+                }
+            case "$vne":
+                if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
+                    return Utils.shared.paddedVersionString(input: attributeString) != Utils.shared.paddedVersionString(input: conditionString)
+                }
+            case "$vgt":
+                if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
+                    return Utils.shared.paddedVersionString(input: attributeString) > Utils.shared.paddedVersionString(input: conditionString)
+                }
+            case "$vgte":
+                if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
+                    return Utils.shared.paddedVersionString(input: attributeString) >= Utils.shared.paddedVersionString(input: conditionString)
+                }
+            case "$vlt":
+                if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
+                    return Utils.shared.paddedVersionString(input: attributeString) < Utils.shared.paddedVersionString(input: conditionString)
+                }
+            case "$vlte":
+                if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
+                    return Utils.shared.paddedVersionString(input: attributeString) <= Utils.shared.paddedVersionString(input: conditionString)
+                }
             // Evaluate EQ operator - whether condition equals to attribute
             case "$eq":
                 return  attributeValue == conditionValue

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -106,6 +106,23 @@ public class Utils {
         }
         return nil
     }
+    
+    func paddedVersionString(input: String) -> String {
+        var parts = input.replacingOccurrences(of: "[v]", with: "", options: .regularExpression)
+        if let range = parts.range(of: "+")?.lowerBound {
+            parts = String(parts.prefix(upTo: range))
+        }
+        
+        var partArray = parts.components(separatedBy: [".", "-"])
+        
+        if partArray.count == 3 {
+            partArray.append("~")
+        }
+        
+        let paddedVersion = partArray.map({ $0.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil ? "    " + $0 : $0}).joined(separator: "-")
+                
+        return paddedVersion
+    }
 
     private func digest(_ string: String) -> UInt32 {
         return Common.fnv1a(Array(string.utf8), offsetBasis: Common.offsetBasis32, prime: Common.prime32)


### PR DESCRIPTION
Features and Changes

The original version enforces a valid semantic version while this newer approach is more flexible, allowing any string to be compared, splitting the string into segments on the dot and dash characters, and comparing each segment alphanumerically, while padding digit-only segments so they can be compared as strings. This also means that a version comparison like v1.2.3 == 1-2.3 is true since it treats. and - characters the same.