### PR TITLE
Fix GET requests: errorResult not executed

### DIFF
--- a/Sources/CommonMain/Network/NetworkClient.swift
+++ b/Sources/CommonMain/Network/NetworkClient.swift
@@ -13,11 +13,11 @@ class CoreNetworkClient: NetworkProtocol {
         guard let url = URL(string: url) else { return }
 
         let request = URLSession.shared.dataTask(with: url) {(data: Data?, response: URLResponse?, error: Error?) in
-            guard let data = data else { return }
             if let error = error {
                 errorResult(error)
             }
-            successResult(data)
+            guard let responseData = data else { return }
+            successResult(responseData)
         }
         request.resume()
     }


### PR DESCRIPTION
In our app `refreshHandler` is never called with `false`, probably because network requests don't return error's.

Also, I've got a question, why `refreshHandler` is called only with Bool, and not `SDKError?` for example? It would be useful to know why `featuresFetchFailed` has failed. I swear I've seen a PR fixing this, but wasn't able to find it now, I can make one, are you interested in that?