### PR TITLE
Update podspec to support arm64 in iOS simulators

### DIFF
--- a/GrowthBook-IOS.podspec
+++ b/GrowthBook-IOS.podspec
@@ -18,8 +18,4 @@ Pod::Spec.new do |spec|
 
   spec.pod_target_xcconfig       = { 'DEFINES_MODULE' => 'YES' }
 
-  spec.xcconfig                  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  spec.pod_target_xcconfig       = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  spec.user_target_xcconfig      = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-
 end


### PR DESCRIPTION
By not excluding the arm64 architecture in the iphonesimulator sdk, we avoid having to use Rosetta when launching iOS simulators in Macs with Apple silicon.

This change significantly enhances the performance of the simulator. We've tested the Growthbook sdk with these changes in the podspec file, and it runs smoothly in a MacBook Pro with a M2 Pro chip.

Fixes https://github.com/growthbook/growthbook-swift/issues/43