### PR TITLE
Support latest versions

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -12,6 +12,7 @@
 		84095C8C281823BC00ADDF19 /* LoggingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C8A281822B900ADDF19 /* LoggingManager.swift */; };
 		84095C902818245700ADDF19 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C8E2818245100ADDF19 /* Formatter.swift */; };
 		84095C932818254400ADDF19 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C91281824DB00ADDF19 /* Theme.swift */; };
+		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
 		8484CC0C2817D7230092A39B /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8043294B5CB900B22168 /* CryptoTests.swift */; };
 		849114C7280DA73000C0B9A5 /* FeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F0827FD64EB003309DC /* FeaturesViewModelTests.swift */; };
@@ -82,7 +83,7 @@
 		843363FF27F845EB0072BFDC /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		8433640027F845EB0072BFDC /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		8433640227F845EB0072BFDC /* ExperimentEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEvaluator.swift; sourceTree = "<group>"; };
-		8433640327F845EB0072BFDC /* FeatureEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluator.swift; sourceTree = "<group>"; };
+		8433640327F845EB0072BFDC /* FeatureEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluator.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		8433640427F845EB0072BFDC /* ConditionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluator.swift; sourceTree = "<group>"; };
 		8433640627F845EB0072BFDC /* CachingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManager.swift; sourceTree = "<group>"; };
 		8433640827F845EB0072BFDC /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
@@ -102,6 +103,7 @@
 		84628062280DAE2900C83CDE /* Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
 		846280E7280DBE9C00C83CDE /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		84628147280F2AC400C83CDE /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptionUtils.swift; sourceTree = "<group>"; };
 		848B8043294B5CB900B22168 /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		849114BD280DA71E00C0B9A5 /* GrowthBookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowthBookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		84BC2E9C294A11F100289BC2 /* Crypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Crypto.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				84628062280DAE2900C83CDE /* Common.swift */,
 				84628147280F2AC400C83CDE /* Logger.swift */,
 				84BC2E9C294A11F100289BC2 /* Crypto.swift */,
+				8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -436,6 +439,7 @@
 				84CDE33B2812F454008B3E6F /* Common.swift in Sources */,
 				84CDE33C2812F454008B3E6F /* Logger.swift in Sources */,
 				84CDE33D2812F454008B3E6F /* ExperimentEvaluator.swift in Sources */,
+				8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */,
 				84CDE33E2812F454008B3E6F /* FeatureEvaluator.swift in Sources */,
 				84CDE33F2812F454008B3E6F /* ConditionEvaluator.swift in Sources */,
 				84CDE3402812F454008B3E6F /* CachingManager.swift in Sources */,
@@ -462,6 +466,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YD4Z8XL3TV;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
@@ -479,6 +484,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = YD4Z8XL3TV;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */; };
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
+		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
+		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
+		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
 		84BC2E9D294A11F100289BC2 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BC2E9C294A11F100289BC2 /* Crypto.swift */; };
 		84CDE32B2812F359008B3E6F /* GrowthBook.h in Headers */ = {isa = PBXBuildFile; fileRef = 84CDE32A2812F359008B3E6F /* GrowthBook.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84CDE3332812F454008B3E6F /* GrowthBookSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F627F845EB0072BFDC /* GrowthBookSDK.swift */; };
@@ -77,7 +80,7 @@
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
-		843363FB27F845EB0072BFDC /* FeaturesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesViewModel.swift; sourceTree = "<group>"; };
+		843363FB27F845EB0072BFDC /* FeaturesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesViewModel.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		843363FC27F845EB0072BFDC /* FeaturesDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataSource.swift; sourceTree = "<group>"; };
 		843363FE27F845EB0072BFDC /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		843363FF27F845EB0072BFDC /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -106,6 +109,9 @@
 		8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptionUtils.swift; sourceTree = "<group>"; };
 		848B8043294B5CB900B22168 /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		849114BD280DA71E00C0B9A5 /* GrowthBookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowthBookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		849952502ACDB676003BBCF7 /* SSEHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSEHandler.swift; sourceTree = "<group>"; };
+		849952562ADD6D66003BBCF7 /* EventModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventModel.swift; sourceTree = "<group>"; };
+		849952582ADD704A003BBCF7 /* EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
 		84BC2E9C294A11F100289BC2 /* Crypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Crypto.swift; sourceTree = "<group>"; };
 		84CDE3282812F359008B3E6F /* GrowthBook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GrowthBook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84CDE32A2812F359008B3E6F /* GrowthBook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook.h; sourceTree = "<group>"; };
@@ -175,6 +181,9 @@
 			isa = PBXGroup;
 			children = (
 				843363F827F845EB0072BFDC /* NetworkClient.swift */,
+				849952502ACDB676003BBCF7 /* SSEHandler.swift */,
+				849952562ADD6D66003BBCF7 /* EventModel.swift */,
+				849952582ADD704A003BBCF7 /* EventHandler.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -355,7 +364,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1330;
-				LastUpgradeCheck = 1330;
+				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					849114BC280DA71E00C0B9A5 = {
 						CreatedOnToolsVersion = 13.3.1;
@@ -428,6 +437,8 @@
 				84CDE3342812F454008B3E6F /* NetworkClient.swift in Sources */,
 				84095C902818245700ADDF19 /* Formatter.swift in Sources */,
 				84CDE3352812F454008B3E6F /* FeaturesDataModel.swift in Sources */,
+				849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */,
+				849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */,
 				84CDE3362812F454008B3E6F /* FeaturesViewModel.swift in Sources */,
 				84CDE3372812F454008B3E6F /* FeaturesDataSource.swift in Sources */,
 				84095C932818254400ADDF19 /* Theme.swift in Sources */,
@@ -446,6 +457,7 @@
 				84CDE3412812F454008B3E6F /* Feature.swift in Sources */,
 				84095C792817EC7800ADDF19 /* JsonManager.swift in Sources */,
 				84CDE3422812F454008B3E6F /* Experiment.swift in Sources */,
