### PR TITLE
Enable path to decode encrypted features

### DIFF
--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -65,6 +65,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
     }
     
     func testWithEncryptGetDataFromCache() throws {
@@ -91,6 +92,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
     }
     
     func testError() throws {
@@ -102,6 +104,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertFalse(isSuccess)
         XCTAssertTrue(isError)
+        XCTAssertFalse(hasFeatures)
     }
 
     func testInvalid() throws {
@@ -112,6 +115,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertFalse(isSuccess)
         XCTAssertTrue(isError)
+        XCTAssertFalse(hasFeatures)
     }
 
     func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -5,6 +5,15 @@ import XCTest
 class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     var isSuccess: Bool = false
     var isError: Bool = false
+    var hasFeatures: Bool = false
+    
+    override func setUp() {
+        super.setUp()
+        
+        isSuccess = false
+        isError = true
+        hasFeatures = false
+    }
 
     func testSuccess() throws {
         isSuccess = false
@@ -16,6 +25,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
     }
 
     func testSuccessForEncryptedFeatures() throws {
@@ -29,6 +39,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
     }
     
     func testGetDataFromCache() throws {
@@ -106,11 +117,13 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {
         isSuccess = true
         isError = false
+        hasFeatures = !features.isEmpty
     }
 
     func featuresFetchFailed(error: SDKError, isRemote: Bool) {
         isSuccess = false
         isError = true
+        hasFeatures = false
     }
     
     func featuresAPIModelSuccessfully(model: FeaturesDataModel) {

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -79,7 +79,7 @@ class FeaturesViewModel {
         let decoder = JSONDecoder()
         if let jsonPetitions = try? decoder.decode(FeaturesDataModel.self, from: data) {
             delegate?.featuresAPIModelSuccessfully(model: jsonPetitions)
-            if let features = jsonPetitions.features {
+            if let features = jsonPetitions.features, !features.isEmpty {
                 if let featureData = try? JSONEncoder().encode(features) {
                     manager.putData(fileName: Constants.featureCache, content: featureData)
                 }


### PR DESCRIPTION
This PR fixes an issue with responses containing `encryptedFeatures`. 

With encryption enabled, no features can be found inside the `FeaturesViewModel`.
The problem can be reproduced by checking for the existence of decoded features in all `FeaturesViewModelTests.`

To pass the tests again I added a check if the list of unencrypted features `isEmpty` to enable the pah for encrypted features in this case. 

There is the same `isNullOrEmpty()` check int the Kotlin SDK at https://github.com/growthbook/growthbook-kotlin/blob/8e693071a63194518ef074056d40f68108b7a7a2/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt#L102.

I was also wondering if the server response should even contain `features: {}` in case of enable encryption and this lead to the problem?

Sidenote: We have a similar problem with the Kotlin SDK on Android but we are still investigating the reasons.
