### PR TITLE
Updating sticket bucketing functionality

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -28,8 +28,9 @@
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
+		84AE3B1A2BE2466C006BA49B /* RemoteEvalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AE3B182BE2466B006BA49B /* RemoteEvalModel.swift */; };
+		84AE3B1B2BE2466C006BA49B /* StickyAssignmentsDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AE3B192BE2466C006BA49B /* StickyAssignmentsDocument.swift */; };
 		84BC2E9D294A11F100289BC2 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BC2E9C294A11F100289BC2 /* Crypto.swift */; };
-		84C55A322BCF08940058E669 /* RemoteEvalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C55A312BCF08940058E669 /* RemoteEvalModel.swift */; };
 		84CDE32B2812F359008B3E6F /* GrowthBook.h in Headers */ = {isa = PBXBuildFile; fileRef = 84CDE32A2812F359008B3E6F /* GrowthBook.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84CDE3332812F454008B3E6F /* GrowthBookSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F627F845EB0072BFDC /* GrowthBookSDK.swift */; };
 		84CDE3342812F454008B3E6F /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F827F845EB0072BFDC /* NetworkClient.swift */; };
@@ -48,7 +49,7 @@
 		84CDE3412812F454008B3E6F /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640827F845EB0072BFDC /* Feature.swift */; };
 		84CDE3422812F454008B3E6F /* Experiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640927F845EB0072BFDC /* Experiment.swift */; };
 		84CDE3432812F454008B3E6F /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640A27F845EB0072BFDC /* Context.swift */; };
-		84FEA9ED2BC98F4F00111EE2 /* StickyAssignmentsDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FEA9EC2BC98F4F00111EE2 /* StickyAssignmentsDocument.swift */; };
+		84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E82C3C2BD2AF8F003F000B /* StickyBucketingTests.swift */; };
 		84FEA9F12BC9913700111EE2 /* StickyBucketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FEA9EF2BC9913300111EE2 /* StickyBucketService.swift */; };
 /* End PBXBuildFile section */
 
@@ -117,12 +118,13 @@
 		849952502ACDB676003BBCF7 /* SSEHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSEHandler.swift; sourceTree = "<group>"; };
 		849952562ADD6D66003BBCF7 /* EventModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventModel.swift; sourceTree = "<group>"; };
 		849952582ADD704A003BBCF7 /* EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
+		84AE3B182BE2466B006BA49B /* RemoteEvalModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteEvalModel.swift; sourceTree = "<group>"; };
+		84AE3B192BE2466C006BA49B /* StickyAssignmentsDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickyAssignmentsDocument.swift; sourceTree = "<group>"; };
 		84BC2E9C294A11F100289BC2 /* Crypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Crypto.swift; sourceTree = "<group>"; };
-		84C55A312BCF08940058E669 /* RemoteEvalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteEvalModel.swift; sourceTree = "<group>"; };
 		84CDE3282812F359008B3E6F /* GrowthBook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GrowthBook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84CDE32A2812F359008B3E6F /* GrowthBook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook.h; sourceTree = "<group>"; };
+		84E82C3C2BD2AF8F003F000B /* StickyBucketingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyBucketingTests.swift; sourceTree = "<group>"; };
 		84F51E9627F419B000994D1C /* GrowthBook_IOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook_IOS.h; sourceTree = "<group>"; };
-		84FEA9EC2BC98F4F00111EE2 /* StickyAssignmentsDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickyAssignmentsDocument.swift; sourceTree = "<group>"; };
 		84FEA9EF2BC9913300111EE2 /* StickyBucketService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickyBucketService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -243,11 +245,11 @@
 		8433640727F845EB0072BFDC /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				84FEA9EC2BC98F4F00111EE2 /* StickyAssignmentsDocument.swift */,
 				8433640827F845EB0072BFDC /* Feature.swift */,
 				8433640927F845EB0072BFDC /* Experiment.swift */,
 				8433640A27F845EB0072BFDC /* Context.swift */,
-				84C55A312BCF08940058E669 /* RemoteEvalModel.swift */,
+				84AE3B182BE2466B006BA49B /* RemoteEvalModel.swift */,
+				84AE3B192BE2466C006BA49B /* StickyAssignmentsDocument.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -265,6 +267,7 @@
 			children = (
 				84391F2528016C5C003309DC /* Source */,
 				84391F0827FD64EB003309DC /* FeaturesViewModelTests.swift */,
+				84E82C3C2BD2AF8F003F000B /* StickyBucketingTests.swift */,
 				84391F0C27FD701D003309DC /* ConditionTests.swift */,
 				84391F0E27FD715B003309DC /* ExperimentRunTests.swift */,
 				84391F1027FD7388003309DC /* FeatureValueTests.swift */,
@@ -443,6 +446,7 @@
 				848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */,
 				849114CB280DA73100C0B9A5 /* TestHelper.swift in Sources */,
 				849114CC280DA73100C0B9A5 /* UtilsTests.swift in Sources */,
+				84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */,
 				849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
@@ -453,7 +457,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				84FEA9ED2BC98F4F00111EE2 /* StickyAssignmentsDocument.swift in Sources */,
 				84CDE3332812F454008B3E6F /* GrowthBookSDK.swift in Sources */,
 				84CDE3342812F454008B3E6F /* NetworkClient.swift in Sources */,
 				84095C902818245700ADDF19 /* Formatter.swift in Sources */,
@@ -467,6 +470,7 @@
 				84BC2E9D294A11F100289BC2 /* Crypto.swift in Sources */,
 				84CDE3392812F454008B3E6F /* Extensions.swift in Sources */,
 				84CDE33A2812F454008B3E6F /* Utils.swift in Sources */,
+				84AE3B1A2BE2466C006BA49B /* RemoteEvalModel.swift in Sources */,
 				84FEA9F12BC9913700111EE2 /* StickyBucketService.swift in Sources */,
 				84095C8C281823BC00ADDF19 /* LoggingManager.swift in Sources */,
 				84CDE33B2812F454008B3E6F /* Common.swift in Sources */,
@@ -477,12 +481,12 @@
 				84CDE33F2812F454008B3E6F /* ConditionEvaluator.swift in Sources */,
 				84CDE3402812F454008B3E6F /* CachingManager.swift in Sources */,
 				84CDE3412812F454008B3E6F /* Feature.swift in Sources */,
+				84AE3B1B2BE2466C006BA49B /* StickyAssignmentsDocument.swift in Sources */,
 				84095C792817EC7800ADDF19 /* JsonManager.swift in Sources */,
 				840E386F2B88BD75003DFC9F /* ExperimentHelper.swift in Sources */,
 				84CDE3422812F454008B3E6F /* Experiment.swift in Sources */,
 				849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */,
 				84CDE3432812F454008B3E6F /* Context.swift in Sources */,