+				849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */,
 				84CDE3432812F454008B3E6F /* Context.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -466,13 +478,15 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YD4Z8XL3TV;
+				DEVELOPMENT_TEAM = SDDQDQ7RGG;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevychsolutions.GrowthBookTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -484,13 +498,15 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YD4Z8XL3TV;
+				DEVELOPMENT_TEAM = SDDQDQ7RGG;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevychsolutions.GrowthBookTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -501,12 +517,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -519,12 +537,16 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevychsolutions.GrowthBook;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
 		};
@@ -532,12 +554,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -550,12 +574,16 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++17";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kevychsolutions.GrowthBook;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;
 		};
@@ -563,6 +591,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -596,6 +625,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -630,6 +660,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -663,6 +694,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/GrowthBook-IOS.xcodeproj/xcshareddata/xcschemes/GrowthBook.xcscheme
+++ b/GrowthBook-IOS.xcodeproj/xcshareddata/xcschemes/GrowthBook.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GrowthBook-IOS.xcodeproj/xcshareddata/xcschemes/GrowthBookTests.xcscheme
+++ b/GrowthBook-IOS.xcodeproj/xcshareddata/xcschemes/GrowthBookTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GrowthBookTests/ConditionTests.swift
+++ b/GrowthBookTests/ConditionTests.swift
@@ -53,6 +53,10 @@ class ConditionTests: XCTestCase {
         XCTAssertTrue(evaluator.isEvalOperatorCondition(operatorKey: "$gte", attributeValue: JSON("abc"), conditionValue: JSON("abc")))
         
         XCTAssertTrue(evaluator.isEvalOperatorCondition(operatorKey: "$vlt", attributeValue: "0.9.0", conditionValue: "0.10.0"))
+        
+        XCTAssertTrue(evaluator.isEvalOperatorCondition(operatorKey: "$in", attributeValue: JSON("abc"), conditionValue: [JSON("abc")]))
+        
+        XCTAssertFalse(evaluator.isEvalOperatorCondition(operatorKey: "$nin", attributeValue: JSON("abc"), conditionValue: [JSON("abc")]))
     }
 
     func testConditionFailAttributeDoesNotExist() throws {

--- a/GrowthBookTests/ExperimentRunTests.swift
+++ b/GrowthBookTests/ExperimentRunTests.swift
@@ -18,12 +18,13 @@ class ExperimentRunTests: XCTestCase {
             let experiment = Experiment(json: item[2].dictionaryValue)
 
             let gbContext = Context(url: nil,
+                                    sseUrl: nil,
                                     encryptionKey: nil,
                                     isEnabled: testContext.isEnabled,
                                     attributes: testContext.attributes,
                                     forcedVariations: testContext.forcedVariations,
                                     isQaMode: testContext.isQaMode,
-                                    trackingClosure: { _, _ in })
+                                    trackingClosure: { _, _ in }, backgroundSync: false)
 
             let evaluator = ExperimentEvaluator()
             let result = evaluator.evaluateExperiment(context: gbContext, experiment: experiment)

--- a/GrowthBookTests/FeatureValueTests.swift
+++ b/GrowthBookTests/FeatureValueTests.swift
@@ -30,7 +30,7 @@ class FeatureValueTests: XCTestCase {
             }
 
             let evaluator = FeatureEvaluator()
-            let result = evaluator.evaluateFeature(context: gbContext, featureKey: item[2].stringValue)
+            let result = evaluator.evaluateFeature(context: gbContext, featureKey: item[2].stringValue, attributeOverrides: item)
 
             let expectedResult = FeatureResultTest(json: item[3].dictionaryValue)
 

--- a/GrowthBookTests/FeatureValueTests.swift
+++ b/GrowthBookTests/FeatureValueTests.swift
@@ -18,12 +18,14 @@ class FeatureValueTests: XCTestCase {
             let testData = FeaturesTest(json: item[1].dictionaryValue)
 
             let gbContext = Context(url: nil,
+                                    sseUrl: nil,
                                     encryptionKey: nil,
                                     isEnabled: true,
                                     attributes: testData.attributes,
                                     forcedVariations: JSON(),
                                     isQaMode: false,
-                                    trackingClosure: { _, _ in })
+                                    trackingClosure: { _, _ in }, 
+                                    backgroundSync: false)
 
             if let features = testData.features {
                 gbContext.features = features

--- a/GrowthBookTests/FeatureValueTests.swift
+++ b/GrowthBookTests/FeatureValueTests.swift
@@ -29,8 +29,8 @@ class FeatureValueTests: XCTestCase {
                 gbContext.features = features
             }
 
-            let evaluator = FeatureEvaluator()
-            let result = evaluator.evaluateFeature(context: gbContext, featureKey: item[2].stringValue, attributeOverrides: item)
+            let evaluator = FeatureEvaluator(context: gbContext, featureKey: item[2].stringValue, attributeOverrides: item)
+            let result = evaluator.evaluateFeature()
 
             let expectedResult = FeatureResultTest(json: item[3].dictionaryValue)
 

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -10,9 +10,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         isSuccess = false
         isError = true
 
-        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)))
+        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)), backgroundSync: false)
 
-        viewModel.fetchFeatures(apiUrl: "")
+        viewModel.fetchFeatures(apiUrl: "", sseURL: "")
 
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
@@ -22,10 +22,10 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         isSuccess = false
         isError = true
         
-        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)))
+        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)), backgroundSync: false)
         
         viewModel.encryptionKey = "3tfeoyW0wlo47bDnbWDkxg=="
-        viewModel.fetchFeatures(apiUrl: "")
+        viewModel.fetchFeatures(apiUrl: "", sseURL: "")
         
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
@@ -35,10 +35,10 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         isSuccess = false
         isError = true
         
-        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)))
+        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)), backgroundSync: false)
         
-        viewModel.fetchFeatures(apiUrl: "")
-        
+        viewModel.fetchFeatures(apiUrl: "", sseURL: "")
+
         let cachingManager: CachingLayer = CachingManager()
         
         guard let featureData = cachingManager.getContent(fileName: Constants.featureCache) else {
@@ -60,11 +60,11 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         isSuccess = false
         isError = true
         
-        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)))
+        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)), backgroundSync: false)
         
         viewModel.encryptionKey = "3tfeoyW0wlo47bDnbWDkxg=="
-        viewModel.fetchFeatures(apiUrl: "")
-        
+        viewModel.fetchFeatures(apiUrl: "", sseURL: "")
+
         let cachingManager: CachingLayer = CachingManager()
         
         guard let featureData = cachingManager.getContent(fileName: Constants.featureCache) else {
@@ -85,9 +85,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     func testError() throws {
         isSuccess = false
         isError = true
-        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: .failedToLoadData)))
+        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: .failedToLoadData)), backgroundSync: false)
 
-        viewModel.fetchFeatures(apiUrl: "")
+        viewModel.fetchFeatures(apiUrl: "", sseURL: "")
 
         XCTAssertFalse(isSuccess)
         XCTAssertTrue(isError)
@@ -96,8 +96,8 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     func testInvalid() throws {
         isSuccess = false
         isError = true
-        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().errorResponse, error: nil)))
-        viewModel.fetchFeatures(apiUrl: "")
+        let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().errorResponse, error: nil)), backgroundSync: false)
+        viewModel.fetchFeatures(apiUrl: "", sseURL: "")
 
         XCTAssertFalse(isSuccess)
         XCTAssertTrue(isError)

--- a/GrowthBookTests/GrowthBookSDKBuilderTests.swift
+++ b/GrowthBookTests/GrowthBookSDKBuilderTests.swift
@@ -3,19 +3,23 @@ import XCTest
 @testable import GrowthBook
 
 class GrowthBookSDKBuilderTests: XCTestCase {
-    let testURL = "https://host.com/api/features/4r23r324f23"
+    let testUrl = "https://host.com/api/features/4r23r324f23"
+    let testSseUrl = "https://host.com/sub/4r23r324f23"
+    let expectedURL = "https://host.com/api/features/4r23r324f23"
     let testAttributes: JSON = JSON()
     let testKeyString = "Ns04T5n9+59rl2x3SlNHtQ=="
     
     func testSDKInitializationDefault() throws {
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             encryptionKey: testKeyString,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).initializer()
+                                            refreshHandler: nil, 
+                                            backgroundSync: false).initializer()
         
         XCTAssertTrue(sdkInstance.getGBContext().isEnabled)
-        XCTAssertTrue(sdkInstance.getGBContext().url == testURL)
+        XCTAssertTrue(sdkInstance.getGBContext().url == expectedURL)
         XCTAssertTrue(sdkInstance.getGBContext().encryptionKey == testKeyString)
         XCTAssertFalse(sdkInstance.getGBContext().isQaMode)
         XCTAssertTrue(sdkInstance.getGBContext().attributes == testAttributes)
@@ -26,13 +30,14 @@ class GrowthBookSDKBuilderTests: XCTestCase {
         
         let variations: [String: Int] = [:]
 
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in }).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
+                                            refreshHandler: nil, backgroundSync: false).setRefreshHandler(refreshHandler: { _ in }).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
         
         XCTAssertFalse(sdkInstance.getGBContext().isEnabled)
-        XCTAssertTrue(sdkInstance.getGBContext().url == testURL)
+        XCTAssertTrue(sdkInstance.getGBContext().url == expectedURL)
         XCTAssertTrue(sdkInstance.getGBContext().isQaMode)
         XCTAssertTrue(sdkInstance.getGBContext().attributes == testAttributes)
         XCTAssertTrue(sdkInstance.getGBContext().forcedVariations == JSON(variations))
@@ -43,13 +48,15 @@ class GrowthBookSDKBuilderTests: XCTestCase {
         
         let variations: [String: Int] = [:]
 
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
+                                            refreshHandler: nil,
+                                            backgroundSync: false).setRefreshHandler(refreshHandler: { _ in }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
         
         XCTAssertFalse(sdkInstance.getGBContext().isEnabled)
-        XCTAssertTrue(sdkInstance.getGBContext().url == testURL)
+        XCTAssertTrue(sdkInstance.getGBContext().url == expectedURL)
         XCTAssertTrue(sdkInstance.getGBContext().isQaMode)
         XCTAssertTrue(sdkInstance.getGBContext().attributes == testAttributes)
         
@@ -59,14 +66,16 @@ class GrowthBookSDKBuilderTests: XCTestCase {
         
         let variations: [String: Int] = [:]
         
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             encryptionKey: "3tfeoyW0wlo47bDnbWDkxg==",
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
+                                            refreshHandler: nil, 
+                                            backgroundSync: false).setRefreshHandler(refreshHandler: { _ in }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)).setEnabled(isEnabled: false).setForcedVariations(forcedVariations: variations).setQAMode(isEnabled: true).initializer()
         
         XCTAssertFalse(sdkInstance.getGBContext().isEnabled)
-        XCTAssertTrue(sdkInstance.getGBContext().url == testURL)
+        XCTAssertTrue(sdkInstance.getGBContext().url == expectedURL)
         XCTAssertTrue(sdkInstance.getGBContext().isQaMode)
         XCTAssertTrue(sdkInstance.getGBContext().attributes == testAttributes)
         XCTAssertTrue(sdkInstance.getGBContext().features.contains(where: { $0.key == "pricing-test-new"}))
@@ -75,10 +84,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     func testSDKRefreshHandler() throws {
         
         var isRefreshed = false
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
+                                            refreshHandler: nil,
+                                            backgroundSync: false).setRefreshHandler(refreshHandler: { _ in
             isRefreshed = true
         }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
 
@@ -96,10 +107,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
         
         var isRefreshed = false
 
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
+                                            refreshHandler: nil,
+                                            backgroundSync: false).setRefreshHandler(refreshHandler: { _ in
             isRefreshed = true
         }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
         
@@ -110,10 +123,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     }
     
     func testSDKRunMethods() throws {
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
+                                            refreshHandler: nil, 
+                                            backgroundSync: false).setRefreshHandler(refreshHandler: { _ in
             
         }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)).initializer()
         
@@ -125,10 +140,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     }
     
     func testEncrypt() throws {
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).initializer()
+                                            refreshHandler: nil,
+                                            backgroundSync: false).initializer()
         let decoder = JSONDecoder()
         let encryptedFeatures = "vMSg2Bj/IurObDsWVmvkUg==.L6qtQkIzKDoE2Dix6IAKDcVel8PHUnzJ7JjmLjFZFQDqidRIoCxKmvxvUj2kTuHFTQ3/NJ3D6XhxhXXv2+dsXpw5woQf0eAgqrcxHrbtFORs18tRXRZza7zqgzwvcznx"
         let expectedResult = "{\"testfeature1\":{\"defaultValue\":true,\"rules\":[{\"condition\":{\"id\":\"1234\"},\"force\":false}]}}"
@@ -146,10 +163,12 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     
     func testClearCache() throws {
         
-        let sdkInstance = GrowthBookBuilder(url: testURL,
+        let sdkInstance = GrowthBookBuilder(url: testUrl,
+                                            sseUrl: testSseUrl,
                                             attributes: testAttributes,
                                             trackingCallback: { _, _ in },
-                                            refreshHandler: nil).setRefreshHandler(refreshHandler: { _ in
+                                            refreshHandler: nil, 
+                                            backgroundSync: false).setRefreshHandler(refreshHandler: { _ in
 
         }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil))
             .setCacheDirectory(.documents)

--- a/GrowthBookTests/Source/json.json
+++ b/GrowthBookTests/Source/json.json
@@ -1,5 +1,35 @@
 {
       "evalCondition": [
+          [
+              "null condition - null attribute",
+              {"userId": null},
+              {"userId": null},
+              true
+          ],
+          [
+              "null condition - missing attribute",
+              {"userId": null},
+              {},
+              true
+          ],
+          [
+              "null condition - string attribute",
+              {"userId": null},
+              {"userId": "123"},
+              false
+          ],
+          [
+              "null condition - zero attribute",
+              {"userId": null},
+              {"userId": 0},
+              false
+          ],
+          [
+              "null condition - empty string attribute",
+              {"userId": null},
+              {"userId": ""},
+              false
+          ],
         [
           "$not     - pass",
           {
@@ -3965,5 +3995,67 @@
             0.25
           ]
         ]
-      ]
+      ],
+      "decrypt": [
+          [
+            "Valid feature",
+            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznZ6SX28Yjg==",
+            "{\"feature\":{\"defaultValue\":true}}"
+          ],
+          [
+            "Broken JSON",
+            "SVZIM2oKD1JoHNIeeoW3Uw==.AGbRiGAHf2f6/ziVr9UTIy+bVFmVli6+bHZ2jnCm9N991ITv1ROvOEjxjLSmgEpv",
+            "UQD0Qqw7fM1bhfKKPH8TGw==",
+            "{\"feature\":{\"defaultValue\":true?5%"
+          ],
+          [
+            "Wrong key",
+            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznZ6SX39Yjg==",
+            null
+          ],
+          [
+            "Invalid key length",
+            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznSX39Yjg==",
+            null
+          ],
+          [
+            "Invalid key characters",
+            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/%!(pFDznZ6SX39Yjg==",
+            null
+          ],
+          [
+            "Invalid body",
+            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q0!*&()f3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznZ6SX28Yjg==",
+            null
+          ],
+          [
+            "Invalid iv length",
+            "m5ylFM6ndyOPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznZ6SX28Yjg==",
+            null
+          ],
+          [
+            "Invalid iv",
+            "m5ylFM6*&(OJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznZ6SX28Yjg==",
+            null
+          ],
+          [
+            "Missing delimiter",
+            "m5ylFM6ndyOJA2OPadubkw==Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+            "Zvwv/+uhpFDznZ6SX28Yjg==",
+            null
+          ],
+          [
+            "Corrupted payload",
+            "fsa*(&(SF*&F&SF^SD&*FS&*6fsdkajfd",
+            "Zvwv/+uhpFDznZ6SX28Yjg==",
+            null
+          ]
+        ]
     }

--- a/GrowthBookTests/TestHelper.swift
+++ b/GrowthBookTests/TestHelper.swift
@@ -25,7 +25,6 @@ class TestHelper {
     }
 
     func getFeatureData() -> [JSON]? {
-
         let array = testData?.dictionaryValue["feature"]
         return array?.arrayValue
     }
@@ -48,6 +47,10 @@ class TestHelper {
     func getEqualWeightsData() -> [JSON]? {
         let array = testData?.dictionaryValue["getEqualWeights"] 
         return array?.arrayValue
+    }
+    
+    func getDecryptData() -> [JSON]? {
+        testData?.dictionaryValue["decrypt"]?.arrayValue
     }
 
     private func loadTestData() -> JSON? {

--- a/GrowthBookTests/UtilsTests.swift
+++ b/GrowthBookTests/UtilsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import GrowthBook
 
 class UtilsTests: XCTestCase {
-
+    
     func testHash() throws {
         guard let evalConditions = TestHelper().getFNVHashData() else { return }
         var failedScenarios: [String] = []
@@ -11,25 +11,25 @@ class UtilsTests: XCTestCase {
         for item in evalConditions {
             let testContext = item.arrayValue[0].stringValue//jsonPrimitive.content
             let experiment = item.arrayValue[1].floatValue
-
-            let result = Utils.shared.hash(data: testContext)
-
-            let status = item[0].stringValue + "\nExpected Result - " + item[1].stringValue + "\nActual result - " + String(result) + "\n"
-
+            
+            let result = Utils.shared.hash(seed: "", value: testContext, version: 1)
+            
+            let status = item[0].stringValue + "\nExpected Result - " + item[1].stringValue + "\nActual result - " + String(result ?? 0.0) + "\n"
+            
             if experiment == result {
                 passedScenarios.append(status)
             } else {
                 failedScenarios.append(status)
             }
         }
-
+        
         logger.info("TOTAL TESTS - \(evalConditions.count)")
         logger.info("Passed TESTS - \(passedScenarios.count)")
         logger.info("Failed TESTS - \(failedScenarios.count)")
-
+        
         XCTAssertTrue(failedScenarios.count == 0)
     }
-
+    
     func testBucketRange() throws {
         guard let evalConditions = TestHelper().getBucketRangeData() else { return }
         var failedScenarios: [String] = []
@@ -43,57 +43,56 @@ class UtilsTests: XCTestCase {
                     Float(value) ?? 0.0
                 })
             }
-
+            
             let bucketRange = Utils.shared.getBucketRanges(numVariations: numVariations ?? 1, coverage: coverage ?? 1, weights: weights ?? [])
-
-
+            
             let status = "\(item.arrayValue[0].stringValue) \nExpected Result - \(item.arrayValue[2].stringValue) \nActual result - \(JSON(bucketRange).stringValue) \n"
-
+            
             if isCompareBucket(expectedResults: JSON.convertToTwoArrayFloat(jsonArray: item.arrayValue[2].arrayValue), calculatedResults: bucketRange) {
                 passedScenarios.append(status)
             } else {
                 failedScenarios.append(status)
             }
         }
-
+        
         logger.info("TOTAL TESTS - \(evalConditions.count)")
         logger.info("Passed TESTS - \(passedScenarios.count)")
         logger.info("Failed TESTS - \(failedScenarios.count)")
-
+        
         XCTAssertTrue(failedScenarios.count == 0)
     }
-
+    
     func isCompareBucket(expectedResults: [[Float]], calculatedResults: [BucketRange]) -> Bool {
         let pairExpectedResults = getPairedData(items: expectedResults)
-
+        
         if pairExpectedResults.count != expectedResults.count {
             return false
         }
-
+        
         var result = true
         for i in 0..<pairExpectedResults.count {
             let source = pairExpectedResults[i]
             let target = calculatedResults[i]
-
-            if (source.0 != target.0 || source.1 != target.1) {
+            
+            if (source.number1 != target.number1 || source.number2 != target.number2) {
                 result = false
                 break
             }
         }
-
+        
         return result
     }
-
+    
     func getPairedData(items: [[Float]]) -> [BucketRange] {
-        var pairExpectedResults: [(Float, Float)] = []
-
+        var pairExpectedResults: [BucketRange] = []
+        
         for item in items {
             let pair = (item[0], item[1])
-            pairExpectedResults.append((pair.0, pair.1))
+            pairExpectedResults.append(BucketRange(number1: pair.0, number2: pair.1))
         }
         return pairExpectedResults
     }
-
+    
     func testChooseVariation() throws {
         guard let evalConditions = TestHelper().getChooseVariationData() else { return }
         var failedScenarios: [String] = []
@@ -101,25 +100,25 @@ class UtilsTests: XCTestCase {
         for item in evalConditions {
             let hash = item.arrayValue[1].float
             let rangeData = getPairedData(items: JSON.convertToTwoArrayFloat(jsonArray: item.arrayValue[2].arrayValue))
-
+            
             let result = Utils.shared.chooseVariation(n: hash ?? 0, ranges: rangeData)
-
+            
             let status = item.arrayValue[0].stringValue + "\nExpected Result - " + item.arrayValue[3].stringValue + "\nActual result - " + String(result) + "\n"
-
+            
             if item.arrayValue[3].stringValue == String(result) {
                 passedScenarios.append(status)
             } else {
                 failedScenarios.append(status)
             }
         }
-
+        
         logger.info("TOTAL TESTS - \(evalConditions.count)")
         logger.info("Passed TESTS - \(passedScenarios.count)")
         logger.info("Failed TESTS - \(failedScenarios.count)")
-
+        
         XCTAssertTrue(failedScenarios.count == 0)
     }
-
+    
     func testInNameSpace() throws {
         guard let evalConditions = TestHelper().getInNameSpaceData() else { return }
         var failedScenarios: [String] = []
@@ -128,74 +127,73 @@ class UtilsTests: XCTestCase {
             let userId = item.arrayValue[1].stringValue
             let jsonArray = item.arrayValue[2].arrayValue
             guard let namespace = Utils.shared.getGBNameSpace(namespace: jsonArray) else { continue }
-
+            
             let result = Utils.shared.inNamespace(userId: userId, namespace: namespace)
-
+            
             let status = item.arrayValue[0].stringValue + "\nExpected Result - " + item.arrayValue[3].stringValue + "\nActual result - " + String(result) + "\n"
-
-
+            
             if item.arrayValue[3].stringValue == String(result) {
                 passedScenarios.append(status)
             } else {
                 failedScenarios.append(status)
             }
         }
-
+        
         logger.info("TOTAL TESTS - \(evalConditions.count)")
         logger.info("Passed TESTS - \(passedScenarios.count)")
         logger.info("Failed TESTS - \(failedScenarios.count)")
-
+        
         XCTAssertTrue(failedScenarios.count == 0)
     }
-
+    
     func testEqualWeights() throws {
         guard let evalConditions = TestHelper().getEqualWeightsData() else { return }
         var failedScenarios: [String] = []
         var passedScenarios: [String] = []
         for item in evalConditions {
-
+            
             let numVariations = item.arrayValue[0].intValue
-
+            
             let result = Utils.shared.getEqualWeights(numVariations: numVariations)
-
+            
             let status =  "Expected Result - \(item.arrayValue[1].stringValue) \nActual result - \(result) \n"
-
+            
             var resultTest = true
-
+            
             if item.arrayValue[1].arrayValue.count != result.count {
                 resultTest = false
             } else {
                 for i in 0..<result.count {
                     let source = item.arrayValue[1].arrayValue[i].floatValue
                     let target = result[i]
-
+                    
                     if source != target {
                         resultTest = false
                         break
                     }
                 }
             }
-
+            
             if resultTest {
                 passedScenarios.append(status)
             } else {
                 failedScenarios.append(status)
             }
         }
-
+        
         logger.info("TOTAL TESTS - \(evalConditions.count)")
         logger.info("Passed TESTS - \(passedScenarios.count)")
         logger.info("Failed TESTS - \(failedScenarios.count)")
-
+        
         XCTAssertTrue(failedScenarios.count == 0)
     }
-
+    
     func testEdgeCases() throws {
         XCTAssertFalse(Utils.shared.inNamespace(userId: "4242", namespace: NameSpace("", 0.0, 0.0)))
-
+        
         var items = [JSON]()
         items.append(JSON(1))
-
+        
         XCTAssertTrue(Utils.shared.getGBNameSpace(namespace: items) == nil)
     }
     
@@ -205,5 +203,33 @@ class UtilsTests: XCTestCase {
         let endValue = Utils.shared.paddedVersionString(input: startValue)
         
         XCTAssertEqual(endValue, expectedValue)
+    }
+    
+    func testDecrypt() throws {
+        guard let testCases = TestHelper().getDecryptData() else { return }
+        
+        for jsonElement in testCases {
+            guard let test = jsonElement.arrayObject,
+                  let payload = test[1] as? String,
+                  let key = test[2] as? String else {
+                continue
+            }
+            let expectedElem = test[3]
+            
+            do {
+                if let expected = test[3] as? String {
+                    let actual = try DecryptionUtils.decrypt(payload: payload, encryptionKey: key).trimmingCharacters(in: .whitespacesAndNewlines)
+                    XCTAssertEqual(expected, actual)
+                }
+            } catch let error as DecryptionException {
+                print("message \(error.errorMessage)")
+                
+                if expectedElem is NSNull {
+                    XCTAssertTrue(true)
+                }
+            } catch {
+                XCTFail("An unexpected error occurred: \(error)")
+            }
+        }
     }
 }

--- a/GrowthBookTests/UtilsTests.swift
+++ b/GrowthBookTests/UtilsTests.swift
@@ -46,6 +46,7 @@ class UtilsTests: XCTestCase {
             
             let bucketRange = Utils.shared.getBucketRanges(numVariations: numVariations ?? 1, coverage: coverage ?? 1, weights: weights ?? [])
             
+            
             let status = "\(item.arrayValue[0].stringValue) \nExpected Result - \(item.arrayValue[2].stringValue) \nActual result - \(JSON(bucketRange).stringValue) \n"
             
             if isCompareBucket(expectedResults: JSON.convertToTwoArrayFloat(jsonArray: item.arrayValue[2].arrayValue), calculatedResults: bucketRange) {
@@ -131,6 +132,7 @@ class UtilsTests: XCTestCase {
             let result = Utils.shared.inNamespace(userId: userId, namespace: namespace)
             
             let status = item.arrayValue[0].stringValue + "\nExpected Result - " + item.arrayValue[3].stringValue + "\nActual result - " + String(result) + "\n"
+            
             
             if item.arrayValue[3].stringValue == String(result) {
                 passedScenarios.append(status)

--- a/README.md
+++ b/README.md
@@ -67,16 +67,17 @@ Now you can start/stop tests, adjust coverage and variation weights, and apply a
 
 ```swift
 var sdkInstance: GrowthBookSDK = GrowthBookBuilder(url: <GrowthBook_URL/API_KEY>,
+    sseUrl: <GrowthBook_SSEURL/API_KEY>,
     attributes: <[String: Any]>,
     trackingCallback: { experiment, experimentResult in 
 
-    }).initializer()
+    }, backroundSync: Bool?).initializer()
 ```
 You must also provide the encryption key if you intend to use data encryption.
 
 ```swift
 var sdkInstance: GrowthBookSDK = GrowthBookBuilder(url: <GrowthBook_URL/API_KEY>,
-    encryptionKey: <String>,
+    sseUrl: <GrowthBook_SSEURL/API_KEY>,
     attributes: <[String: Any]>,
     trackingCallback: { experiment, experimentResult in 
 
@@ -84,7 +85,8 @@ var sdkInstance: GrowthBookSDK = GrowthBookBuilder(url: <GrowthBook_URL/API_KEY>
 ```
 
 ```swift
-var sdkInstance: GrowthBookSDK = GrowthBookBuilder(features: <Data>,
+var sdkInstance: GrowthBookSDK = GrowthBookBuilder(url: <GrowthBook_URL/API_KEY>,
+    sseUrl: <GrowthBook_SSEURL/API_KEY>,
     attributes: <[String: Any]>,
     trackingCallback: { experiment, experimentResult in 
 
@@ -95,6 +97,7 @@ There are additional properties which can be setup at the time of initialization
 
 ```swift
 var sdkInstance: GrowthBookSDK = GrowthBookBuilder(url: <GrowthBook_URL/API_KEY>,
+    sseUrl: <GrowthBook_SSEURL/API_KEY>,
     attributes: <[String: Any]>,
     trackingCallback: { experiment, experimentResult in 
 
@@ -173,6 +176,8 @@ func setEncryptedFeatures(encryptedString: String, encryptionKey: String, subtle
 class Context {
     /// URL
     let url: String?
+    /// URL for enabling streaming updates
+    let sseURl: String?
     /// Encryption key for encrypted features.
     let encryptionKey: String?
     /// Switch to globally disable all experiments. Default true.
@@ -347,6 +352,17 @@ public struct TrackData {
 
 ```
 
+
+## Streaming updates
+
+To enable streaming updates set backgroundSync variable to "true" and add streaming updates URL
+
+var sdkInstance: GrowthBookSDK = GrowthBookBuilder(url: <GrowthBook_URL/API_KEY>,
+    sseUrl: <GrowthBook_SSEURL/API_KEY>,
+    attributes: <[String: Any]>,
+    trackingCallback: { experiment, experimentResult in 
+
+    }, backgroundSync: true).initializer( 
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -165,11 +165,6 @@ func isOn(feature id: String) -> Bool
 func setEncryptedFeatures(encryptedString: String, encryptionKey: String, subtle: CryptoProtocol? = nil)
 ```
 
-- Checks if the number is in range of numbers
-
-```swift
-func inRange(n: Float, range: BucketRange) -> Bool
-```
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ func isOn(feature id: String) -> Bool
 func setEncryptedFeatures(encryptedString: String, encryptionKey: String, subtle: CryptoProtocol? = nil)
 ```
 
+- Checks if the number is in range of numbers
+
+```swift
+func inRange(n: Float, range: BucketRange) -> Bool
+```
 
 ## Models
 
@@ -221,6 +226,24 @@ struct FeatureRule {
     let namespace: [JSON]?
     /// What user attribute should be used to assign variations (defaults to id)
     let hashAttribute: String?
+    /// Hash version of hash function
+    let hashVersion: Float?
+    /// A more precise version of `coverage`
+    let range: BucketRange?
+    /// Ranges for experiment variations
+    let ranges: [BucketRange]?
+    /// Meta info about the experiment variations
+    let meta: [VariationMeta]?
+    /// Array of filters to apply to the rule
+    let filters: [Filter]?
+    /// Seed to use for hashing
+    let seed: String?
+    /// Human-readable name for the experiment
+    let name: String?
+    /// The phase id of the experiment
+    let phase: String?
+    /// Array of tracking calls to fire
+    let tracks: [TrackData]?
 }
 
 /// Enum For defining feature value source
@@ -275,6 +298,18 @@ class Experiment {
     var condition: JSON?
     /// All users included in the experiment will be forced into the specific variation index
     var force: Int?
+    /// Array of ranges, one per variation
+    let ranges: [BucketRange]?
+    /// Meta info about the variations
+    let meta: [VariationMeta]?
+    /// Array of filters to apply
+    let filters: [Filter]?
+    /// The hash seed to use
+    let seed: String?
+    /// Human-readable name for the experiment
+    let name: String?
+    /// Id of the current experiment phase
+    let phase: String?
 }
 
 /// The result of running an Experiment given a specific Context
@@ -288,8 +323,33 @@ class ExperimentResult {
     /// The user attribute used to assign a variation
     let hashAttribute: String?
     /// The value of that attribute
-    let hashValue: String?
+    let valueHash: String?
+    /// The unique key for the assigned variation
+    let key: String
+    /// The human-readable name of the assigned variation
+    let name: String?
+    /// The hash value used to assign a variation (float from `0` to `1`)
+    let bucket: Float?
+    /// Used for holdout groups
+    let passthrough: Bool?
 }
+
+/// Meta info about the variations
+public struct VariationMeta {
+    /// Used to implement holdout groups
+    let passthrough: Bool?
+    /// A unique key for this variation
+    let key: String?
+    /// A human-readable name for this variation
+    let name: String?
+}
+
+///Used for remote feature evaluation to trigger the `TrackingCallback`
+public struct TrackData {
+    let experiment: Experiment
+    let result: ExperimentResult
+}
+
 ```
 
 

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -9,7 +9,7 @@ public protocol CachingLayer: AnyObject {
 /// This is actual implementation of Caching Layer in iOS
 public class CachingManager: CachingLayer {
     public static let shared = CachingManager()
-
+    
     private var cacheDirectory = CacheDirectory.applicationSupport
     
     func getData(fileName: String) -> Data? {

--- a/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
@@ -167,7 +167,9 @@ class ConditionEvaluator {
 
     /// Evaluates Condition Value against given condition & attributes
     func isEvalConditionValue(conditionValue: JSON, attributeValue: JSON?) -> Bool {
+        let conditionJson = JSON(conditionValue)
         // If conditionValue is a string, number, boolean, return true if it's "equal" to attributeValue and false if not.
+        
         var unwrappedAttribute = attributeValue
         
         if attributeValue == nil {
@@ -207,7 +209,7 @@ class ConditionEvaluator {
                     }
                 }
             } else if attributeValue != nil {
-                return isEqual(conditionValue, attributeValue)  //conditionValue.equals(attributeValue)
+                return Common.isEqual(conditionValue, attributeValue)  //conditionValue.equals(attributeValue)
             } else {
                 return false
             }
@@ -285,9 +287,9 @@ class ConditionEvaluator {
         if let conditionValue = conditionJson.array, let attributeValue = attributeValue {
             switch operatorKey {
             case "$in":
-                return conditionValue.contains(attributeValue)
+                return Common.isIn(actual: attributeValue, expected: conditionValue)
             case "$nin":
-                return !conditionValue.contains(attributeValue)
+                return !Common.isIn(actual: attributeValue, expected: conditionValue)
             case "$all":
                 if let attributeValue = attributeValue.array {
                     // Loop through conditionValue array
@@ -412,8 +414,5 @@ class ConditionEvaluator {
         }
         return false
     }
-
-    private func isEqual<T>(_ a: T, _ b: T) -> Bool where T : Equatable {
-        return a == b
-    }
+    
 }

--- a/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
@@ -167,11 +167,16 @@ class ConditionEvaluator {
 
     /// Evaluates Condition Value against given condition & attributes
     func isEvalConditionValue(conditionValue: JSON, attributeValue: JSON?) -> Bool {
-        let conditionJson = JSON(conditionValue)
         // If conditionValue is a string, number, boolean, return true if it's "equal" to attributeValue and false if not.
-        if let attributeValue = attributeValue {
-            if isPrimitive(value: conditionValue) && isPrimitive(value: attributeValue) {
-                return conditionValue == attributeValue
+        var unwrappedAttribute = attributeValue
+        
+        if attributeValue == nil {
+            unwrappedAttribute = .null
+        }
+        
+        if let unwrappedAttribute = unwrappedAttribute {
+            if isPrimitive(value: conditionValue) && isPrimitive(value: unwrappedAttribute) {
+                return conditionValue == unwrappedAttribute
             }
         } else if isPrimitive(value: conditionValue) {
             return false
@@ -192,9 +197,9 @@ class ConditionEvaluator {
         }
 
         // If conditionValue is an object, loop over each key/value pair:
-        if let _ = conditionJson.dictionary {
+        if let _ = conditionValue.dictionary {
 
-            if isOperatorObject(obj: conditionJson) {
+            if isOperatorObject(obj: conditionValue) {
                 for key in conditionValue.dictionaryValue.keys {
                     // If evalOperatorCondition(key, attributeValue, value) is false, return false
                     if let value = conditionValue.dictionaryValue[key], !isEvalOperatorCondition(operatorKey: key, attributeValue: attributeValue, conditionValue: value) {
@@ -401,7 +406,8 @@ class ConditionEvaluator {
     }
 
     private func isPrimitive(value: JSON) -> Bool {
-        if value.number != nil || value.string != nil || value.bool != nil || value.int != nil {
+        
+        if value.number != nil || value.string != nil || value.bool != nil || value.int != nil || value == .null {
             return true
         }
         return false

--- a/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
@@ -63,7 +63,7 @@ class ExperimentEvaluator {
             bucketRange = Utils.shared.getBucketRanges(numVariations: experiment.variations.count, coverage: coverage, weights: weights)
         }
 
-        let hash = Utils.shared.hash(data: attributeValue + experiment.key)
+        let hash = Utils.shared.hash(seed: experiment.key, value: attributeValue, version: 1) ?? 0.0
         let assigned = Utils.shared.chooseVariation(n: hash, ranges: bucketRange)
 
         // If not assigned a variation (assigned === -1), return immediately (not in experiment, variationId 0)
@@ -91,6 +91,8 @@ class ExperimentEvaluator {
 
     /// This is a helper method to create an ExperimentResult object.
     private func getExperimentResult(gbContext: Context, experiment: Experiment, variationIndex: Int = 0, inExperiment: Bool = false) -> ExperimentResult {
+        let key = experiment.key
+        let name = experiment.name
         var targetVariationIndex = variationIndex
 
         // Check whether variationIndex lies within bounds of variations size
@@ -115,7 +117,7 @@ class ExperimentEvaluator {
                                 variationId: targetVariationIndex,
                                 value: targetValue,
                                 hashAttribute: hashAttribute,
-                                hashValue: hashValue)
+                                hashValue: hashValue, key: key, name: name)
     }
 
 }

--- a/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
@@ -158,8 +158,8 @@ class FeatureEvaluator {
             let hash = Utils.shared.hash(seed: filter.seed, value: hashValue, version: filter.hashVersion)
             guard let hashValue = hash else { return true }
             
-            return !filter.ranges.contains { r in
-                return Utils.shared.inRange(n: hashValue, range: r)
+            return !filter.ranges.contains { range in
+                return Utils.shared.inRange(n: hashValue, range: range)
             }
         }
     }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -157,7 +157,7 @@ public struct GrowthBookModel {
 
     /// Get the value of the feature with a fallback
     public func getFeatureValue(feature id: String, default defaultValue: JSON) -> JSON {
-        return FeatureEvaluator().evaluateFeature(context: gbContext, featureKey: id).value ?? defaultValue
+        return FeatureEvaluator().evaluateFeature(context: gbContext, featureKey: id, attributeOverrides: gbContext.attributes).value ?? defaultValue
     }
 
     @objc public func featuresFetchedSuccessfully(features: [String: Feature], isRemote: Bool) {
@@ -183,7 +183,7 @@ public struct GrowthBookModel {
 
     /// The feature method takes a single string argument, which is the unique identifier for the feature and returns a FeatureResult object.
     @objc public func evalFeature(id: String) -> FeatureResult {
-        return FeatureEvaluator().evaluateFeature(context: gbContext, featureKey: id)
+        return FeatureEvaluator().evaluateFeature(context: gbContext, featureKey: id, attributeOverrides: gbContext.attributes)
     }
 
     /// The isOn method takes a single string argument, which is the unique identifier for the feature and returns the feature state on/off

--- a/Sources/CommonMain/JsonManager/JsonManager.swift
+++ b/Sources/CommonMain/JsonManager/JsonManager.swift
@@ -207,8 +207,6 @@ public struct JSON {
                 rawString = string
             case _ as NSNull:
                 type = .null
-            case nil:
-                type = .null
             case let array as [Any]:
                 type = .array
                 rawArray = array

--- a/Sources/CommonMain/Model/Context.swift
+++ b/Sources/CommonMain/Model/Context.swift
@@ -4,6 +4,8 @@ import Foundation
 @objc public class Context: NSObject {
     /// URL
     public let url: String?
+    /// SSE URL
+    public let sseUrl: String?
     /// Encryption key for encrypted features.
     public let encryptionKey: String?
     /// Switch to globally disable all experiments. Default true.
@@ -16,20 +18,25 @@ import Foundation
     public let isQaMode: Bool
     /// A function that takes experiment and result as arguments.
     public let trackingClosure: (Experiment, ExperimentResult) -> Void
+    /// Disable background streaming connection
+    public let backgroundSync: Bool?
 
     // Keys are unique identifiers for the features and the values are Feature objects.
     // Feature definitions - To be pulled from API / Cache
     var features: Features
 
     init(url: String?,
+         sseUrl: String?,
          encryptionKey: String?,
          isEnabled: Bool,
          attributes: JSON,
          forcedVariations: JSON?,
          isQaMode: Bool,
          trackingClosure: @escaping (Experiment, ExperimentResult) -> Void,
-         features: Features = [:]) {
+         features: Features = [:],
+         backgroundSync: Bool?) {
         self.url = url
+        self.sseUrl = sseUrl
         self.encryptionKey = encryptionKey
         self.isEnabled = isEnabled
         self.attributes = attributes
@@ -37,5 +44,6 @@ import Foundation
         self.isQaMode = isQaMode
         self.trackingClosure = trackingClosure
         self.features = features
+        self.backgroundSync = backgroundSync
     }
 }

--- a/Sources/CommonMain/Model/Experiment.swift
+++ b/Sources/CommonMain/Model/Experiment.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Defines a single experiment
-@objc public class Experiment: NSObject, Decodable {
+@objc public class Experiment: NSObject, Codable {
     /// The globally unique tracking key for the experiment
     public let key: String
     /// The different variations to choose between
@@ -20,16 +20,34 @@ import Foundation
     public var condition: JSON?
     /// All users included in the experiment will be forced into the specific variation index
     public var force: Int?
-
+    /// Array of ranges, one per variation
+    public let ranges: [BucketRange]?
+    /// Meta info about the variations
+    public let meta: [VariationMeta]?
+    /// Array of filters to apply
+    public let filters: [Filter]?
+    /// The hash seed to use
+    public let seed: String?
+    /// Human-readable name for the experiment
+    public let name: String?
+    /// Id of the current experiment phase
+    public let phase: String?
+    
     public init(key: String,
-         variations: [Any] = [],
-         namespace: [Any]? = nil,
-         hashAttribute: String? = nil,
-         weights: [Float]? = nil,
-         isActive: Bool = true,
-         coverage: Float? = nil,
-         condition: Any? = nil,
-         force: Int? = nil) {
+                variations: [Any] = [],
+                namespace: [Any]? = nil,
+                hashAttribute: String? = nil,
+                weights: [Float]? = nil,
+                isActive: Bool = true,
+                coverage: Float? = nil,
+                condition: Any? = nil,
+                force: Int? = nil,
+                ranges: [BucketRange]? = nil,
+                meta: [VariationMeta]? = nil,
+                filters: [Filter]? = nil,
+                seed: String? = nil,
+                name: String? = nil,
+                phase: String? = nil) {
         self.key = key
         self.variations = JSON(variations).arrayValue
         if let namespace = namespace {
@@ -45,6 +63,12 @@ import Foundation
             self.condition = JSON(condition)
         }
         self.force = force
+        self.ranges = ranges
+        self.meta = meta
+        self.filters = filters
+        self.seed = seed
+        self.name = name
+        self.phase = phase
     }
 
     init(key: String,
@@ -55,7 +79,13 @@ import Foundation
          isActive: Bool = true,
          coverage: Float? = nil,
          condition: Condition? = nil,
-         force: Int? = nil) {
+         force: Int? = nil,
+         ranges: [BucketRange]? = nil,
+         meta: [VariationMeta]? = nil,
+         filters: [Filter]? = nil,
+         seed: String? = nil,
+         name: String? = nil,
+         phase: String? = nil) {
         self.key = key
         self.variations = variations
         self.namespace = namespace
@@ -65,6 +95,12 @@ import Foundation
         self.coverage = coverage
         self.condition = condition
         self.force = force
+        self.ranges = ranges
+        self.meta = meta
+        self.filters = filters
+        self.seed = seed
+        self.name = name
+        self.phase = phase
     }
 
     init(json: [String: JSON]) {
@@ -87,6 +123,19 @@ import Foundation
         condition = json["condition"]
 
         force = json["force"]?.intValue
+        
+        ranges = json["ranges"]?.arrayObject as? [BucketRange]
+        
+        meta = json["meta"]?.arrayObject as? [VariationMeta]
+        
+        filters = json["filters"]?.arrayObject as? [Filter]
+        
+        seed = json["seed"]?.stringValue
+        
+        name = json["name"]?.stringValue
+        
+        phase = json["phase"]?.stringValue
+        
     }
 }
 
@@ -102,12 +151,32 @@ import Foundation
     public let hashAttribute: String?
     /// The value of that attribute
     public let valueHash: String?
+    /// The unique key for the assigned variation
+    public let key: String
+    /// The human-readable name of the assigned variation
+    public let name: String?
+    /// The hash value used to assign a variation (float from `0` to `1`)
+    public let bucket: Float?
+    /// Used for holdout groups
+    public let passthrough: Bool?
 
-    init(inExperiment: Bool, variationId: Int, value: JSON, hashAttribute: String? = nil, hashValue: String? = nil) {
+    init(inExperiment: Bool,
+         variationId: Int,
+         value: JSON,
+         hashAttribute: String? = nil,
+         hashValue: String? = nil,
+         key: String,
+         name: String? = nil,
+         bucket: Float? = nil,
+         passthrough: Bool? = nil) {
         self.inExperiment = inExperiment
         self.variationId = variationId
         self.value = value
         self.hashAttribute = hashAttribute
         self.valueHash = hashValue
+        self.key = key
+        self.name = name
+        self.bucket = bucket
+        self.passthrough = passthrough
     }
 }

--- a/Sources/CommonMain/Model/Feature.swift
+++ b/Sources/CommonMain/Model/Feature.swift
@@ -31,6 +31,24 @@ public struct FeatureRule: Codable {
     public let namespace: [JSON]?
     /// What user attribute should be used to assign variations (defaults to id)
     public let hashAttribute: String?
+    /// Hash version of hash function
+    public let hashVersion: Float?
+    /// A more precise version of `coverage`
+    public let range: BucketRange?
+    /// Ranges for experiment variations
+    public let ranges: [BucketRange]?
+    /// Meta info about the experiment variations
+    public let meta: [VariationMeta]?
+    /// Array of filters to apply to the rule
+    public let filters: [Filter]?
+    /// Seed to use for hashing
+    public let seed: String?
+    /// Human-readable name for the experiment
+    public let name: String?
+    /// The phase id of the experiment
+    public let phase: String?
+    /// Array of tracking calls to fire
+    public let tracks: [TrackData]?
 
     init(condition: Condition? = nil,
          coverage: Float? = nil,
@@ -39,7 +57,16 @@ public struct FeatureRule: Codable {
          key: String? = nil,
          weights: [Float]? = nil,
          namespace: [JSON]? = nil,
-         hashAttribute: String? = nil) {
+         hashAttribute: String? = nil,
+         hashVersion: Float? = nil,
+         range: BucketRange? = nil,
+         ranges: [BucketRange]? = nil,
+         meta: [VariationMeta]? = nil,
+         filters: [Filter]? = nil,
+         seed: String? = nil,
+         name: String? = nil,
+         phase: String? = nil,
+         tracks: [TrackData]? = nil) {
         self.condition = condition
         self.coverage = coverage
         self.force = force
@@ -48,6 +75,15 @@ public struct FeatureRule: Codable {
         self.weights = weights
         self.namespace = namespace
         self.hashAttribute = hashAttribute
+        self.hashVersion = hashVersion
+        self.range = range
+        self.ranges = ranges
+        self.meta = meta
+        self.filters = filters
+        self.seed = seed
+        self.name = name
+        self.phase = phase
+        self.tracks = tracks
     }
 }
 

--- a/Sources/CommonMain/Network/EventHandler.swift
+++ b/Sources/CommonMain/Network/EventHandler.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+class EventHandler {
+
+    private let validNewlineCharacters = ["\r\n", "\n", "\r"]
+    private let dataBuffer: NSMutableData
+
+    init() {
+        dataBuffer = NSMutableData()
+    }
+
+    var currentBuffer: String? {
+        return NSString(data: dataBuffer as Data, encoding: String.Encoding.utf8.rawValue) as String?
+    }
+
+    func append(data: Data?) -> [SSEEvent] {
+        guard let data = data else { return [] }
+        dataBuffer.append(data)
+        let events = extractEventsFromBuffer().compactMap { [weak self] eventString -> SSEEvent? in
+            guard let self else { return nil }
+            return SSEEvent(eventString: eventString, newLineCharacters: self.validNewlineCharacters)
+        }
+        return events
+    }
+
+    private func extractEventsFromBuffer() -> [String] {
+        var events = [String]()
+
+        var searchRange =  NSRange(location: 0, length: dataBuffer.length)
+        while let foundRange = searchFirstEventDelimiter(in: searchRange) {
+            let dataChunk = dataBuffer.subdata(
+                with: NSRange(location: searchRange.location, length: foundRange.location - searchRange.location)
+            )
+            if let text = String(bytes: dataChunk, encoding: .utf8) {
+                events.append(text)
+            }
+            searchRange.location = foundRange.location + foundRange.length
+            searchRange.length = dataBuffer.length - searchRange.location
+        }
+        dataBuffer.replaceBytes(in: NSRange(location: 0, length: searchRange.location), withBytes: nil, length: 0)
+        return events
+    }
+
+    private func searchFirstEventDelimiter(in range: NSRange) -> NSRange? {
+        let delimiters = validNewlineCharacters.map {
+            "\($0)\($0)".data(using: String.Encoding.utf8)
+        }
+        for delimiter in delimiters {
+            guard let delimiter = delimiter else { continue }
+            let foundRange = dataBuffer.range(
+                of: delimiter, options: NSData.SearchOptions(), in: range
+            )
+            if foundRange.location != NSNotFound {
+                return foundRange
+            }
+        }
+        return nil
+    }
+}
+

--- a/Sources/CommonMain/Network/EventModel.swift
+++ b/Sources/CommonMain/Network/EventModel.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+enum SSEEvent {
+    case event(id: String?, event: String?, data: String?, time: String?)
+    
+    init?(eventString: String?, newLineCharacters: [String]) {
+        guard let eventString = eventString else { return nil }
+        
+        if eventString.hasPrefix(":") {
+            return nil
+        }
+        self = SSEEvent.parseEvent(eventString, newLineCharacters: newLineCharacters)
+    }
+    
+    var id: String? {
+        guard case let .event(id, _, _, _) = self else { return nil }
+        return id
+    }
+    
+    var event: String? {
+        guard case let .event(_, name, _, _) = self else { return nil }
+        return name
+    }
+    
+    var data: String? {
+        guard case let .event(_, _, data, _) = self else { return nil }
+        return data
+    }
+    
+    var retryTime: Int? {
+        guard case let .event(_, _, _, time) = self, let time = time else { return nil }
+        return Int(time.trimmingCharacters(in: CharacterSet.whitespaces))
+    }
+    
+    var onlyRetryEvent: Bool? {
+        guard case let .event(id, name, data, time) = self else { return nil }
+        let otherThanTime = id ?? name ?? data
+        
+        if otherThanTime == nil && time != nil {
+            return true
+        }
+        
+        return false
+        
+    }
+}
+
+private extension SSEEvent {
+    
+    static func parseEvent(_ eventString: String, newLineCharacters: [String]) -> SSEEvent {
+        var event: [String: String?] = [:]
+        
+        for line in eventString.components(separatedBy: CharacterSet.newlines) as [String] {
+            let (akey, value) = SSEEvent.parseLine(line, newLineCharacters: newLineCharacters)
+            guard let key = akey else { continue }
+            
+            if let value = value, let previousValue = event[key] ?? nil {
+                event[key] = "\(previousValue)\n\(value)"
+            } else if let value = value {
+                event[key] = value
+            } else {
+                event[key] = nil
+            }
+        }
+        
+        return .event(
+            id: event["id"] ?? nil,
+            event: event["event"] ?? nil,
+            data: event["data"] ?? nil,
+            time: event["retry"] ?? nil
+        )
+    }
+    
+    static func parseLine(_ line: String, newLineCharacters: [String]) -> (key: String?, value: String?) {
+        var key: NSString?, value: NSString?
+        let scanner = Scanner(string: line)
+        if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            if let scannedKey = scanner.scanUpToString(":") {
+                key = scannedKey as NSString
+            }
+            _ = scanner.scanString(":")
+        } else {
+            scanner.scanUpTo(":", into: &key)
+            scanner.scanString(":", into: nil)
+        }
+        
+        for newline in newLineCharacters {
+            if #available(iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+                if let scannedValue = scanner.scanUpToString(newline) {
+                    value = scannedValue as NSString
+                    break
+                }
+            } else {
+                if scanner.scanUpTo(newline, into: &value) {
+                    break
+                }
+            }
+        }
+        
+        if key != "event" && value == nil {
+            value = ""
+        }
+        
+        return (key as String?, value as String?)
+    }
+}

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+enum SSEConnectionStatus {
+    case connecting
+    case connected
+    case disconnected
+}
+
+class SSEHandler: NSObject, URLSessionDataDelegate {
+    static let DefaultRetryTime = 1000
+    public let url: URL
+    public var lastEventId: String?
+    public var retryTime = SSEHandler.DefaultRetryTime
+    public var headers: [String: String]
+    public var connectionStatus: SSEConnectionStatus
+
+    private var onConnect: (() -> Void)?
+    private var onDisconnect: ((Int?, Bool?, NSError?) -> Void)?
+    private var eventListeners: [String: (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
+    private var eventHandler: EventHandler?
+    private var operationQueue: OperationQueue
+    private var mainQueue = DispatchQueue.main
+    private var urlSession: URLSession?
+
+    public init(
+        url: URL,
+        headers: [String: String] = [:]
+    ) {
+        self.url = url
+        self.headers = headers
+
+        connectionStatus = SSEConnectionStatus.disconnected
+        operationQueue = OperationQueue()
+        operationQueue.maxConcurrentOperationCount = 1
+
+        super.init()
+    }
+
+    public func connect(lastEventId: String? = nil) {
+        eventHandler = EventHandler()
+        connectionStatus = .connecting
+
+        let configuration = sessionConfiguration(lastEventId: lastEventId)
+        urlSession = URLSession(configuration: configuration, delegate: self, delegateQueue: operationQueue)
+        urlSession?.dataTask(with: url).resume()
+    }
+
+    public func disconnect() {
+        connectionStatus = .disconnected
+        urlSession?.invalidateAndCancel()
+    }
+
+    public func onConnect(onConnect: @escaping (() -> ())) {
+        self.onConnect = onConnect
+    }
+
+    public func onDissconnect(onDisconnect: @escaping ((Int?, Bool?, NSError?) -> ())) {
+        self.onDisconnect = onDisconnect
+    }
+
+    public func addEventListener(event: String,
+                                 handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> ())) {
+        eventListeners[event] = handler
+    }
+
+    public func removeEventListener(event: String) {
+        eventListeners.removeValue(forKey: event)
+    }
+
+    public func events() -> [String] {
+        return Array(eventListeners.keys)
+    }
+
+    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        if connectionStatus != .connected {
+            return
+        }
+        if let events = eventHandler?.append(data: data) {
+            notifyReceivedEvents(events)
+        }
+    }
+
+    open func urlSession(_ session: URLSession,
+                         dataTask: URLSessionDataTask,
+                         didReceive response: URLResponse,
+                         completionHandler: @escaping (URLSession.ResponseDisposition) -> ()) {
+
+        completionHandler(URLSession.ResponseDisposition.allow)
+        connectionStatus = .connected
+        mainQueue.async { [weak self] in self?.onConnect?() }
+    }
+
+    open func urlSession(_ session: URLSession,
+                         task: URLSessionTask,
+                         didCompleteWithError error: Error?) {
+
+        guard let responseStatusCode = (task.response as? HTTPURLResponse)?.statusCode else {
+            mainQueue.async { [weak self] in self?.onDisconnect?(nil, nil, error as NSError?) }
+            return
+        }
+
+        let reconnect = shouldReconnect(statusCode: responseStatusCode)
+        mainQueue.async { [weak self] in self?.onDisconnect?(responseStatusCode, reconnect, nil) }
+    }
+
+    open func urlSession(_ session: URLSession,
+                         task: URLSessionTask,
+                         willPerformHTTPRedirection response: HTTPURLResponse,
+                         newRequest request: URLRequest,
+                         completionHandler: @escaping (URLRequest?) -> Void) {
+
+        var newRequest = request
+        self.headers.forEach { newRequest.setValue($1, forHTTPHeaderField: $0) }
+        completionHandler(newRequest)
+    }
+}
+
+extension SSEHandler {
+
+    func sessionConfiguration(lastEventId: String?) -> URLSessionConfiguration {
+
+        var additionalHeaders = headers
+        if let eventID = lastEventId {
+            additionalHeaders["Last-Event-Id"] = eventID
+        }
+        additionalHeaders["Accept"] = "application/json; q=0.5"
+        additionalHeaders["Accept"] = "text/event-stream"
+        additionalHeaders["Cache-Control"] = "no-cache"
+
+        let sessionConfiguration = URLSessionConfiguration.default
+        sessionConfiguration.timeoutIntervalForRequest = TimeInterval(INT_MAX)
+        sessionConfiguration.timeoutIntervalForResource = TimeInterval(INT_MAX)
+        sessionConfiguration.httpAdditionalHeaders = additionalHeaders
+
+        return sessionConfiguration
+    }
+
+    func readyStateOpen() {
+        connectionStatus = .connected
+    }
+}
+
+
+extension SSEHandler {
+
+    private func notifyReceivedEvents(_ events: [SSEEvent]) {
+
+        for event in events {
+            lastEventId = event.id
+            retryTime = event.retryTime ?? SSEHandler.DefaultRetryTime
+
+            if event.onlyRetryEvent == true {
+                continue
+            }
+
+            if let eventName = event.event, let eventHandler = eventListeners[eventName] {
+                mainQueue.async { eventHandler(event.id, event.event, event.data) }
+            }
+        }
+    }
+    
+    private func shouldReconnect(statusCode: Int) -> Bool {
+        switch statusCode {
+        case 200:
+            return false
+        case _ where statusCode > 200 && statusCode < 300:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/CommonMain/Utils/Common.swift
+++ b/Sources/CommonMain/Utils/Common.swift
@@ -32,5 +32,18 @@ extension Common {
 
         return hash
     }
+    
+    static func isEqual<T>(_ a: T, _ b: T) -> Bool where T : Equatable {
+        return a == b
+    }
+
+    static func isIn<T: Equatable>(actual: T, expected: [T]) -> Bool {
+        // Check if actual is an array
+        if let actualArray = actual as? [T] {
+            return actualArray.contains { expected.contains($0) }
+        }
+        
+        return expected.contains(actual)
+    }
 
 }

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -15,7 +15,7 @@ typealias Features = [String: Feature]
 typealias Condition = JSON
 
 /// Handler for Refresh Cache Request
-///
+/// 
 /// It updates back whether cache was refreshed or not
 public typealias CacheRefreshHandler = (Bool) -> Void
 

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -27,12 +27,50 @@ public typealias TrackingCallback = (Experiment, ExperimentResult) -> Void
 /// It has ID, StartRange & EndRange
 typealias NameSpace = (String, Float, Float)
 
-/// Double Tuple for GrowthBook Ranges
-typealias BucketRange = (Float, Float)
+/// Double Struct for GrowthBook Ranges
+public struct BucketRange: Codable {
+    let number1: Float
+    let number2: Float
+}
 
 /// GrowthBook Error Class to handle any error / exception scenario
 @objc public enum SDKError: NSInteger, Error {
     case failedToLoadData = 0
     case failedParsedData = 1
     case failedMissingKey = 2
+}
+
+/// Meta info about the variations
+public struct VariationMeta: Codable {
+    /// Used to implement holdout groups
+    let passthrough: Bool?
+    /// A unique key for this variation
+    let key: String?
+    /// A human-readable name for this variation
+    let name: String?
+}
+
+///Used for remote feature evaluation to trigger the `TrackingCallback`
+public struct TrackData: Codable {
+    let experiment: Experiment
+    let result: ExperimentResult
+}
+
+/// Object used for mutual exclusion and filtering users out of experiments based on random hashes.
+@objc public class Filter: NSObject, Codable {
+    /// The attribute to use (default to `"id"`)
+    var attribute: String?
+    /// The seed used in the hash
+    var seed: String
+    /// The hash version to use (default to `2`)
+    var hashVersion: Float
+    /// Array of ranges that are included
+    var ranges: [BucketRange]
+    
+    init(attribute: String?, seed: String, hashVersion: Float, ranges: [BucketRange]) {
+        self.attribute = attribute
+        self.seed = seed
+        self.hashVersion = hashVersion
+        self.ranges = ranges
+    }
 }

--- a/Sources/CommonMain/Utils/DecryptionUtils.swift
+++ b/Sources/CommonMain/Utils/DecryptionUtils.swift
@@ -1,0 +1,97 @@
+//
+//  DecryptionUtils.swift
+//  GrowthBook
+//
+//  Created by admin on 9/21/23.
+//
+
+import Foundation
+import CommonCrypto
+
+class DecryptionUtils {
+    
+    enum DecryptionError: Error {
+        case invalidPayload
+        case invalidEncryptionKey
+        case decryptionFailed
+    }
+    
+    static func decrypt(payload: String, encryptionKey: String) throws -> String {
+        guard payload.contains(".") else {
+            throw DecryptionError.invalidPayload
+        }
+        
+        do {
+            let parts = payload.split(separator: ".")
+            let ivString = String(parts[0])
+            let cipherTextString = String(parts[1])
+            
+            guard let ivData = Data(base64Encoded: ivString),
+                  let encryptionKeyData = Data(base64Encoded: encryptionKey) else {
+                throw DecryptionError.invalidPayload
+            }
+            
+            let cipherTextData = Data(base64Encoded: cipherTextString)
+            
+            let decryptedData = try AESCryptor.decrypt(data: cipherTextData, key: encryptionKeyData, iv: ivData)
+            
+            guard let decryptedString = String(data: decryptedData, encoding: .utf8) else {
+                throw DecryptionError.decryptionFailed
+            }
+            
+            return decryptedString
+        } catch {
+            throw DecryptionError.decryptionFailed
+        }
+    }
+    
+    private static func keyFromSecret(encryptionKey: String) -> Data {
+        guard let keyData = Data(base64Encoded: encryptionKey) else {
+            fatalError("Invalid encryption key")
+        }
+        return keyData
+    }
+}
+
+class AESCryptor {
+    
+    static func decrypt(data: Data?, key: Data, iv: Data) throws -> Data {
+        guard let inputData = data else {
+            throw DecryptionUtils.DecryptionError.decryptionFailed
+        }
+        
+        var buffer = [UInt8](repeating: 0, count: inputData.count + kCCBlockSizeAES128)
+        var numBytesDecrypted = 0
+        
+        let status = key.withUnsafeBytes { keyBytes in
+            iv.withUnsafeBytes { ivBytes in
+                inputData.withUnsafeBytes { dataBytes in
+                    CCCrypt(
+                        CCOperation(kCCDecrypt),
+                        CCAlgorithm(kCCAlgorithmAES),
+                        CCOptions(kCCOptionPKCS7Padding),
+                        keyBytes.baseAddress, key.count,
+                        ivBytes.baseAddress,
+                        dataBytes.baseAddress, inputData.count,
+                        &buffer, buffer.count,
+                        &numBytesDecrypted
+                    )
+                }
+            }
+        }
+        
+        guard status == kCCSuccess else {
+            throw DecryptionUtils.DecryptionError.decryptionFailed
+        }
+        
+        return Data(buffer.prefix(numBytesDecrypted))
+    }
+}
+
+class DecryptionException: Error {
+    let errorMessage: String
+
+    init(errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+}


### PR DESCRIPTION
1. v0.4
- Changed signature of hash method and added multiple hashing versions
- New inRange, isIncludedInRollout, and isFilteredOut helper methods
- New hashVersion, range, ranges, meta, filters, seed, name, tracks, and phase properties of FeatureRules
- New hashVersion, ranges, meta, filters, seed, name, and phase properties of Experiments
- New key, name, bucket, and passthrough fields in Experiment Results
- New Filter, VariationMeta, and TrackData data structures
- Added decrypt function and set of test cases
- hash function now returns null instead of -1 when an invalid hashVersion is specified
- Fixed broken feature test case (was using [0.99] instead of 0.99 for coverage)

2. v0.5.0
- New isIn helper function for conditions, plus new evalCondition test cases for $in and $nin operators when attribute is an array

3. Added support streaming update