-				84C55A322BCF08940058E669 /* RemoteEvalModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GrowthBookTests/Source/json.json
+++ b/GrowthBookTests/Source/json.json
@@ -2019,79 +2019,764 @@
         "v": "1.2.3-alpha"
       },
       true
-    ]
+    ],
+    [
+          "version 0.9.99 < 1.0.0",
+          {
+            "version": {
+              "$vlt": "1.0.0"
+            }
+          },
+          {
+            "version": "0.9.99"
+          },
+          true
+        ],
+        [
+          "version 0.9.0 < 0.10.0",
+          {
+            "version": {
+              "$vlt": "0.10.0"
+            }
+          },
+          {
+            "version": "0.9.0"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-0.0 < 1.0.0-0.0.0",
+          {
+            "version": {
+              "$vlt": "1.0.0-0.0.0"
+            }
+          },
+          {
+            "version": "1.0.0-0.0"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-9999 < 1.0.0--",
+          {
+            "version": {
+              "$vlt": "1.0.0--"
+            }
+          },
+          {
+            "version": "1.0.0-9999"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-99 < 1.0.0-100",
+          {
+            "version": {
+              "$vlt": "1.0.0-100"
+            }
+          },
+          {
+            "version": "1.0.0-99"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-alpha < 1.0.0-alpha.1",
+          {
+            "version": {
+              "$vlt": "1.0.0-alpha.1"
+            }
+          },
+          {
+            "version": "1.0.0-alpha"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-alpha.1 < 1.0.0-alpha.beta",
+          {
+            "version": {
+              "$vlt": "1.0.0-alpha.beta"
+            }
+          },
+          {
+            "version": "1.0.0-alpha.1"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-alpha.beta < 1.0.0-beta",
+          {
+            "version": {
+              "$vlt": "1.0.0-beta"
+            }
+          },
+          {
+            "version": "1.0.0-alpha.beta"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-beta < 1.0.0-beta.2",
+          {
+            "version": {
+              "$vlt": "1.0.0-beta.2"
+            }
+          },
+          {
+            "version": "1.0.0-beta"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-beta.2 < 1.0.0-beta.11",
+          {
+            "version": {
+              "$vlt": "1.0.0-beta.11"
+            }
+          },
+          {
+            "version": "1.0.0-beta.2"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-beta.11 < 1.0.0-rc.1",
+          {
+            "version": {
+              "$vlt": "1.0.0-rc.1"
+            }
+          },
+          {
+            "version": "1.0.0-beta.11"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-rc.1 < 1.0.0",
+          {
+            "version": {
+              "$vlt": "1.0.0"
+            }
+          },
+          {
+            "version": "1.0.0-rc.1"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-0 < 1.0.0--1",
+          {
+            "version": {
+              "$vlt": "1.0.0--1"
+            }
+          },
+          {
+            "version": "1.0.0-0"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-0 < 1.0.0-1",
+          {
+            "version": {
+              "$vlt": "1.0.0-1"
+            }
+          },
+          {
+            "version": "1.0.0-0"
+          },
+          true
+        ],
+        [
+          "version 1.0.0-1.0 < 1.0.0-1.-1",
+          {
+            "version": {
+              "$vlt": "1.0.0-1.-1"
+            }
+          },
+          {
+            "version": "1.0.0-1.0"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-a.b.c < 1.2.3-a.b.c.d",
+          {
+            "version": {
+              "$vlt": "1.2.3-a.b.c.d"
+            }
+          },
+          {
+            "version": "1.2.3-a.b.c"
+          },
+          true
+        ],
+        [
+          "version 0.0.0 > 0.0.0-foo",
+          {
+            "version": {
+              "$vgt": "0.0.0-foo"
+            }
+          },
+          {
+            "version": "0.0.0"
+          },
+          true
+        ],
+        [
+          "version 0.0.1 > 0.0.0",
+          {
+            "version": {
+              "$vgt": "0.0.0"
+            }
+          },
+          {
+            "version": "0.0.1"
+          },
+          true
+        ],
+        [
+          "version 1.0.0 > 0.9.9",
+          {
+            "version": {
+              "$vgt": "0.9.9"
+            }
+          },
+          {
+            "version": "1.0.0"
+          },
+          true
+        ],
+        [
+          "version 0.10.0 > 0.9.0",
+          {
+            "version": {
+              "$vgt": "0.9.0"
+            }
+          },
+          {
+            "version": "0.10.0"
+          },
+          true
+        ],
+        [
+          "version 0.99.0 > 0.10.0",
+          {
+            "version": {
+              "$vgt": "0.10.0"
+            }
+          },
+          {
+            "version": "0.99.0"
+          },
+          true
+        ],
+        [
+          "version 2.0.0 > 1.2.3",
+          {
+            "version": {
+              "$vgt": "1.2.3"
+            }
+          },
+          {
+            "version": "2.0.0"
+          },
+          true
+        ],
+        [
+          "version v0.0.0 > 0.0.0-foo",
+          {
+            "version": {
+              "$vgt": "0.0.0-foo"
+            }
+          },
+          {
+            "version": "v0.0.0"
+          },
+          true
+        ],
+        [
+          "version v0.0.1 > 0.0.0",
+          {
+            "version": {
+              "$vgt": "0.0.0"
+            }
+          },
+          {
+            "version": "v0.0.1"
+          },
+          true
+        ],
+        [
+          "version v1.0.0 > 0.9.9",
+          {
+            "version": {
+              "$vgt": "0.9.9"
+            }
+          },
+          {
+            "version": "v1.0.0"
+          },
+          true
+        ],
+        [
+          "version v0.10.0 > 0.9.0",
+          {
+            "version": {
+              "$vgt": "0.9.0"
+            }
+          },
+          {
+            "version": "v0.10.0"
+          },
+          true
+        ],
+        [
+          "version v0.99.0 > 0.10.0",
+          {
+            "version": {
+              "$vgt": "0.10.0"
+            }
+          },
+          {
+            "version": "v0.99.0"
+          },
+          true
+        ],
+        [
+          "version v2.0.0 > 1.2.3",
+          {
+            "version": {
+              "$vgt": "1.2.3"
+            }
+          },
+          {
+            "version": "v2.0.0"
+          },
+          true
+        ],
+        [
+          "version 0.0.0 > v0.0.0-foo",
+          {
+            "version": {
+              "$vgt": "v0.0.0-foo"
+            }
+          },
+          {
+            "version": "0.0.0"
+          },
+          true
+        ],
+        [
+          "version 0.0.1 > v0.0.0",
+          {
+            "version": {
+              "$vgt": "v0.0.0"
+            }
+          },
+          {
+            "version": "0.0.1"
+          },
+          true
+        ],
+        [
+          "version 1.0.0 > v0.9.9",
+          {
+            "version": {
+              "$vgt": "v0.9.9"
+            }
+          },
+          {
+            "version": "1.0.0"
+          },
+          true
+        ],
+        [
+          "version 0.10.0 > v0.9.0",
+          {
+            "version": {
+              "$vgt": "v0.9.0"
+            }
+          },
+          {
+            "version": "0.10.0"
+          },
+          true
+        ],
+        [
+          "version 0.99.0 > v0.10.0",
+          {
+            "version": {
+              "$vgt": "v0.10.0"
+            }
+          },
+          {
+            "version": "0.99.0"
+          },
+          true
+        ],
+        [
+          "version 2.0.0 > v1.2.3",
+          {
+            "version": {
+              "$vgt": "v1.2.3"
+            }
+          },
+          {
+            "version": "2.0.0"
+          },
+          true
+        ],
+        [
+          "version 1.2.3 > 1.2.3-asdf",
+          {
+            "version": {
+              "$vgt": "1.2.3-asdf"
+            }
+          },
+          {
+            "version": "1.2.3"
+          },
+          true
+        ],
+        [
+          "version 1.2.3 > 1.2.3-4",
+          {
+            "version": {
+              "$vgt": "1.2.3-4"
+            }
+          },
+          {
+            "version": "1.2.3"
+          },
+          true
+        ],
+        [
+          "version 1.2.3 > 1.2.3-4-foo",
+          {
+            "version": {
+              "$vgt": "1.2.3-4-foo"
+            }
+          },
+          {
+            "version": "1.2.3"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-5-foo > 1.2.3-5",
+          {
+            "version": {
+              "$vgt": "1.2.3-5"
+            }
+          },
+          {
+            "version": "1.2.3-5-foo"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-5 > 1.2.3-4",
+          {
+            "version": {
+              "$vgt": "1.2.3-4"
+            }
+          },
+          {
+            "version": "1.2.3-5"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-5-foo > 1.2.3-5-Foo",
+          {
+            "version": {
+              "$vgt": "1.2.3-5-Foo"
+            }
+          },
+          {
+            "version": "1.2.3-5-foo"
+          },
+          true
+        ],
+        [
+          "version 3.0.0 > 2.7.2+asdf",
+          {
+            "version": {
+              "$vgt": "2.7.2+asdf"
+            }
+          },
+          {
+            "version": "3.0.0"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-a.10 > 1.2.3-a.5",
+          {
+            "version": {
+              "$vgt": "1.2.3-a.5"
+            }
+          },
+          {
+            "version": "1.2.3-a.10"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-a.b > 1.2.3-a.5",
+          {
+            "version": {
+              "$vgt": "1.2.3-a.5"
+            }
+          },
+          {
+            "version": "1.2.3-a.b"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-a.b > 1.2.3-a",
+          {
+            "version": {
+              "$vgt": "1.2.3-a"
+            }
+          },
+          {
+            "version": "1.2.3-a.b"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-a.b.c.10.d.5 > 1.2.3-a.b.c.5.d.100",
+          {
+            "version": {
+              "$vgt": "1.2.3-a.b.c.5.d.100"
+            }
+          },
+          {
+            "version": "1.2.3-a.b.c.10.d.5"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-r2 > 1.2.3-r100",
+          {
+            "version": {
+              "$vgt": "1.2.3-r100"
+            }
+          },
+          {
+            "version": "1.2.3-r2"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-r100 > 1.2.3-R2",
+          {
+            "version": {
+              "$vgt": "1.2.3-R2"
+            }
+          },
+          {
+            "version": "1.2.3-r100"
+          },
+          true
+        ],
+        [
+          "version a.b.c.d.e.f > 1.2.3",
+          {
+            "version": {
+              "$vgt": "1.2.3"
+            }
+          },
+          {
+            "version": "a.b.c.d.e.f"
+          },
+          true
+        ],
+        [
+          "version 10.0.0 > 9.0.0",
+          {
+            "version": {
+              "$vgt": "9.0.0"
+            }
+          },
+          {
+            "version": "10.0.0"
+          },
+          true
+        ],
+        [
+          "version 10000.0.0 > 9999.0.0",
+          {
+            "version": {
+              "$vgt": "9999.0.0"
+            }
+          },
+          {
+            "version": "10000.0.0"
+          },
+          true
+        ],
+        [
+          "version 1.2.3 == 1.2.3",
+          {
+            "version": {
+              "$veq": "1.2.3"
+            }
+          },
+          {
+            "version": "1.2.3"
+          },
+          true
+        ],
+        [
+          "version 1.2.3 == v1.2.3",
+          {
+            "version": {
+              "$veq": "v1.2.3"
+            }
+          },
+          {
+            "version": "1.2.3"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-0 == v1.2.3-0",
+          {
+            "version": {
+              "$veq": "v1.2.3-0"
+            }
+          },
+          {
+            "version": "1.2.3-0"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-1 == 1.2.3-1",
+          {
+            "version": {
+              "$veq": "1.2.3-1"
+            }
+          },
+          {
+            "version": "1.2.3-1"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-1 == v1.2.3-1",
+          {
+            "version": {
+              "$veq": "v1.2.3-1"
+            }
+          },
+          {
+            "version": "1.2.3-1"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-beta == 1.2.3-beta",
+          {
+            "version": {
+              "$veq": "1.2.3-beta"
+            }
+          },
+          {
+            "version": "1.2.3-beta"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-beta == v1.2.3-beta",
+          {
+            "version": {
+              "$veq": "v1.2.3-beta"
+            }
+          },
+          {
+            "version": "1.2.3-beta"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-beta+build == 1.2.3-beta+otherbuild",
+          {
+            "version": {
+              "$veq": "1.2.3-beta+otherbuild"
+            }
+          },
+          {
+            "version": "1.2.3-beta+build"
+          },
+          true
+        ],
+        [
+          "version 1.2.3-beta+build == v1.2.3-beta+otherbuild",
+          {
+            "version": {
+              "$veq": "v1.2.3-beta+otherbuild"
+            }
+          },
+          {
+            "version": "1.2.3-beta+build"
+          },
+          true
+        ],
+        [
+          "version 1-2-3 == 1.2.3",
+          {
+            "version": {
+              "$veq": "1.2.3"
+            }
+          },
+          {
+            "version": "1-2-3"
+          },
+          true
+        ],
+        [
+          "version 1-2-3 == 1-2.3+build99",
+          {
+            "version": {
+              "$veq": "1-2.3+build99"
+            }
+          },
+          {
+            "version": "1-2-3"
+          },
+          true
+        ],
+        [
+          "version 1-2-3 == v1.2.3",
+          {
+            "version": {
+              "$veq": "v1.2.3"
+            }
+          },
+          {
+            "version": "1-2-3"
+          },
+          true
+        ],
+        [
+          "version 1.2.3.4 == 1.2.3-4",
+          {
+            "version": {
+              "$veq": "1.2.3-4"
+            }
+          },
+          {
+            "version": "1.2.3.4"
+          },
+          true
+        ]
   ],
-  "versionCompare": {
-    "lt": [
-      ["0.9.99", "1.0.0", true],
-      ["0.9.0", "0.10.0", true],
-      ["1.0.0-0.0", "1.0.0-0.0.0", true],
-      ["1.0.0-9999", "1.0.0--", true],
-      ["1.0.0-99", "1.0.0-100", true],
-      ["1.0.0-alpha", "1.0.0-alpha.1", true],
-      ["1.0.0-alpha.1", "1.0.0-alpha.beta", true],
-      ["1.0.0-alpha.beta", "1.0.0-beta", true],
-      ["1.0.0-beta", "1.0.0-beta.2", true],
-      ["1.0.0-beta.2", "1.0.0-beta.11", true],
-      ["1.0.0-beta.11", "1.0.0-rc.1", true],
-      ["1.0.0-rc.1", "1.0.0", true],
-      ["1.0.0-0", "1.0.0--1", true],
-      ["1.0.0-0", "1.0.0-1", true],
-      ["1.0.0-1.0", "1.0.0-1.-1", true]
-    ],
-    "gt": [
-      ["0.0.0", "0.0.0-foo", true],
-      ["0.0.1", "0.0.0", true],
-      ["1.0.0", "0.9.9", true],
-      ["0.10.0", "0.9.0", true],
-      ["0.99.0", "0.10.0", true],
-      ["2.0.0", "1.2.3", true],
-      ["v0.0.0", "0.0.0-foo", true],
-      ["v0.0.1", "0.0.0", true],
-      ["v1.0.0", "0.9.9", true],
-      ["v0.10.0", "0.9.0", true],
-      ["v0.99.0", "0.10.0", true],
-      ["v2.0.0", "1.2.3", true],
-      ["0.0.0", "v0.0.0-foo", true],
-      ["0.0.1", "v0.0.0", true],
-      ["1.0.0", "v0.9.9", true],
-      ["0.10.0", "v0.9.0", true],
-      ["0.99.0", "v0.10.0", true],
-      ["2.0.0", "v1.2.3", true],
-      ["1.2.3", "1.2.3-asdf", true],
-      ["1.2.3", "1.2.3-4", true],
-      ["1.2.3", "1.2.3-4-foo", true],
-      ["1.2.3-5-foo", "1.2.3-5", true],
-      ["1.2.3-5", "1.2.3-4", true],
-      ["1.2.3-5-foo", "1.2.3-5-Foo", true],
-      ["3.0.0", "2.7.2+asdf", true],
-      ["1.2.3-a.10", "1.2.3-a.5", true],
-      ["1.2.3-a.b", "1.2.3-a.5", true],
-      ["1.2.3-a.b", "1.2.3-a", true],
-      ["1.2.3-a.b.c", "1.2.3-a.b.c.d", false],
-      ["1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100", true],
-      ["1.2.3-r2", "1.2.3-r100", true],
-      ["1.2.3-r100", "1.2.3-R2", true],
-      ["a.b.c.d.e.f", "1.2.3", true],
-      ["10.0.0", "9.0.0", true],
-      ["10000.0.0", "9999.0.0", true]
-    ],
-    "eq": [
-      ["1.2.3", "1.2.3", true],
-      ["1.2.3", "v1.2.3", true],
-      ["1.2.3-0", "v1.2.3-0", true],
-      ["1.2.3-1", "1.2.3-1", true],
-      ["1.2.3-1", "v1.2.3-1", true],
-      ["1.2.3-beta", "1.2.3-beta", true],
-      ["1.2.3-beta", "v1.2.3-beta", true],
-      ["1.2.3-beta+build", "1.2.3-beta+otherbuild", true],
-      ["1.2.3-beta+build", "v1.2.3-beta+otherbuild", true],
-      ["1-2-3", "1.2.3", true],
-      ["1-2-3", "1-2.3+build99", true],
-      ["1-2-3", "v1.2.3", true],
-      ["1.2.3.4", "1.2.3-4", true]
-    ]
-  },
   "hash": [
       [
         "a",
@@ -2450,6 +3135,33 @@
         "off": false,
         "source": "defaultValue"
       }
+    ],
+    [
+        "force rules - coverage 0",
+        {
+            "attributes": {
+                "id": "d0bc0a5a"
+            },
+            "features": {
+                "8d156": {
+                    "defaultValue": 0,
+                    "rules": [
+                        {
+                            "force": 1,
+                            "coverage": 0,
+                            "hashVersion": 2
+                        }
+                    ]
+                }
+            }
+        },
+        "8d156",
+        {
+            "value": 0,
+            "on": false,
+            "off": true,
+            "source": "defaultValue"
+        }
     ],
     [
       "force rules - condition pass",

--- a/GrowthBookTests/Source/json.json
+++ b/GrowthBookTests/Source/json.json
@@ -4794,467 +4794,530 @@
     ]
   ],
   "stickyBucket": [
-    [
-      "use fallbackAttribute when missing hashAttribute",
-      {
-        "attributes": { "anonymousId": "123" },
-        "features": {
-          "feature": {
-            "defaultValue": 0,
-            "rules": [
-              {
-                "variations": [0, 1, 2, 3],
-                "hashAttribute": "id",
-                "fallbackAttribute": "anonymousId"
+      [
+          "use fallbackAttribute when missing hashAttribute",
+          {
+              "attributes": { "anonymousId": "123" },
+              "features": {
+                  "feature": {
+                      "defaultValue": 0,
+                      "rules": [
+                          {
+                              "variations": [0, 1, 2, 3],
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "anonymousId"
+                          }
+                      ]
+                  }
               }
-            ]
-          }
-        }
-      },
-      "feature",
-      {
-        "bucket": 0.863,
-        "featureId": "feature",
-        "hashAttribute": "anonymousId",
-        "hashUsed": true,
-        "hashValue": "123",
-        "inExperiment": true,
-        "key": "3",
-        "stickyBucketUsed": false,
-        "value": 3,
-        "variationId": 3
-      },
-      {
-        "anonymousId||123": {
-          "assignments": { "feature__0": "3" },
-          "attributeName": "anonymousId",
-          "attributeValue": "123"
-        }
-      }
-    ],
-    [
-      "performs evaluation without sticky bucket",
-      {
-        "attributes": {
-          "deviceId": "d123",
-          "anonymousId": "ses123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        },
-        "stickyBucketAssignmentDocs": {}
-      },
-      "exp1",
-      {
-        "bucket": 0.6468,
-        "featureId": "exp1",
-        "hashAttribute": "deviceId",
-        "hashUsed": true,
-        "hashValue": "d123",
-        "inExperiment": true,
-        "key": "1",
-        "stickyBucketUsed": false,
-        "value": "red",
-        "variationId": 1
-      },
-      {
-        "deviceId||d123": {
-          "assignments": { "feature-exp__0": "1" },
-          "attributeName": "deviceId",
-          "attributeValue": "d123"
-        }
-      }
-    ],
-    [
-      "evaluates based on stored sticky bucket",
-      {
-        "attributes": {
-          "deviceId": "d123",
-          "anonymousId": "ses123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        },
-        "stickyBucketAssignmentDocs": {
-          "deviceId||d123": {
-            "attributeName": "deviceId",
-            "attributeValue": "d123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          }
-        }
-      },
-      "exp1",
-      {
-        "bucket": 0.6468,
-        "featureId": "exp1",
-        "hashAttribute": "deviceId",
-        "hashUsed": true,
-        "hashValue": "d123",
-        "inExperiment": true,
-        "key": "2",
-        "stickyBucketUsed": true,
-        "value": "blue",
-        "variationId": 2
-      },
-      {
-        "deviceId||d123": {
-          "assignments": { "feature-exp__0": "2" },
-          "attributeName": "deviceId",
-          "attributeValue": "d123"
-        }
-      }
-    ],
-    [
-      "upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute",
-      {
-        "attributes": {
-          "id": "i123",
-          "anonymousId": "ses123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        },
-        "stickyBucketAssignmentDocs": {
-          "anonymousId||123": {
-            "attributeName": "anonymousId",
-            "attributeValue": "123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
-          }
-        }
-      },
-      "exp1",
-      {
-        "bucket": 0.9943,
-        "featureId": "exp1",
-        "hashAttribute": "id",
-        "hashUsed": true,
-        "hashValue": "i123",
-        "inExperiment": true,
-        "key": "2",
-        "stickyBucketUsed": true,
-        "value": "blue",
-        "variationId": 2
-      },
-      {
-        "anonymousId||123": {
-          "assignments": { "feature-exp__0": "2" },
-          "attributeName": "anonymousId",
-          "attributeValue": "123"
-        },
-        "id||i123": {
-          "assignments": { "feature-exp__0": "2" },
-          "attributeName": "id",
-          "attributeValue": "i123"
-        }
-      }
-    ],
-    [
-      "favors a sticky bucket doc based on hashAttribute over fallbackAttribute",
-      {
-        "attributes": {
-          "id": "i123",
-          "anonymousId": "ses123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 0,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        },
-        "stickyBucketAssignmentDocs": {
-          "anonymousId||123": {
-            "attributeName": "anonymousId",
-            "attributeValue": "123",
-            "assignments": {
-              "feature-exp__0": "2"
-            }
           },
-          "id||i123": {
-            "attributeName": "id",
-            "attributeValue": "i123",
-            "assignments": {
-              "feature-exp__0": "1"
-            }
-          }
-        }
-      },
-      "exp1",
-      {
-        "bucket": 0.9943,
-        "featureId": "exp1",
-        "hashAttribute": "id",
-        "hashUsed": true,
-        "hashValue": "i123",
-        "inExperiment": true,
-        "key": "1",
-        "stickyBucketUsed": true,
-        "value": "red",
-        "variationId": 1
-      },
-      {
-        "anonymousId||123": {
-          "assignments": { "feature-exp__0": "2" },
-          "attributeName": "anonymousId",
-          "attributeValue": "123"
-        },
-        "id||i123": {
-          "assignments": { "feature-exp__0": "1" },
-          "attributeName": "id",
-          "attributeValue": "i123"
-        }
-      }
-    ],
-    [
-      "resets sticky bucketing when the bucketVersion changes",
-      {
-        "attributes": {
-          "id": "i123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 3,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "assignments": { "feature-exp__0": "1" },
-            "attributeName": "id",
-            "attributeValue": "i123"
-          }
-        }
-      },
-      "exp1",
-      {
-        "bucket": 0.9943,
-        "featureId": "exp1",
-        "hashAttribute": "id",
-        "hashUsed": true,
-        "hashValue": "i123",
-        "inExperiment": true,
-        "key": "2",
-        "stickyBucketUsed": false,
-        "value": "blue",
-        "variationId": 2
-      },
-      {
-        "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1",
-            "feature-exp__3": "2"
+          [],
+          "feature",
+          {
+              "bucket": 0.863,
+              "featureId": "feature",
+              "hashAttribute": "anonymousId",
+              "hashUsed": true,
+              "hashValue": "123",
+              "inExperiment": true,
+              "key": "3",
+              "stickyBucketUsed": false,
+              "value": 3,
+              "variationId": 3
           },
-          "attributeName": "id",
-          "attributeValue": "i123"
-        }
-      }
-    ],
-    [
-      "stops test enrollment when and existing sticky bucket is blocked by version",
-      {
-        "attributes": {
-          "id": "i123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 3,
-                "minBucketVersion": 3,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
+          {
+              "anonymousId||123": {
+                  "assignments": { "feature__0": "3" },
+                  "attributeName": "anonymousId",
+                  "attributeValue": "123"
               }
-            ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "assignments": { "feature-exp__0": "1" },
-            "attributeName": "id",
-            "attributeValue": "i123"
-          }
-        }
-      },
-      "exp1",
-      null,
-      {
-        "id||i123": {
-          "assignments": {
-            "feature-exp__0": "1"
+      ],
+      [
+          "performs evaluation without sticky bucket",
+          {
+              "attributes": {
+                  "deviceId": "d123",
+                  "anonymousId": "ses123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "deviceId",
+                              "hashVersion": 2,
+                              "bucketVersion": 0,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              },
+              "stickyBucketAssignmentDocs": {}
           },
-          "attributeName": "id",
-          "attributeValue": "i123"
-        }
-      }
-    ],
-    [
-      "disables sticky bucketing when disabled by experiment",
-      {
-        "attributes": {
-          "id": "i123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 1,
-                "disableStickyBucketing": true,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
+          [],
+          "exp1",
+          {
+              "bucket": 0.6468,
+              "featureId": "exp1",
+              "hashAttribute": "deviceId",
+              "hashUsed": true,
+              "hashValue": "d123",
+              "inExperiment": true,
+              "key": "1",
+              "stickyBucketUsed": false,
+              "value": "red",
+              "variationId": 1
+          },
+          {
+              "deviceId||d123": {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "deviceId",
+                  "attributeValue": "d123"
               }
-            ]
           }
-        },
-        "stickyBucketAssignmentDocs": {
-          "id||i123": {
-            "attributeName": "id",
-            "attributeValue": "i123",
-            "assignments": { "feature-exp__0": "1" }
+      ],
+      [
+          "evaluates based on stored sticky bucket",
+          {
+              "attributes": {
+                  "deviceId": "d123",
+                  "anonymousId": "ses123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "deviceId",
+                              "hashVersion": 2,
+                              "bucketVersion": 0,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "attributeName": "deviceId",
+                  "attributeValue": "d123",
+                  "assignments": {
+                      "feature-exp__0": "2"
+                  }
+              }
+          ],
+          "exp1",
+          {
+              "bucket": 0.6468,
+              "featureId": "exp1",
+              "hashAttribute": "deviceId",
+              "hashUsed": true,
+              "hashValue": "d123",
+              "inExperiment": true,
+              "key": "2",
+              "stickyBucketUsed": true,
+              "value": "blue",
+              "variationId": 2
+          },
+          {
+              "deviceId||d123": {
+                  "assignments": { "feature-exp__0": "2" },
+                  "attributeName": "deviceId",
+                  "attributeValue": "d123"
+              }
           }
-        }
-      },
-      "exp1",
-      {
-        "bucket": 0.9943,
-        "featureId": "exp1",
-        "hashAttribute": "id",
-        "hashUsed": true,
-        "hashValue": "i123",
-        "inExperiment": true,
-        "key": "2",
-        "stickyBucketUsed": false,
-        "value": "blue",
-        "variationId": 2
-      },
-      {
-        "id||i123": {
-          "attributeName": "id",
-          "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
-        }
-      }
-    ]
+      ],
+      [
+          "does not consume a sticky bucket not belonging to the user",
+          {
+              "attributes": {
+                  "deviceId": "d123",
+                  "anonymousId": "ses123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "deviceId",
+                              "hashVersion": 2,
+                              "bucketVersion": 0,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "attributeName": "deviceId",
+                  "attributeValue": "d456",
+                  "assignments": {
+                      "feature-exp__0": "2"
+                  }
+              }
+          ],
+          "exp1",
+          {
+              "bucket": 0.6468,
+              "featureId": "exp1",
+              "hashAttribute": "deviceId",
+              "hashUsed": true,
+              "hashValue": "d123",
+              "inExperiment": true,
+              "key": "1",
+              "stickyBucketUsed": false,
+              "value": "red",
+              "variationId": 1
+          },
+          {
+              "deviceId||d123": {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "deviceId",
+                  "attributeValue": "d123"
+              }
+          }
+      ],
+      [
+          "upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute",
+          {
+              "attributes": {
+                  "id": "i123",
+                  "anonymousId": "ses123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "anonymousId",
+                              "hashVersion": 2,
+                              "bucketVersion": 0,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "attributeName": "anonymousId",
+                  "attributeValue": "ses123",
+                  "assignments": {
+                      "feature-exp__0": "1"
+                  }
+              }
+          ],
+          "exp1",
+          {
+              "bucket": 0.9943,
+              "featureId": "exp1",
+              "hashAttribute": "id",
+              "hashUsed": true,
+              "hashValue": "i123",
+              "inExperiment": true,
+              "key": "1",
+              "stickyBucketUsed": true,
+              "value": "red",
+              "variationId": 1
+          },
+          {
+              "anonymousId||ses123": {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "anonymousId",
+                  "attributeValue": "ses123"
+              },
+              "id||i123": {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "id",
+                  "attributeValue": "i123"
+              }
+          }
+      ],
+      [
+          "favors a sticky bucket doc based on hashAttribute over fallbackAttribute",
+          {
+              "attributes": {
+                  "id": "i123",
+                  "anonymousId": "ses123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "anonymousId",
+                              "hashVersion": 2,
+                              "bucketVersion": 0,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "attributeName": "anonymousId",
+                  "attributeValue": "ses123",
+                  "assignments": {
+                      "feature-exp__0": "2"
+                  }
+              },
+              {
+                  "attributeName": "id",
+                  "attributeValue": "i123",
+                  "assignments": {
+                      "feature-exp__0": "1"
+                  }
+              }
+          ],
+          "exp1",
+          {
+              "bucket": 0.9943,
+              "featureId": "exp1",
+              "hashAttribute": "id",
+              "hashUsed": true,
+              "hashValue": "i123",
+              "inExperiment": true,
+              "key": "1",
+              "stickyBucketUsed": true,
+              "value": "red",
+              "variationId": 1
+          },
+          {
+              "anonymousId||ses123": {
+                  "assignments": { "feature-exp__0": "2" },
+                  "attributeName": "anonymousId",
+                  "attributeValue": "ses123"
+              },
+              "id||i123": {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "id",
+                  "attributeValue": "i123"
+              }
+          }
+      ],
+      [
+          "resets sticky bucketing when the bucketVersion changes",
+          {
+              "attributes": {
+                  "id": "i123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "deviceId",
+                              "hashVersion": 2,
+                              "bucketVersion": 3,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "id",
+                  "attributeValue": "i123"
+              }
+          ],
+          "exp1",
+          {
+              "bucket": 0.9943,
+              "featureId": "exp1",
+              "hashAttribute": "id",
+              "hashUsed": true,
+              "hashValue": "i123",
+              "inExperiment": true,
+              "key": "2",
+              "stickyBucketUsed": false,
+              "value": "blue",
+              "variationId": 2
+          },
+          {
+              "id||i123": {
+                  "assignments": {
+                      "feature-exp__0": "1",
+                      "feature-exp__3": "2"
+                  },
+                  "attributeName": "id",
+                  "attributeValue": "i123"
+              }
+          }
+      ],
+      [
+          "stops test enrollment when and existing sticky bucket is blocked by version",
+          {
+              "attributes": {
+                  "id": "i123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "deviceId",
+                              "hashVersion": 2,
+                              "bucketVersion": 3,
+                              "minBucketVersion": 3,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "assignments": { "feature-exp__0": "1" },
+                  "attributeName": "id",
+                  "attributeValue": "i123"
+              }
+          ],
+          "exp1",
+          null,
+          {
+              "id||i123": {
+                  "assignments": {
+                      "feature-exp__0": "1"
+                  },
+                  "attributeName": "id",
+                  "attributeValue": "i123"
+              }
+          }
+      ],
+      [
+          "disables sticky bucketing when disabled by experiment",
+          {
+              "attributes": {
+                  "id": "i123",
+                  "foo": "bar",
+                  "country": "USA"
+              },
+              "features": {
+                  "exp1": {
+                      "defaultValue": "control",
+                      "rules": [
+                          {
+                              "key": "feature-exp",
+                              "seed": "feature-exp",
+                              "hashAttribute": "id",
+                              "fallbackAttribute": "deviceId",
+                              "hashVersion": 2,
+                              "bucketVersion": 1,
+                              "disableStickyBucketing": true,
+                              "condition": { "country": "USA" },
+                              "variations": ["control", "red", "blue"],
+                              "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                              "coverage": 1,
+                              "weights": [0.3334, 0.3333, 0.3333],
+                              "phase": "0"
+                          }
+                      ]
+                  }
+              }
+          },
+          [
+              {
+                  "attributeName": "id",
+                  "attributeValue": "i123",
+                  "assignments": { "feature-exp__0": "1" }
+              }
+          ],
+          "exp1",
+          {
+              "bucket": 0.9943,
+              "featureId": "exp1",
+              "hashAttribute": "id",
+              "hashUsed": true,
+              "hashValue": "i123",
+              "inExperiment": true,
+              "key": "2",
+              "stickyBucketUsed": false,
+              "value": "blue",
+              "variationId": 2
+          },
+          {
+              "id||i123": {
+                  "attributeName": "id",
+                  "attributeValue": "i123",
+                  "assignments": { "feature-exp__0": "1" }
+              }
+          }
+      ]
   ],
   "urlRedirect": [
     [

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import GrowthBook
+
+class StickyBucketingFeatureTests: XCTestCase {
+    var service: StickyBucketService!
+    var evalConditions: [JSON]?
+
+    override func setUp() {
+        evalConditions = TestHelper().getStickyBucketingData()
+        service = StickyBucketService()
+    }
+
+    func testEvaluateFeatureWithStickyBucketingFeature() {
+        guard let evalConditions = evalConditions else { return }
+        var failedScenarios: [String] = []
+        var passedScenarios: [String] = []
+                
+        for item in evalConditions {
+            
+            let testData = FeaturesTest(json: item[1].dictionaryValue, stickyBucketingJson: item[2].arrayValue)
+            let attributes = testData.attributes
+            let stickyBucketAssignmentDocs = testData.stickyBucketAssignmentDocs
+            let forcedVariations = testData.forcedVariations
+            let features = testData.features
+        
+            var expectedStickyAssignmentDocs: [String: StickyAssignmentsDocument] = [:]
+            
+            item[5].dictionaryValue.forEach { (key, value) in
+                expectedStickyAssignmentDocs[key] = StickyAssignmentsDocument(attributeName: value.dictionaryValue["attributeName"]?.stringValue ?? "", attributeValue: value.dictionaryValue["attributeValue"]?.stringValue ?? "", assignments: value.dictionaryValue["assignments"]?.dictionaryValue ?? [:])
+            }
+            
+            let gbContext = Context(apiHost: nil,
+                                    clientKey: nil,
+                                    encryptionKey: nil,
+                                    isEnabled: true,
+                                    attributes: attributes,
+                                    forcedVariations: forcedVariations,
+                                    stickyBucketAssignmentDocs: stickyBucketAssignmentDocs,
+                                    stickyBucketService: service,
+                                    isQaMode: false,
+                                    trackingClosure: { _, _ in },
+                                    features: features ?? [:],
+                                    backgroundSync: false)
+            
+            let expectedResult = ExperimentResultTest(json: item[4].dictionaryValue)
+            let evaluator = FeatureEvaluator(context: gbContext, featureKey: item[3].stringValue, attributeOverrides: attributes)
+            let result = evaluator.evaluateFeature().experimentResult
+            
+            let status = "\(item[0].stringValue) \nExpected Result - \(expectedResult.variationId?.description) \(expectedResult.hashValue) \(expectedResult.inExperiment?.description) \(expectedResult.value?.stringValue) \(expectedResult.hashAttribute ?? "") & \(item[4].stringValue) \(expectedResult.hashUsed?.description) \nActual result - \(result?.variationId.description ?? "") \(result?.valueHash ?? "") \(result?.inExperiment.description ?? "") \(result?.value.stringValue ?? "") \(result?.hashAttribute ?? "") \(result?.hashUsed?.description) \n\n"
+
+            if result?.variationId == expectedResult.variationId &&
+                result?.value == expectedResult.value &&
+                result?.stickyBucketUsed == expectedResult.stickyBucketUsed &&
+                ((gbContext.stickyBucketAssignmentDocs?.allSatisfy({ (key, value) in
+                    expectedStickyAssignmentDocs[key] == value
+                })) != nil) 
+            {
+                print("PASSED: \(status)")
+                passedScenarios.append(status)
+            } else {
+                print("FAILED: \(status)")
+                failedScenarios.append(status)
+            }
+
+        }
+
+        print("\nTOTAL TESTS - \(evalConditions.count)")
+        print("Passed TESTS - \(passedScenarios.count)")
+        print("Failed TESTS - \(failedScenarios.count)")
+
+        XCTAssertTrue(failedScenarios.count == 0)
+    }
+}

--- a/GrowthBookTests/TestHelper.swift
+++ b/GrowthBookTests/TestHelper.swift
@@ -9,6 +9,11 @@ class TestHelper {
         }
     }
     
+    func getStickyBucketingData() -> [JSON]? {
+        let array = testData?.dictionaryValue["stickyBucket"]
+        return array?.arrayValue
+    }
+    
     func getServerSideEvent() -> [JSON]? {
         let array = testData?.dictionaryValue["backgroundsync"]
         return array?.arrayValue
@@ -103,8 +108,9 @@ struct FeaturesTest: Codable {
     var features: Features? = nil
     var attributes: JSON = JSON()
     var forcedVariations: JSON? = nil
+    var stickyBucketAssignmentDocs: [String: StickyAssignmentsDocument]? = nil
 
-    init(json: [String: JSON]) {
+    init(json: [String: JSON], stickyBucketingJson: [JSON]? = nil) {
         if let features = json["features"] {
             self.features = TestHelper.convertToFeaturesModel(dict: features.dictionaryValue)
         }
@@ -115,6 +121,23 @@ struct FeaturesTest: Codable {
         
         if let forcedVariations = json["forcedVariations"] {
             self.forcedVariations = forcedVariations
+        }
+        
+        if let stickyBucketingJson = stickyBucketingJson {
+            var docArray: [StickyAssignmentsDocument] = []
+            var newDict: [String: StickyAssignmentsDocument] = [:]
+
+            stickyBucketingJson.forEach { value in
+                let doc = StickyAssignmentsDocument(attributeName: value.dictionaryValue["attributeName"]?.stringValue ?? "", attributeValue: value.dictionaryValue["attributeValue"]?.stringValue ?? "", assignments: value.dictionaryValue["assignments"]?.dictionaryValue ?? [:])
+                docArray.append(doc)
+            }
+            
+            docArray.forEach { value in
+                let key = "\(value.attributeName)||\(value.attributeValue)"
+                newDict[key] = value
+            }
+            
+            self.stickyBucketAssignmentDocs = newDict == [:] ? nil : newDict
         }
     }
 }
@@ -168,46 +191,69 @@ class FeatureResultTest {
 
 class ExperimentResultTest {
     /// Whether or not the user is part of the experiment
-    let inExperiment: Bool
+    let inExperiment: Bool?
     /// The array index of the assigned variation
-    let variationId: Int
+    let variationId: Int?
     /// The array value of the assigned variation
-    let value: JSON
+    let value: JSON?
     /// The user attribute used to assign a variation
-    var hashAttribute: String? = nil
-    ///  The value of that attribute
-    var hashValue: String? = nil
+    let hashAttribute: String?
+    /// The value of that attribute
+    let hashValue: String?
+    /// The unique key for the assigned variation
+    let key: String?
+    /// The human-readable name of the assigned variation
+    var name: String?
+    /// The hash value used to assign a variation (float from `0` to `1`)
+    var bucket: Float?
+    /// Used for holdout groups
+    var passthrough: Bool?
+    /// If a hash was used to assign a variation
+    let hashUsed: Bool?
+    /// The id of the feature (if any) that the experiment came from
+    let featureId: String?
+    /// If sticky bucketing was used to assign a variation
+    let stickyBucketUsed: Bool?
 
-    init(inExperiment: Bool, variationId: Int, value: JSON, hashAttribute: String? = nil, hashValue: String? = nil) {
+    init(inExperiment: Bool,
+         variationId: Int,
+         value: JSON,
+         hashAttribute: String? = nil,
+         hashValue: String? = nil,
+         key: String,
+         name: String? = nil,
+         bucket: Float? = nil,
+         passthrough: Bool? = nil,
+         hashUsed: Bool? = nil,
+         featureId: String? = nil,
+         stickyBucketUsed: Bool? = nil) {
         self.inExperiment = inExperiment
         self.variationId = variationId
         self.value = value
         self.hashAttribute = hashAttribute
         self.hashValue = hashValue
+        self.key = key
+        self.name = name
+        self.bucket = bucket
+        self.passthrough = passthrough
+        self.hashUsed = hashUsed
+        self.featureId = featureId
+        self.stickyBucketUsed = stickyBucketUsed
     }
-
+    
     init(json: [String: JSON]) {
-        if let inExperiment = json["inExperiment"] {
-            self.inExperiment = inExperiment.boolValue
-        } else {
-            self.inExperiment = false
-        }
-        if let variationId = json["variationId"] {
-            self.variationId = variationId.intValue
-        } else {
-            self.variationId = 0
-        }
-        if let value = json["value"] {
-            self.value = value
-        } else {
-            self.value = JSON()
-        }
-        if let hashAttribute = json["hashAttribute"] {
-            self.hashAttribute = hashAttribute.string
-        }
-        if let hashValue = json["hashValue"] {
-            self.hashValue = hashValue.string
-        }
+        inExperiment = json["inExperiment"]?.boolValue
+        variationId = json["variationId"]?.intValue
+        value = json["value"]
+        hashAttribute = json["hashAttribute"]?.stringValue
+        hashValue = json["hashValue"]?.stringValue
+        key = json["key"]?.stringValue
+        name = json["name"]?.stringValue
+        bucket = json["bucket"]?.floatValue
+        passthrough = json["passthrough"]?.boolValue
+        hashUsed = json["hashUsed"]?.boolValue
+        featureId = json["featureId"]?.stringValue
+        stickyBucketUsed = json["stickyBucketUsed"]?.boolValue
     }
 }
 

--- a/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
@@ -41,11 +41,15 @@ class ExperimentEvaluator {
         var stickyBucketVersionIsBlocked = false
         
         if context.stickyBucketService != nil, !(experiment.disableStickyBucketing ?? true) {
-            let (variation, versionIsBlocked) = Utils.getStickyBucketVariation(context: context, 
-                                                                         experimentKey: experiment.key,
-                                                                         experimentBucketVersion: experiment.bucketVersion ?? 0,
-                                                                         minExperimentBucketVersion: experiment.minBucketVersion ?? 0,
-                                                                         meta: experiment.meta ?? [])
+            let (variation, versionIsBlocked) = Utils.getStickyBucketVariation(context: context,
+                                                                               experimentKey: experiment.key,
+                                                                               experimentBucketVersion: experiment.bucketVersion ?? 0,
+                                                                               minExperimentBucketVersion: experiment.minBucketVersion ?? 0,
+                                                                               meta: experiment.meta ?? [],
+                                                                               expFallBackAttribute: experiment.fallbackAttribute,
+                                                                               expHashAttribute: experiment.hashAttribute,
+                                                                               attributeOverrides: attributeOverrides)
+            
             foundStickyBucket = variation >= 0;
             assigned = variation
             stickyBucketVersionIsBlocked = versionIsBlocked ?? false

--- a/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
@@ -136,7 +136,6 @@ class FeatureEvaluator {
 
                     // Return (value = forced value, source = force)
                     
-                    // TODO: check why do we need return rule.id as well
                     return prepareResult(value: force, source: FeatureSource.force)
                 } else {
                     
@@ -172,9 +171,7 @@ class FeatureEvaluator {
                         return prepareResult(value: result.value, source: FeatureSource.experiment, experiment: exp, result: result)
                     }
                 }
-
             }
-
         }
 
         // Return (value = defaultValue or null, source = defaultValue)
@@ -186,6 +183,10 @@ class FeatureEvaluator {
     private func isIncludedInRollout(seed: String, hashAttribute: String?, fallbackAttribute: String?, range: BucketRange?, coverage: Float?, hashVersion: Float?) -> Bool {
         if range == nil, coverage == nil {
             return true
+        }
+        
+        if range == nil, coverage == 0 {
+            return false
         }
         
         let hashValue = Utils.getHashAttribute(context: context, attr: hashAttribute, fallback: fallbackAttribute, attributeOverrides: attributeOverrides).hashValue

--- a/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
@@ -151,7 +151,7 @@ class FeatureEvaluator {
                                          hashAttribute: rule.hashAttribute,
                                          fallBackAttribute: rule.fallbackAttribute,
                                          hashVersion: rule.hashVersion,
-                                         disableStickyBucketing: rule.disableStickyBucketing,
+                                         disableStickyBucketing: rule.disableStickyBucketing ?? false,
                                          bucketVersion: rule.bucketVersion,
                                          minBucketVersion: rule.minBucketVersion,
                                          weights: rule.weights,

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -85,6 +85,7 @@ class FeaturesViewModel {
     /// Cache API Response and push success event
     func prepareFeaturesData(data: Data) {
         // Call Success Delegate with mention of data available with remote
+        
         let decoder = JSONDecoder()
         if let jsonPetitions = try? decoder.decode(FeaturesDataModel.self, from: data) {
             delegate?.featuresAPIModelSuccessfully(model: jsonPetitions)

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -65,7 +65,7 @@ public struct GrowthBookModel {
         return self
     }
     
-    public func setStickyBucketService(stickyBucketService: StickyBucketServiceProtocol? = nil) -> GrowthBookBuilder {
+    public func setStickyBucketService(stickyBucketService: StickyBucketServiceProtocol? = StickyBucketService()) -> GrowthBookBuilder {
         growthBookBuilderModel.stickyBucketService = stickyBucketService
         return self
     }

--- a/Sources/CommonMain/Model/Feature.swift
+++ b/Sources/CommonMain/Model/Feature.swift
@@ -23,7 +23,7 @@ import Foundation
 
 /// Rule object consists of various definitions to apply to calculate feature value
 public struct FeatureRule: Codable {
-    
+    /// Unique feature rule id
     public let id: String?
     /// Optional targeting condition
     public let condition: JSON?
@@ -117,7 +117,7 @@ public struct FeatureRule: Codable {
         self.tracks = tracks
     }
     
-    init(json: [String: JSON]) {
+    init(json: [String: JSON]) {        
         id = json["id"]?.stringValue
         
         condition = json["condition"]

--- a/Sources/CommonMain/Model/RemoteEvalModel.swift
+++ b/Sources/CommonMain/Model/RemoteEvalModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RemoteEvalParams: Decodable {
+public struct RemoteEvalParams: Decodable {
     let attributes: JSON?
     let forcedFeatures: JSON?
     let forcedVariations: JSON?

--- a/Sources/CommonMain/Model/StickyAssignmentsDocument.swift
+++ b/Sources/CommonMain/Model/StickyAssignmentsDocument.swift
@@ -1,7 +1,25 @@
 import Foundation
 
-public struct StickyAssignmentsDocument: Codable {
+public struct StickyAssignmentsDocument: Codable, Equatable {
     var attributeName: String
     var attributeValue: String
     var assignments: [String: String]
+    
+    init(attributeName: String, attributeValue: String, assignments: [String : String]) {
+        self.attributeName = attributeName
+        self.attributeValue = attributeValue
+        self.assignments = assignments
+    }
+    
+    init(attributeName: String, attributeValue: String, assignments: [String : JSON]) {
+        self.attributeName = attributeName
+        self.attributeValue = attributeValue
+        
+        var assignmentsDict: [String: String] = [:]
+        assignments.forEach { (key, value) in
+            assignmentsDict[key] = value.stringValue
+        }
+        
+        self.assignments = assignmentsDict
+    }
 }

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -133,7 +133,15 @@ public class Utils {
             parts = String(parts.prefix(upTo: range))
         }
         
-        var partArray = parts.components(separatedBy: [".", "-"])
+        let stringArray = parts.components(separatedBy: [".", "-"])
+        
+        var partArray: [String] = []
+        
+        for part in stringArray {
+            if part != "" {
+                partArray.append(part)
+            }
+        }
         
         if partArray.count == 3 {
             partArray.append("~")

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -168,7 +168,7 @@ public class Utils {
         }
         
         // if no match, try fallback
-        if hashValue.isEmpty, let fallback = fallback {
+        if let fallback = fallback {
             if attributeOverrides[fallback] != .null {
                 hashValue = attributeOverrides[fallback].stringValue
             } else if context.attributes[fallback] != .null {
@@ -180,16 +180,54 @@ public class Utils {
             }
         }
         
+        if let fallback = fallback, let fallbackAttributeValue = context.stickyBucketAssignmentDocs?["\(fallback)||\(attributeOverrides[fallback].stringValue)"]?.attributeValue,
+           fallbackAttributeValue != attributeOverrides[fallback].stringValue {
+            context.stickyBucketAssignmentDocs = [:]
+        }
+        
         return (hashAttribute, hashValue)
     }
     
     // Returns assignments for StickyAssignmentsDocuments
-    static func getStickyBucketAssignments(context: Context) -> [String: String] {
+    static func getStickyBucketAssignments(
+        context: Context,
+        expHashAttribute: String?,
+        expFallbackAttribute: String? = nil,
+        attributeOverrides: JSON
+    ) -> [String: String] {
+        
+        guard let stickyBucketAssignmentDocs = context.stickyBucketAssignmentDocs else {
+            return [:]
+        }
+        
+         let (hashAttribute, hashValue) = getHashAttribute(
+            context: context,
+            attr: expHashAttribute,
+            fallback: nil,
+            attributeOverrides: attributeOverrides
+        )
+        
+        let hashKey = "\(hashAttribute)||\(hashValue)"
+        
+        let (fallbackAttribute, fallbackValue) = getHashAttribute(
+            context: context,
+            attr: nil,
+            fallback: expFallbackAttribute,
+            attributeOverrides: attributeOverrides
+        )
+        
+        let fallbackKey = fallbackValue.isEmpty ? nil : "\(fallbackAttribute)||\(fallbackValue)"
+        
         var mergedAssignments: [String: String] = [:]
         
-        context.stickyBucketAssignmentDocs?.values.forEach({ doc in
-            mergedAssignments.merge(doc.assignments)
-        })
+        if let fallbackKey = fallbackKey, let fallbackAssignments = stickyBucketAssignmentDocs[fallbackKey] {
+            mergedAssignments.merge(fallbackAssignments.assignments) { (_, new) in new }
+        }
+        
+        if let hashAssignments = stickyBucketAssignmentDocs[hashKey] {
+            mergedAssignments.merge(hashAssignments.assignments) { (_, new) in new }
+        }
+        
         return mergedAssignments
     }
     
@@ -242,17 +280,25 @@ public class Utils {
     }
     
     // Get variation of sticky bucketing to use specific functionality
-    static func getStickyBucketVariation(context: Context,
+    static func getStickyBucketVariation(
+        context: Context,
         experimentKey: String,
         experimentBucketVersion: Int = 0,
         minExperimentBucketVersion: Int = 0,
-        meta: [VariationMeta] = []
+        meta: [VariationMeta] = [],
+        expFallBackAttribute: String? = nil,
+        expHashAttribute: String? = "id",
+        attributeOverrides: JSON
     ) -> (variation: Int, versionIsBlocked: Bool?) {
         
         let id = getStickyBucketExperimentKey(experimentKey, experimentBucketVersion)
-        let assignments = getStickyBucketAssignments(context: context)
+        let assignments = getStickyBucketAssignments(
+            context: context,
+            expHashAttribute: expHashAttribute,
+            expFallbackAttribute: expFallBackAttribute,
+            attributeOverrides: attributeOverrides
+        )
         
-        // users with any blocked bucket version (0 to minExperimentBucketVersion) are excluded from the test
         if minExperimentBucketVersion > 0 {
             for version in 0...minExperimentBucketVersion {
                 let blockedKey = getStickyBucketExperimentKey(experimentKey, version)


### PR DESCRIPTION
- Updating sticket bucketing functionality
- Remove versionCompare test cases (these are now just included as part of evalCondition)
- Tweak to isIncludedInRollout to handle an edge case when coverage is zero. Also added test case for this.