### PR TITLE
chore: sticky cache file naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ xcuserdata
 
 # macOS
 .DS_Store
+
+# Swift Package
+/.swiftpm

--- a/GrowthBookTests/Caching/DataStorageBoxTests.swift
+++ b/GrowthBookTests/Caching/DataStorageBoxTests.swift
@@ -1,0 +1,96 @@
+//
+//  DataStorageBoxTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/23/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+class DataStorageInterfaceMock<Value: Decodable>: StorageInterfaceMock<Value>, DataStorageInterface {
+    var underlyingData: Data?
+
+    init(_ underlyingData: Data? = nil, value underlyingValue: Value? = nil) {
+        self.underlyingData = underlyingData
+        super.init(underlyingValue)
+    }
+
+    var didCallSetRawData: Bool = false
+    var setRawDataCalls: [Data?] = []
+    func setRawData(_ data: Data?) throws {
+        didCallSetRawData = true
+        setRawDataCalls.append(data)
+        underlyingData = data
+        underlyingValue = data.flatMap { try? JSONDecoder().decode(Value.self, from: $0) }
+    }
+
+    var didCallGetRawData: Bool = false
+    func getRawData() throws -> Data? {
+        didCallGetRawData = true
+        return underlyingData
+    }
+}
+
+class DataStorageBoxTests: XCTestCase {
+    func testUpdateValue() throws {
+        let storageMock: DataStorageInterfaceMock<Int> = .init()
+        let newValue: Int = 42
+
+        let sut = DataStorageBox(storageMock)
+
+        try sut.updateValue(newValue)
+
+        XCTAssertEqual(storageMock.underlyingValue, newValue)
+        XCTAssertTrue(storageMock.didCallUpdateValue)
+        XCTAssertEqual(storageMock.updateValueCalls, [42])
+    }
+
+    func testGetValue() throws {
+        let value: Int = 42
+        let storageMock: DataStorageInterfaceMock<Int> = .init(value: value)
+
+        let sut = DataStorageBox(storageMock)
+
+        try XCTAssertEqual(sut.value(), value)
+        XCTAssertTrue(storageMock.didCallValue)
+    }
+
+    func testReset() throws {
+        let value: Int = 42
+        let storageMock: DataStorageInterfaceMock<Int> = .init(value: value)
+
+        let sut = DataStorageBox(storageMock)
+        XCTAssertNotNil(storageMock.underlyingValue)
+
+        try sut.reset()
+
+        XCTAssertNil(storageMock.underlyingValue)
+        XCTAssertTrue(storageMock.didCallReset)
+    }
+
+    func testSetData() throws {
+        let storageMock: DataStorageInterfaceMock<Int> = .init()
+        let newData: Data = Data([42])
+
+        let sut = DataStorageBox(storageMock)
+
+        try sut.setRawData(newData)
+
+        XCTAssertEqual(storageMock.underlyingData, newData)
+        XCTAssertTrue(storageMock.didCallSetRawData)
+        XCTAssertEqual(storageMock.setRawDataCalls, [newData])
+    }
+
+    func testGetData() throws {
+        let data: Data = Data([42])
+        let storageMock: DataStorageInterfaceMock<Int> = .init(data)
+
+        let sut = DataStorageBox(storageMock)
+
+        try XCTAssertEqual(sut.getRawData(), data)
+        XCTAssertTrue(storageMock.didCallGetRawData)
+    }
+}

--- a/GrowthBookTests/Caching/FeaturesCacheTests.swift
+++ b/GrowthBookTests/Caching/FeaturesCacheTests.swift
@@ -1,0 +1,84 @@
+//
+//  FeaturesCacheTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/24/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+
+class FeaturesCacheTests: XCTestCase {
+    func testGetFeatures() throws {
+        let storage = DataStorageInterfaceMock<Features>()
+        let featureKey: String = "key"
+        let featureRawValue: Bool = true
+        let featureJSON: JSON = .init(featureRawValue)
+        let feature: Feature = .init(json: ["defaultValue": featureJSON])
+        let features: Features = [featureKey: feature]
+        storage.underlyingValue = .init(features)
+
+        let sut = FeaturesCache(storage: storage)
+
+        XCTAssertEqual(try sut.features(), features)
+        XCTAssertTrue(storage.didCallValue)
+    }
+
+    func testSetFeatures() throws {
+        let storage = DataStorageInterfaceMock<Features>()
+
+        let featureKey: String = "key"
+        let featureRawValue: Bool = true
+        let featureJSON: JSON = .init(featureRawValue)
+        let feature: Feature = .init(json: ["defaultValue": featureJSON])
+        let features: Features = [featureKey: feature]
+
+        let sut = FeaturesCache(storage: storage)
+
+        try sut.updateFeatures(features)
+
+        XCTAssertTrue(storage.didCallUpdateValue)
+        XCTAssertEqual(storage.updateValueCalls, [features])
+        try XCTAssertEqual(sut.features(), features)
+    }
+
+    func testSetEncodedFeaturesRawData() throws {
+        let storage = DataStorageInterfaceMock<Features>()
+
+        let featureKey: String = "key"
+        let featureDefaultRawValue: Bool = true
+        let featureJSON: JSON = .init(featureDefaultRawValue)
+        let feature: Feature = .init(json: ["defaultValue": featureJSON])
+        let features: Features = [featureKey: feature]
+        let encodedFeaturesData = try JSONEncoder().encode(features)
+
+        let sut = FeaturesCache(storage: storage)
+
+        try sut.setEncodedFeaturesRawData(encodedFeaturesData)
+
+        XCTAssertTrue(storage.didCallSetRawData)
+        XCTAssertEqual(storage.setRawDataCalls, [encodedFeaturesData])
+        try XCTAssertEqual(sut.features()?[featureKey]?.defaultValue?.boolValue, featureDefaultRawValue)
+    }
+
+    func testClearCache() throws {
+        let storage = DataStorageInterfaceMock<Features>()
+        let featureKey: String = "key"
+        let featureRawValue: Bool = true
+        let featureJSON: JSON = .init(featureRawValue)
+        let feature: Feature = .init(json: ["defaultValue": featureJSON])
+        let features: Features = [featureKey: feature]
+        storage.underlyingValue = .init(features)
+
+        let sut = FeaturesCache(storage: storage)
+        try XCTAssertNotNil(sut.features())
+
+        try sut.clearCache()
+
+        try XCTAssertNil(sut.features())
+        XCTAssertTrue(storage.didCallReset)
+    }
+}

--- a/GrowthBookTests/Caching/FileStorageTests.swift
+++ b/GrowthBookTests/Caching/FileStorageTests.swift
@@ -1,0 +1,111 @@
+//
+//  FileStorageTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/23/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+fileprivate struct StoredValue: Codable, Equatable {
+    var value: Int
+    init(value: Int = 42) {
+        self.value = value
+    }
+}
+
+class FileStorageTests: XCTestCase {
+    let fileURL: URL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(UUID().uuidString).json")
+
+    override func setUp() {
+        super.setUp()
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    func testUpdateValue() throws {
+        let storedValue: StoredValue = .init()
+
+        let sut = FileStorage<StoredValue>(fileURL: fileURL)
+
+        try XCTAssertNil(sut.value())
+
+        try sut.updateValue(storedValue)
+
+        try XCTAssertEqual(sut.value(), storedValue)
+    }
+
+    func testGetValue() throws {
+        let storedValue: StoredValue = .init()
+        let storedData: Data = try JSONEncoder().encode(storedValue)
+        try storedData.write(to: fileURL)
+
+        let sut = FileStorage<StoredValue>(fileURL: fileURL)
+
+        try XCTAssertEqual(sut.value(), storedValue)
+    }
+
+    func testGetValueMalformedData() throws {
+        let storedData: Data = try JSONEncoder().encode(["storedValue"])
+        try storedData.write(to: fileURL)
+
+        let sut = FileStorage<StoredValue>(fileURL: fileURL)
+
+        try XCTAssertNil(sut.value())
+        XCTAssertNil(try? sut.getRawData())
+    }
+
+    func testReset() throws {
+        let storedValue: StoredValue = .init()
+        let storedData: Data = try JSONEncoder().encode(storedValue)
+        try storedData.write(to: fileURL)
+
+        let sut = FileStorage<StoredValue>(fileURL: fileURL)
+        try XCTAssertNotNil(sut.value())
+        try XCTAssertNotNil(sut.getRawData())
+
+        try sut.reset()
+
+        try XCTAssertNil(sut.value())
+        do {
+            _ = try sut.getRawData()
+            XCTFail("Data must be nil")
+        } catch SDKError.failedToLoadData {
+        } catch {
+            XCTFail("Expected SDKError.failedToLoadData, got \(error)")
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    func testSetData() throws {
+        let storedValue: StoredValue = .init()
+        let storedData: Data = try JSONEncoder().encode(storedValue)
+
+        let sut = FileStorage<StoredValue>(fileURL: fileURL)
+        try XCTAssertNil(sut.value())
+        XCTAssertNil(try? sut.getRawData())
+
+        try sut.setRawData(storedData)
+
+        try XCTAssertEqual(sut.getRawData(), storedData)
+        try XCTAssertEqual(sut.value(), storedValue)
+    }
+
+    func testGetData() throws {
+        let storedValue: StoredValue = .init()
+        let storedData: Data = try JSONEncoder().encode(storedValue)
+        try storedData.write(to: fileURL)
+
+        let sut = FileStorage<StoredValue>(fileURL: fileURL)
+
+        try XCTAssertEqual(sut.getRawData(), storedData)
+    }
+}

--- a/GrowthBookTests/Caching/GrowthBookSDKCachingManagerTests.swift
+++ b/GrowthBookTests/Caching/GrowthBookSDKCachingManagerTests.swift
@@ -1,0 +1,59 @@
+//
+//  GrowthBookSDKCachingManagerTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/24/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+class GrowthBookSDKCachingManagerTests: XCTestCase {
+    let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory().appending("/test"))
+
+    override func setUp() {
+        super.setUp()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+
+    func testClearCache() throws {
+        let featuresCache: FeaturesCacheInterfaceMock = .init()
+        let savedGroupsCache: SavedGroupsCacheInterfaceMock = .init()
+
+        let sut = GrowthBookSDKCachingManager(featuresCache: featuresCache, savedGroupsCache: savedGroupsCache)
+
+        try sut.clearCache()
+
+        XCTAssertTrue(featuresCache.didCallClearCache)
+        XCTAssertTrue(savedGroupsCache.didCallClearCache)
+    }
+
+    func testFileStorage() throws {
+        let featuresCacheFilename = "features"
+        let savedGroupsCacheFilename = "savedGroups"
+        let fileManager: FileManager = .default
+
+        let sut = GrowthBookSDKCachingManager.withFileStorage(directoryURL: directoryURL, featuresCacheFilename: featuresCacheFilename, savedGroupsCacheFilename: savedGroupsCacheFilename, fileManager: fileManager)
+
+        XCTAssertFalse(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(featuresCacheFilename, isDirectory: false).path))
+        XCTAssertFalse(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(savedGroupsCacheFilename, isDirectory: false).path))
+
+        try sut.featuresCache.updateFeatures([:])
+        XCTAssertTrue(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(featuresCacheFilename, isDirectory: false).path))
+
+        try sut.savedGroupsCache.updateSavedGroups(JSON(true))
+        XCTAssertTrue(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(savedGroupsCacheFilename, isDirectory: false).path))
+
+        try sut.clearCache()
+
+        XCTAssertFalse(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(featuresCacheFilename, isDirectory: false).path))
+        XCTAssertFalse(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(savedGroupsCacheFilename, isDirectory: false).path))
+    }
+}

--- a/GrowthBookTests/Caching/Keyed/KeyedStorageCacheTests.swift
+++ b/GrowthBookTests/Caching/Keyed/KeyedStorageCacheTests.swift
@@ -1,0 +1,157 @@
+//
+//  KeyedStorageCacheTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/23/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+class KeyedStorageInterfaceMock<Value>: KeyedStorageInterface {
+    var storage: [String: Value] = [:]
+    init(storage: [String : Value] = [:]) {
+        self.storage = storage
+    }
+
+    var didCallValue: Bool = false
+    var valueCalls: [String] = []
+    func value(for key: String) throws -> Value? {
+        didCallValue = true
+        valueCalls.append(key)
+        return storage[key]
+    }
+
+    var didCallUpdateValue: Bool = false
+    var updateValueCalls: [(Value?, String)] = []
+    func updateValue(_ value: Value?, for key: String) throws {
+        didCallUpdateValue = true
+        updateValueCalls.append((value, key))
+        storage[key] = value
+    }
+
+    var didCallReset: Bool = false
+    func reset() throws {
+        didCallReset = true
+        storage.removeAll()
+    }
+}
+
+class KeyedStorageCacheTests: XCTestCase {
+
+    func testUpdateValueSet() throws {
+        let newValue: Int = 42
+        let key1: String = "key1"
+        let storage1: StorageInterfaceMock<Int> = .init()
+
+        let sut: KeyedStorageCache<Int> = KeyedStorageCache { key in
+            switch key {
+            case key1:
+                return StorageBox(storage1)
+            default:
+                XCTFail("Should never happen")
+                return StorageBox(StorageInterfaceMock())
+            }
+        }
+
+        try sut.updateValue(newValue, for: key1)
+
+        XCTAssertTrue(storage1.didCallUpdateValue)
+        XCTAssertEqual(storage1.updateValueCalls, [newValue])
+        try XCTAssertEqual(sut.value(for: key1), newValue)
+    }
+
+    func testUpdateValueUpdate() throws {
+        let newValue: Int = 42
+        let key1: String = "key1"
+        let storage1: StorageInterfaceMock<Int> = .init(newValue + 1)
+
+        let sut: KeyedStorageCache<Int> = KeyedStorageCache { key in
+            switch key {
+            case key1:
+                return StorageBox(storage1)
+            default:
+                XCTFail("Should never happen")
+                return StorageBox(StorageInterfaceMock())
+            }
+        }
+
+        try sut.updateValue(newValue, for: key1)
+
+        XCTAssertTrue(storage1.didCallUpdateValue)
+        XCTAssertEqual(storage1.updateValueCalls, [newValue])
+        try XCTAssertEqual(sut.value(for: key1), newValue)
+    }
+
+    func testGetValueExists() throws {
+        let newValue: Int = 42
+        let key1: String = "key1"
+        let storage1: StorageInterfaceMock<Int> = .init(newValue)
+
+        let sut: KeyedStorageCache<Int> = KeyedStorageCache { key in
+            switch key {
+            case key1:
+                return StorageBox(storage1)
+            default:
+                XCTFail("Should never happen")
+                return StorageBox(StorageInterfaceMock())
+            }
+        }
+
+        let fetchedValue = try sut.value(for: key1)
+
+        XCTAssertTrue(storage1.didCallValue)
+        XCTAssertEqual(fetchedValue, newValue)
+    }
+
+    func testGetValueEmpty() throws {
+        let key1: String = "key1"
+        let storage1: StorageInterfaceMock<Int> = .init()
+
+        let sut: KeyedStorageCache<Int> = KeyedStorageCache { key in
+            switch key {
+            case key1:
+                return StorageBox(storage1)
+            default:
+                XCTFail("Should never happen")
+                return StorageBox(StorageInterfaceMock())
+            }
+        }
+
+        let fetchedValue = try sut.value(for: key1)
+
+        XCTAssertTrue(storage1.didCallValue)
+        XCTAssertNil(fetchedValue)
+    }
+
+    func testReset() throws {
+        let key1: String = "key1"
+        let key2: String = "key2"
+        let storage1: StorageInterfaceMock<Int> = .init()
+        let storage2: StorageInterfaceMock<Int> = .init()
+
+        let sut: KeyedStorageCache<Int> = KeyedStorageCache { key in
+            switch key {
+            case key1:
+                return StorageBox(storage1)
+            case key2:
+                return StorageBox(storage2)
+            default:
+                XCTFail("Should never happen")
+                return StorageBox(StorageInterfaceMock())
+            }
+        }
+
+        // Register storages.
+        _ = try sut.updateValue(42, for: key1)
+        _ = try sut.updateValue(42, for: key2)
+
+        try sut.reset()
+
+        // Calls reset for all known keys.
+        XCTAssertTrue(storage1.didCallReset)
+        XCTAssertTrue(storage2.didCallReset)
+    }
+}

--- a/GrowthBookTests/Caching/SavedGroupsCacheTests.swift
+++ b/GrowthBookTests/Caching/SavedGroupsCacheTests.swift
@@ -1,0 +1,55 @@
+//
+//  SavedGroupsCacheTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/24/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+class SavedGroupsCacheTests: XCTestCase {
+    func testGetSavedGroups() throws {
+        let storage = DataStorageInterfaceMock<JSON>()
+        let jsonRawValue: Bool = true
+        let savedGroups: JSON = .init(jsonRawValue)
+        storage.underlyingValue = .init(savedGroups)
+
+        let sut = SavedGroupsCache(storage: storage)
+
+        try XCTAssertEqual(sut.savedGroups(), savedGroups)
+        XCTAssertTrue(storage.didCallValue)
+    }
+
+    func testSetSavedGroups() throws {
+        let storage = DataStorageInterfaceMock<JSON>()
+
+        let jsonRawValue: Bool = true
+        let savedGroups: JSON = .init(jsonRawValue)
+
+        let sut = SavedGroupsCache(storage: storage)
+
+        try sut.updateSavedGroups(savedGroups)
+
+        XCTAssertTrue(storage.didCallUpdateValue)
+        XCTAssertEqual(storage.updateValueCalls, [savedGroups])
+        try XCTAssertEqual(sut.savedGroups(), savedGroups)
+    }
+
+    func testClearCache() throws {
+        let storage = DataStorageInterfaceMock<JSON>()
+        let jsonRawValue: Bool = true
+        let savedGroups: JSON = .init(jsonRawValue)
+        storage.underlyingValue = .init(savedGroups)
+
+        let sut = SavedGroupsCache(storage: storage)
+        try XCTAssertNotNil(sut.savedGroups())
+
+        try sut.clearCache()
+
+        try XCTAssertNil(sut.savedGroups())
+        XCTAssertTrue(storage.didCallReset)
+    }
+}

--- a/GrowthBookTests/Caching/StickyBucketCacheTests.swift
+++ b/GrowthBookTests/Caching/StickyBucketCacheTests.swift
@@ -1,0 +1,92 @@
+//
+//  StickyBucketCacheTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/24/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+class StickyBucketCacheTests: XCTestCase {
+    let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory().appending("/test"))
+
+    override func setUp() {
+        super.setUp()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+
+    func testGetAssignment() throws {
+        let storage = KeyedStorageInterfaceMock<StickyAssignmentsDocument>()
+        let key1: String = "key1"
+        let assignment: StickyAssignmentsDocument = .init(attributeName: "a", attributeValue: "b", assignments: ["c": "d"])
+        storage.storage[key1] = assignment
+
+        let sut = StickyBucketFileStorageCache(
+            directoryURL: directoryURL,
+            storage: storage
+        )
+
+        try XCTAssertEqual(sut.stickyAssignment(for: key1), assignment)
+        XCTAssertTrue(storage.didCallValue)
+    }
+
+    func testSetSavedGroups() throws {
+        let storage = KeyedStorageInterfaceMock<StickyAssignmentsDocument>()
+        let key1: String = "key1"
+        let assignment: StickyAssignmentsDocument = .init(attributeName: "a", attributeValue: "b", assignments: ["c": "d"])
+
+        let sut = StickyBucketFileStorageCache(
+            directoryURL: directoryURL,
+            storage: storage
+        )
+        try XCTAssertNil(sut.stickyAssignment(for: key1))
+
+        try sut.updateStickyAssignment(assignment, for: key1)
+
+        try XCTAssertEqual(sut.stickyAssignment(for: key1), assignment)
+        XCTAssertTrue(storage.didCallUpdateValue)
+        XCTAssertEqual(storage.updateValueCalls.first?.0, assignment)
+        XCTAssertEqual(storage.updateValueCalls.first?.1, key1)
+    }
+
+    func testClearCache() throws {
+        let storage = KeyedStorageInterfaceMock<StickyAssignmentsDocument>()
+        let key1: String = "key1"
+        let assignment: StickyAssignmentsDocument = .init(attributeName: "a", attributeValue: "b", assignments: ["c": "d"])
+        storage.storage[key1] = assignment
+
+        let sut = StickyBucketFileStorageCache(
+            directoryURL: directoryURL,
+            storage: storage
+        )
+
+        try sut.clearCache()
+
+        try XCTAssertNil(sut.stickyAssignment(for: key1))
+        XCTAssertTrue(storage.didCallValue)
+    }
+
+    func testFileCacheStorage() throws {
+        let key1: String = "key1"
+        let assignment: StickyAssignmentsDocument = .init(attributeName: "a", attributeValue: "b", assignments: ["c": "d"])
+        let fileManager: FileManager = .default
+
+        let sut = StickyBucketFileStorageCache.withFileCacheStorage(directoryURL: directoryURL, fileManager: fileManager)
+
+        try sut.updateStickyAssignment(assignment, for: key1)
+        XCTAssertTrue(fileManager.fileExists(atPath: directoryURL.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: directoryURL.appendingPathComponent(key1, isDirectory: false).path))
+
+        try sut.clearCache()
+
+        XCTAssertFalse(fileManager.fileExists(atPath: directoryURL.path))
+    }
+}

--- a/GrowthBookTests/Caching/StorageBoxTests.swift
+++ b/GrowthBookTests/Caching/StorageBoxTests.swift
@@ -1,0 +1,76 @@
+//
+//  StorageBoxTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/23/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+class StorageInterfaceMock<Value>: StorageInterface {
+    var underlyingValue: Value?
+    init(_ underlyingValue: Value? = nil) {
+        self.underlyingValue = underlyingValue
+    }
+
+    var didCallValue: Bool = false
+    func value() throws -> Value? {
+        didCallValue = true
+        return underlyingValue
+    }
+
+    var didCallUpdateValue: Bool = false
+    var updateValueCalls: [Value?] = []
+    func updateValue(_ value: Value?) throws {
+        underlyingValue = value
+        didCallUpdateValue = true
+        updateValueCalls.append(value)
+    }
+
+    var didCallReset: Bool = false
+    func reset() throws {
+        didCallReset = true
+        underlyingValue = .none
+    }
+}
+
+class StorageBoxTests: XCTestCase {
+    func testUpdateValue() throws {
+        let storageMock: StorageInterfaceMock<Int> = .init()
+        let newValue: Int = 42
+
+        let sut = StorageBox(storageMock)
+
+        try sut.updateValue(newValue)
+
+        XCTAssertEqual(storageMock.underlyingValue, newValue)
+        XCTAssertTrue(storageMock.didCallUpdateValue)
+        XCTAssertEqual(storageMock.updateValueCalls, [42])
+    }
+
+    func testGetValue() throws {
+        let value: Int = 42
+        let storageMock: StorageInterfaceMock<Int> = .init(value)
+
+        let sut = StorageBox(storageMock)
+
+        try XCTAssertEqual(sut.value(), value)
+        XCTAssertTrue(storageMock.didCallValue)
+    }
+
+    func testReset() throws {
+        let value: Int = 42
+        let storageMock: StorageInterfaceMock<Int> = .init(value)
+
+        let sut = StorageBox(storageMock)
+        XCTAssertNotNil(storageMock.underlyingValue)
+
+        try sut.reset()
+
+        XCTAssertNil(storageMock.underlyingValue)
+        XCTAssertTrue(storageMock.didCallReset)
+    }
+}

--- a/GrowthBookTests/GrowthBookSDKBuilderTests.swift
+++ b/GrowthBookTests/GrowthBookSDKBuilderTests.swift
@@ -173,7 +173,7 @@ class GrowthBookSDKBuilderTests: XCTestCase {
                                             backgroundSync: false).setRefreshHandler(refreshHandler: { _ in
 
         }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil))
-            .setCacheDirectory(.documents)
+            .setCacheDirectoryURL(CacheDirectory.documents.url)
             .initializer()
         
         let fileName = "gb-features.txt"

--- a/GrowthBookTests/Mocks/StickyBucketCacheInterfaceMock.swift
+++ b/GrowthBookTests/Mocks/StickyBucketCacheInterfaceMock.swift
@@ -1,0 +1,25 @@
+//
+//  StickyBucketCacheInterfaceMock.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 3/5/25.
+//
+
+import Foundation
+@testable import GrowthBook
+
+class StickyBucketCacheInterfaceMock: StickyBucketCacheInterface {
+    var docs: [String: GrowthBook.StickyAssignmentsDocument] = [:]
+
+    func stickyAssignment(for key: String) throws -> GrowthBook.StickyAssignmentsDocument? {
+        docs[key]
+    }
+
+    func updateStickyAssignment(_ value: GrowthBook.StickyAssignmentsDocument?, for key: String) throws {
+        docs[key] = value
+    }
+
+    func clearCache() throws {
+        docs.removeAll()
+    }
+}

--- a/GrowthBookTests/ProtectedTests.swift
+++ b/GrowthBookTests/ProtectedTests.swift
@@ -1,0 +1,43 @@
+//
+//  ProtectedTests.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/24/25.
+//
+
+import Foundation
+import XCTest
+
+@testable import GrowthBook
+
+final class ProtectedTests: XCTestCase {
+    func testSafetyClosures() {
+        // Given
+        let initialValue = "value"
+        let protected = Protected<String>(initialValue)
+
+        // When
+        DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+            _ = protected.read { $0 }
+            protected.write { value in value = "\(i)" }
+        }
+
+        // Then
+        XCTAssertNotEqual(protected.read { $0 }, initialValue)
+    }
+
+    func testSafetyDirect() {
+        // Given
+        let initialValue = "value"
+        let protected = Protected<String>(initialValue)
+
+        // When
+        DispatchQueue.concurrentPerform(iterations: 10_000) { i in
+            _ = protected.read()
+            protected.write("\(i)")
+        }
+
+        // Then
+        XCTAssertNotEqual(protected.read { $0 }, initialValue)
+    }
+}

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -77,7 +77,7 @@ class StickyBucketingFeatureTests: XCTestCase {
         let cacheKeyPrefix: String = "_"
         let attributeName: String = "id"
         let attributeValue: String = "some-id"
-        let hash = "\(attributeName)||\(attributeValue)"
+        let hash = "\(attributeName)||\(attributeValue)".sha256HashString
         let cacheKey: String = "\(cacheKeyPrefix)\(hash)"
 
         let doc: StickyAssignmentsDocument = .init(attributeName: attributeName, attributeValue: attributeValue, assignments: assignments)
@@ -100,7 +100,7 @@ class StickyBucketingFeatureTests: XCTestCase {
         let cacheKeyPrefix: String = "_"
         let attributeName: String = "id"
         let attributeValue: String = "some-id"
-        let hash = "\(attributeName)||\(attributeValue)"
+        let hash = "\(attributeName)||\(attributeValue)".sha256HashString
         let cacheKey: String = "\(cacheKeyPrefix)\(hash)"
 
         let initialService: StickyBucketService = .init(prefix: cacheKeyPrefix, cache: cacheMock)

--- a/GrowthBookTests/TestHelper.swift
+++ b/GrowthBookTests/TestHelper.swift
@@ -146,7 +146,7 @@ struct FeaturesTest: Codable {
                 newDict[key] = value
             }
             
-            self.stickyBucketAssignmentDocs = newDict == [:] ? nil : newDict
+            self.stickyBucketAssignmentDocs = newDict
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ var sdkInstance: GrowthBookSDK = GrowthBookBuilder(apiHost: <GrowthBook/API_KEY>
     }, remoteEval: true)
     .initializer()
 
-:::note
+**note**
 
 If you would like to implement Sticky Bucketing while using Remote Evaluation, you must configure your remote evaluation backend to support Sticky Bucketing. You will not need to provide a StickyBucketService instance to the client side SDK.
 

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -15,13 +15,7 @@ public class CachingManager: CachingLayer {
     public static let shared = CachingManager()
 
     static func keyHash(_ input: String) -> String {
-        guard let data = input.data(using: .utf8) else { return "" }
-        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        data.withUnsafeBytes {
-            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
-        }
-        let key = hash.map { String(format: "%02x", $0) }.joined()
-        return String(key.prefix(5))
+        String(input.sha256HashString.prefix(5))
     }
 
     private var cacheDirectoryURL: URL

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -1,21 +1,36 @@
 import Foundation
+import CommonCrypto
+import CryptoKit
 
 /// Interface for Caching Layer
 public protocol CachingLayer: AnyObject {
     func saveContent(fileName: String, content: Data)
     func getContent(fileName: String) -> Data?
+    func setCacheKey(_ key: String)
 }
 
 /// This is actual implementation of Caching Layer in iOS
 public class CachingManager: CachingLayer {
+    
     public static let shared = CachingManager()
 
+    static func keyHash(_ input: String) -> String {
+        guard let data = input.data(using: .utf8) else { return "" }
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+        let key = hash.map { String(format: "%02x", $0) }.joined()
+        return String(key.prefix(5))
+    }
+
     private var cacheDirectoryURL: URL
+    private var cacheKey: String = ""
 
     init(cacheDirectoryURL: URL = CacheDirectory.applicationSupport.url) {
         self.cacheDirectoryURL = cacheDirectoryURL
     }
-
+    
     func getData(fileName: String) -> Data? {
         return getContent(fileName: fileName)
     }
@@ -25,11 +40,15 @@ public class CachingManager: CachingLayer {
     }
 
     func updateCacheDirectory(_ directory: CacheDirectory) {
-        cacheDirectoryURL = directory.url
+        updateCacheDirectoryURL(directory.url)
     }
 
     func updateCacheDirectoryURL(_ directoryURL: URL) {
         cacheDirectoryURL = directoryURL
+    }
+
+    public func setCacheKey(_ key: String) {
+        self.cacheKey = Self.keyHash(key)
     }
 
     /// Save content in cache
@@ -45,7 +64,7 @@ public class CachingManager: CachingLayer {
             do {
                 try fileManager.removeItem(at: fileURL)
             } catch {
-                logger.error("Failed remove error:  \(error.localizedDescription)")
+                logger.error("Failed remove error: \(error.localizedDescription)")
             }
         }
 
@@ -76,7 +95,7 @@ public class CachingManager: CachingLayer {
         // Get Documents Directory Path
         let directoryPath = cacheDirectoryURL.path
         // Append Folder name
-        let targetFolderPath = directoryPath + "/GrowthBook-Cache"
+        let targetFolderPath = directoryPath + "/GrowthBook-Cache-\(cacheKey)"
 
         let fileManager = FileManager.default
         // Check if folder exists
@@ -101,7 +120,7 @@ public class CachingManager: CachingLayer {
     public func clearCache() {
         let directoryPath = cacheDirectoryURL.path
 
-        let targetFolderPath = directoryPath + "/GrowthBook-Cache"
+        let targetFolderPath = directoryPath + "/GrowthBook-Cache-\(cacheKey)"
         let fileManager = FileManager.default
 
         // Check if folder exists
@@ -118,14 +137,16 @@ public class CachingManager: CachingLayer {
 }
 
 /// This enumeration provides a convenient way to interact with various cache directories, simplifying the process of accessing and managing them using the FileManager API.
-@objc public enum CacheDirectory: Int, Sendable {
+public enum CacheDirectory: Sendable {
     case applicationSupport
     case caches
     case documents
     case library
+    case developerLibrary
+    case customPath(String)
 
-    /// Converts the enumeration case into the corresponding `FileManager.SearchPathDirectory` value.
-    var searchPathDirectory: FileManager.SearchPathDirectory {
+    /// Converts the enumeration case into the corresponding `FileManager.SearchPathDirectory` value, if applicable.
+    var searchPathDirectory: FileManager.SearchPathDirectory? {
         switch self {
         case .applicationSupport:
             return .applicationSupportDirectory
@@ -135,16 +156,25 @@ public class CachingManager: CachingLayer {
             return .documentDirectory
         case .library:
             return .libraryDirectory
+        case .developerLibrary:
+            return .developerDirectory
+        case .customPath(_):
+            return nil
         }
     }
 
     /// Retrieves the path to the cache directory represented by the enumeration case.
     var path: String? {
-        return NSSearchPathForDirectoriesInDomains(
-            searchPathDirectory,
-            .userDomainMask,
-            true
-        ).first
+        switch self {
+        case .applicationSupport, .caches, .documents, .library, .developerLibrary:
+            return NSSearchPathForDirectoriesInDomains(
+                searchPathDirectory ?? .cachesDirectory,
+                .userDomainMask,
+                true
+            ).first
+        case .customPath(let customPath):
+            return customPath
+        }
     }
 
     var url: URL {

--- a/Sources/CommonMain/Caching/FeaturesCache.swift
+++ b/Sources/CommonMain/Caching/FeaturesCache.swift
@@ -1,0 +1,47 @@
+//
+//  FeaturesCache.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+
+/// `Features` cache interface.
+protocol FeaturesCacheInterface: AnyObject {
+    /// Returns cached `Features`.
+    func features() throws -> Features?
+    /// Updates stored `Features`.
+    /// - Parameter value: A new `Features` to cache.
+    func updateFeatures(_ value: Features?) throws
+    /// Updates stored `Features` with a given encoded `Data`.
+    /// - Parameter data: An encoded `Features` `Data`.
+    func setEncodedFeaturesRawData(_ data: Data) throws
+    /// Clear the stored cache.
+    func clearCache() throws
+}
+
+/// Default implementation of the `FeaturesCacheInterface`.
+final class FeaturesCache: FeaturesCacheInterface {
+    private let storage: DataStorageBox<Features>
+
+    init<Storage: DataStorageInterface>(storage: Storage) where Storage.Value == Features {
+        self.storage = .init(storage)
+    }
+
+    func features() throws -> Features? {
+        try storage.value()
+    }
+
+    func updateFeatures(_ value: Features?) throws {
+        try storage.updateValue(value)
+    }
+
+    func setEncodedFeaturesRawData(_ data: Data) throws {
+        try storage.setRawData(data)
+    }
+
+    func clearCache() throws {
+        try storage.reset()
+    }
+}

--- a/Sources/CommonMain/Caching/GrowthBookSDKCachingManager.swift
+++ b/Sources/CommonMain/Caching/GrowthBookSDKCachingManager.swift
@@ -1,0 +1,52 @@
+//
+//  GrowthBookCachingManagerInterface.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/20/25.
+//
+
+import Foundation
+import Combine
+
+protocol GrowthBookSDKCachingManagerInterface {
+    /// `Features` cache.
+    var featuresCache: FeaturesCacheInterface { get }
+    /// Saved groups cache.
+    var savedGroupsCache: SavedGroupsCacheInterface { get }
+    // Clears features and saved groups caches.
+    func clearCache() throws
+}
+
+/// Default implementation of the `GrowthBookSDKCachingManagerInterface`.
+class GrowthBookSDKCachingManager: GrowthBookSDKCachingManagerInterface {
+    let featuresCache: FeaturesCacheInterface
+    let savedGroupsCache: SavedGroupsCacheInterface
+
+    init(featuresCache: FeaturesCacheInterface, savedGroupsCache: SavedGroupsCacheInterface) {
+        self.featuresCache = featuresCache
+        self.savedGroupsCache = savedGroupsCache
+    }
+
+    func clearCache() throws {
+        try featuresCache.clearCache()
+        try savedGroupsCache.clearCache()
+    }
+}
+
+extension GrowthBookSDKCachingManager {
+    static func withFileStorage(
+        directoryURL: URL,
+        featuresCacheFilename: String,
+        savedGroupsCacheFilename: String,
+        fileManager: FileManager
+    ) -> GrowthBookSDKCachingManager {
+        .init(
+            featuresCache: FeaturesCache(
+                storage: FileStorage(fileURL: directoryURL.appendingPathComponent(featuresCacheFilename, isDirectory: false), fileManager: fileManager)
+            ),
+            savedGroupsCache: SavedGroupsCache(
+                storage: FileStorage(fileURL: directoryURL.appendingPathComponent(savedGroupsCacheFilename, isDirectory: false), fileManager: fileManager)
+            )
+        )
+    }
+}

--- a/Sources/CommonMain/Caching/SavedGroupsCache.swift
+++ b/Sources/CommonMain/Caching/SavedGroupsCache.swift
@@ -1,0 +1,40 @@
+//
+//  SavedGroupsCache.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+
+/// Saved groups cache interface.
+protocol SavedGroupsCacheInterface: AnyObject {
+    /// Returns cached saved groups.
+    func savedGroups() throws -> JSON?
+    /// Updates cached groups with a given `value`.
+    /// - Parameter value: A new groups to cache.
+    func updateSavedGroups(_ value: JSON?) throws
+    /// Clears the saved groups cache.
+    func clearCache() throws
+}
+
+/// Default implementation of the `SavedGroupsCacheInterface`.
+final class SavedGroupsCache: SavedGroupsCacheInterface {
+    private let storage: StorageBox<JSON>
+
+    init<Storage: StorageInterface>(storage: Storage) where Storage.Value == JSON {
+        self.storage = .init(storage)
+    }
+
+    func savedGroups() throws -> JSON? {
+        try storage.value()
+    }
+
+    func updateSavedGroups(_ value: JSON?) throws {
+        try storage.updateValue(value)
+    }
+
+    func clearCache() throws {
+        try storage.reset()
+    }
+}

--- a/Sources/CommonMain/Caching/StickyBucketCache.swift
+++ b/Sources/CommonMain/Caching/StickyBucketCache.swift
@@ -1,0 +1,123 @@
+//
+//  StickyBucketCache.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+import Combine
+
+/// Sticky bucket cache interface.
+public protocol StickyBucketCacheInterface {
+    /// Returns stored `StickyAssignmentsDocument` for a given key.
+    /// - Parameter key: A key to return value for.
+    func stickyAssignment(for key: String) throws -> StickyAssignmentsDocument?
+
+    /// Stores a new `StickyAssignmentsDocument` for a given key.
+    /// - Parameters:
+    ///   - value: A new value to store.
+    ///   - key: A key to sat value for.
+    func updateStickyAssignment(_ value: StickyAssignmentsDocument?, for key: String) throws
+
+    /// Clears the sticky bucket cache.
+    func clearCache() throws
+}
+
+/// `StickyBucketCacheInterface` with a file storage.
+public protocol StickyBucketFileStorageCacheInterface: StickyBucketCacheInterface {
+    func updateCacheDirectoryURL(_ directoryURL: URL)
+}
+
+/// Default implementation of the `StickyBucketFileStorageCacheInterface`.
+final public class StickyBucketFileStorageCache {
+    struct MutableState {
+        var directoryURL: URL
+        var storage: KeyedStorageBox<StickyAssignmentsDocument>
+    }
+
+    private let mutableState: Protected<MutableState>
+    private let fileManager: FileManager
+
+    private init(
+        directoryURL: URL,
+        storageBox: KeyedStorageBox<StickyAssignmentsDocument>,
+        fileManager: FileManager = .default
+    ) {
+        self.mutableState = .init(.init(directoryURL: directoryURL, storage: storageBox))
+        self.fileManager = fileManager
+    }
+    
+    /// Creates a new `StickyBucketFileStorageCache` with a given params.
+    ///
+    /// - Parameters:
+    ///   - directoryURL: A directory `URL` where to store cache.
+    ///   - storage: A keyed storage interface.
+    ///   - fileManager: A file manager for the underlying `FileStorage`.
+    ///
+    ///   - Note: Used for testing.
+    convenience init<Storage: KeyedStorageInterface>(
+        directoryURL: URL,
+        storage: Storage,
+        fileManager: FileManager = .default
+    ) where Storage.Value == StickyAssignmentsDocument {
+        self.init(directoryURL: directoryURL, storageBox: .init(storage), fileManager: fileManager)
+    }
+
+    private convenience init<Storage: StorageInterface>(
+        directoryURL: URL,
+        storageBuilder: @escaping (_ directoryURL: URL, _ key: String) -> Storage,
+        fileManager: FileManager = .default
+    ) where Storage.Value == StickyAssignmentsDocument {
+        self.init(
+            directoryURL: directoryURL,
+            storage: KeyedStorageCache { storageBuilder(directoryURL, $0) },
+            fileManager: fileManager
+        )
+    }
+
+    public static func withFileCacheStorage(
+        directoryURL: URL,
+        fileManager: FileManager = .default
+    ) -> StickyBucketFileStorageCache {
+        .init(
+            directoryURL: directoryURL,
+            storageBuilder: Self.fileStorageBuilder(fileManager: fileManager),
+            fileManager: fileManager
+        )
+    }
+
+    private static func fileStorageBuilder(fileManager: FileManager) -> (_ directoryURL: URL, _ key: String) -> FileStorage<StickyAssignmentsDocument> {
+        {
+            FileStorage(fileURL: $0.appendingPathComponent($1, isDirectory: false), fileManager: fileManager)
+        }
+    }
+}
+
+extension StickyBucketFileStorageCache: StickyBucketCacheInterface {
+    public func stickyAssignment(for key: String) throws -> StickyAssignmentsDocument? {
+        try mutableState.read { try $0.storage.value(for: key) }
+    }
+    
+    public func updateStickyAssignment(_ value: StickyAssignmentsDocument?, for key: String) throws {
+        try mutableState.read { try $0.storage.updateValue(value, for: key) }
+    }
+
+    public func clearCache() throws {
+        try mutableState.read {
+            try $0.storage.reset()
+            if fileManager.fileExists(atPath: $0.directoryURL.path) {
+                try fileManager.removeItem(at: $0.directoryURL)
+            }
+        }
+    }
+}
+
+extension StickyBucketFileStorageCache: StickyBucketFileStorageCacheInterface {
+    public func updateCacheDirectoryURL(_ directoryURL: URL) {
+        mutableState.write {
+            $0.directoryURL = directoryURL
+            $0.storage = KeyedStorageBox<StickyAssignmentsDocument>(KeyedStorageCache { Self.fileStorageBuilder(fileManager: self.fileManager)(directoryURL, $0) })
+        }
+    }
+}

--- a/Sources/CommonMain/Caching/Storage/DataStorage.swift
+++ b/Sources/CommonMain/Caching/Storage/DataStorage.swift
@@ -1,0 +1,37 @@
+//
+//  DataStorage.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+
+/// Interface for storing values that can be represented as `Data`.
+protocol DataStorageInterface: StorageInterface {
+    /// Stores a new encoded value.
+    /// - Parameter data: A new encoded value.
+    func setRawData(_ data: Data?) throws
+
+    /// Returns an encoded value.
+    func getRawData() throws -> Data?
+}
+
+class DataStorageBox<Value>: StorageBox<Value> {
+    private let storage: any DataStorageInterface
+
+    init<Storage: DataStorageInterface>(_ storage: Storage) where Storage.Value == Value {
+        self.storage = storage
+        super.init(storage)
+    }
+}
+
+extension DataStorageBox: DataStorageInterface {
+    func getRawData() throws -> Data? {
+        try storage.getRawData()
+    }
+
+    func setRawData(_ data: Data?) throws {
+        try storage.setRawData(data)
+    }
+}

--- a/Sources/CommonMain/Caching/Storage/FileStorage.swift
+++ b/Sources/CommonMain/Caching/Storage/FileStorage.swift
@@ -1,0 +1,133 @@
+//
+//  SingleFileStorage.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/20/25.
+//
+
+import Foundation
+
+/// A thread-safe file storage for codable values.
+class FileStorage<Value: Codable> {
+    /// An URL to file where encoded value is stored.
+    private let fileURL: URL
+
+    /// Stored value.
+    ///
+    /// Storing a copy in memory to reduce file read and decoding operations.
+    ///
+    /// The value is not read until first access. This allows to handle load and parse errors on first access.
+    private let storedValue: Protected<Value?>
+
+    /// Encoding closure.
+    private let encode: (Value) throws -> Data
+
+    /// Decoding closure.
+    private let decode: (Data) throws -> Value
+
+    private let fileManager: FileManager
+
+    init<Encoder: TopLevelEncoder, Decoder: TopLevelDecoder>(
+        fileURL: URL,
+        decoder: Decoder = JSONDecoder(),
+        encoder: Encoder = JSONEncoder(),
+        fileManager: FileManager = .default
+    ) where Encoder.Output == Data, Decoder.Input == Data {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        self.encode = { try encoder.encode($0) }
+        self.decode = {
+            do {
+                return try decoder.decode(Value.self, from: $0)
+            } catch {
+                throw SDKError.failedParsedData
+            }
+        }
+
+        if fileManager.fileExists(atPath: fileURL.path) {
+            do {
+                self.storedValue = try .init(decode(Data(contentsOf: fileURL)))
+            } catch {
+                self.storedValue = .init(nil)
+                try? self.reset()
+            }
+        } else {
+            self.storedValue = .init(nil)
+        }
+    }
+
+    private func readDataFromFile() throws -> Data? {
+        try? fileManager.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        do {
+            return try Data(contentsOf: fileURL)
+        } catch {
+            throw SDKError.failedToLoadData
+        }
+    }
+
+    private func writeDataToFile(_ data: Data?) throws {
+        try? fileManager.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data?.write(to: fileURL, options: .atomic)
+    }
+}
+
+extension FileStorage: StorageInterface {
+    func value() throws -> Value? {
+        return storedValue.read()
+    }
+
+    func updateValue(_ value: Value?) throws {
+        try storedValue.write { storedValue in
+            storedValue = value
+            let data: Data = try value.map(encode) ?? Data()
+            try writeDataToFile(data)
+        }
+    }
+
+    func reset() throws {
+        try storedValue.write { storedValue in
+            storedValue = nil
+            if fileManager.fileExists(atPath: fileURL.path) {
+                try fileManager.removeItem(at: fileURL)
+            }
+        }
+    }
+}
+
+extension FileStorage: DataStorageInterface {
+    func getRawData() throws -> Data? {
+        try storedValue.read { _ in try readDataFromFile() }
+    }
+    
+    func setRawData(_ data: Data?) throws {
+        try storedValue.write { storedValue in
+            storedValue = try data.map(decode)
+            try writeDataToFile(data)
+        }
+    }
+}
+
+/// A type that defines methods for decoding.
+///
+/// - Note: Declared in Combine, but has higher requirements for iOS, tvOS, and watchOS
+protocol TopLevelDecoder {
+    /// The type this decoder accepts.
+    associatedtype Input
+    /// Decodes an instance of the indicated type.
+    func decode<T>(_ type: T.Type, from: Self.Input) throws -> T where T : Decodable
+}
+
+/// A type that defines methods for encoding.
+///
+/// - Note: Declared in Combine, but has higher requirements for iOS, tvOS, and watchOS
+protocol TopLevelEncoder {
+    /// The type this encoder produces.
+    associatedtype Output
+    /// Encodes an instance of the indicated type.
+    ///
+    /// - Parameter value: The instance to encode.
+    func encode<T>(_ value: T) throws -> Self.Output where T : Encodable
+}
+
+extension JSONDecoder: TopLevelDecoder {}
+extension JSONEncoder: TopLevelEncoder {}

--- a/Sources/CommonMain/Caching/Storage/Keyed/KeyedStorage.swift
+++ b/Sources/CommonMain/Caching/Storage/Keyed/KeyedStorage.swift
@@ -1,0 +1,105 @@
+//
+//  KeyedStorage.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+
+/// Multi-key interface for storing values.
+public protocol KeyedStorageInterface: AnyObject {
+    /// Associated value type.
+    associatedtype Value
+
+    /// Returns stored value for a given key.
+    /// - Parameter key: A key to return value for.
+    func value(for key: String) throws -> Value?
+
+    /// Stores a new value for a given key.
+    /// - Parameters:
+    ///   - value: A new value to store.
+    ///   - key: A key to sat value for.
+    func updateValue(_ value: Value?, for key: String) throws
+    
+    /// Reset storage.
+    func reset() throws
+}
+
+class KeyedStorageBox<Value> {
+    private let storage: any KeyedStorageInterface
+    private let getValueClosure: (_ key: String) throws -> Value?
+    private let updateValueClosure: (_ value: Value?, _ key: String) throws -> Void
+
+    init<Storage: KeyedStorageInterface>(_ storage: Storage) where Storage.Value == Value {
+        self.storage = storage
+        self.getValueClosure = { try storage.value(for: $0) }
+        self.updateValueClosure = { try storage.updateValue($0, for: $1) }
+    }
+}
+
+extension KeyedStorageBox: KeyedStorageInterface {
+    func value(for key: String) throws -> Value? {
+        try getValueClosure(key)
+    }
+    
+    func updateValue(_ value: Value?, for key: String) throws {
+        try updateValueClosure(value, key)
+    }
+    
+    func reset() throws {
+        try storage.reset()
+    }
+}
+
+/// File storage for codable values.
+class KeyedStorageCache<Value: Codable> {
+    /// Stored value.
+    ///
+    /// Storing a copy in memory to reduce file read and decoding operations.
+    ///
+    /// The value is not read until first access. This allows to handle load and parse errors on first access.
+    private let storedValue: Protected<[String: StorageBox<Value>]> = .init([:])
+
+    private let storageBoxBuilder: (_ key: String) -> StorageBox<Value>
+
+    init(storageBoxBuilder: @escaping (_ key: String) -> StorageBox<Value>) {
+        self.storageBoxBuilder = storageBoxBuilder
+    }
+
+    convenience init<Storage: StorageInterface>(
+        storageBuilder: @escaping (_ key: String) -> Storage
+    ) where Storage.Value == Value {
+        self.init(storageBoxBuilder: { .init(storageBuilder($0)) })
+    }
+}
+
+extension KeyedStorageCache: KeyedStorageInterface {
+    func _storageBox(for key: String, from storedValue: inout [String: StorageBox<Value>]) -> StorageBox<Value> {
+        let storageBox: StorageBox<Value>
+
+        if let existingStorageBox = storedValue[key] {
+            storageBox = existingStorageBox
+        } else {
+            let box = storageBoxBuilder(key)
+            storedValue[key] = box
+            storageBox = box
+        }
+        return storageBox
+    }
+
+    func value(for key: String) throws -> Value? {
+        try storedValue.write { try _storageBox(for: key, from: &$0).value() }
+    }
+
+    func updateValue(_ value: Value?, for key: String) throws {
+        try storedValue.write { try _storageBox(for: key, from: &$0).updateValue(value) }
+    }
+
+    func reset() throws {
+        try storedValue.write { storedValue in
+            try storedValue.values.forEach { try $0.reset() }
+            storedValue.removeAll()
+        }
+    }
+}

--- a/Sources/CommonMain/Caching/Storage/Storage.swift
+++ b/Sources/CommonMain/Caching/Storage/Storage.swift
@@ -1,0 +1,48 @@
+//
+//  StorageInterface.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+
+/// Interface for storing values.
+public protocol StorageInterface: AnyObject {
+    /// Associated value type.
+    associatedtype Value
+
+    /// Returns stored value.
+    func value() throws -> Value?
+
+    /// Stores a new value.
+    /// - Parameter value: A new value to store.
+    func updateValue(_ value: Value?) throws
+
+    /// Reset storage.
+    func reset() throws
+}
+
+class StorageBox<Value> {
+    private let storage: any StorageInterface
+    private let updateValueClosure: (_ value: Value?) throws -> Void
+
+    init<Storage: StorageInterface>(_ storage: Storage) where Storage.Value == Value {
+        self.storage = storage
+        self.updateValueClosure = { try storage.updateValue($0) }
+    }
+}
+
+extension StorageBox: StorageInterface {
+    func value() throws -> Value? {
+        try storage.value() as! Value?
+    }
+
+    func updateValue(_ value: Value?) throws {
+        try updateValueClosure(value)
+    }
+
+    func reset() throws {
+        try storage.reset()
+    }
+}

--- a/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
@@ -142,6 +142,9 @@ class ExperimentEvaluator {
                                                                         assignments: [Utils.getStickyBucketExperimentKey(experiment.key,
                                                                                                                    experiment.bucketVersion ?? 0): result.key])
             if changed {
+                // User context is created for each evaluation.
+                // Changes here don't propagate to the Sticky bucket storage.
+                // There is an extra logic in the StickyBucketService to merge new value with the old ones.
                 context.userContext.stickyBucketAssignmentDocs = context.userContext.stickyBucketAssignmentDocs ?? [:]
                 context.userContext.stickyBucketAssignmentDocs?[key] = doc
                 context.options.stickyBucketService?.saveAssignments(doc: doc)

--- a/Sources/CommonMain/Evaluators/ExperimentHelper.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentHelper.swift
@@ -3,17 +3,21 @@ import Foundation
 internal class ExperimentHelper {
     static let shared = ExperimentHelper()
     
-    private var trackedExperiments: Set<String> = Set<String>()
-    
+    private var trackedExperiments: Protected<Set<String>> = .init([])
+
     func isTracked(_ experiment: Experiment, _ result: ExperimentResult) -> Bool {
         let experimentKey = experiment.key
         
         let key = (result.hashAttribute ?? "") + String(result.valueHash ?? "") + experimentKey + String(result.variationId)
 
-        if trackedExperiments.contains(key) { return true }
-        
-        trackedExperiments.insert(key)
-        
-        return false
+        let isTracked = trackedExperiments.write { trackedExperiments in
+            if trackedExperiments.contains(key) { return true }
+
+            trackedExperiments.insert(key)
+
+            return false
+        }
+
+        return isTracked
     }
 }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -122,8 +122,18 @@ struct GrowthBookCacheOptions {
     }
 
     @available(*, deprecated, renamed: "setCacheDirectoryURL", message: "Use setCacheDirectoryURL instead")
-    @objc public func setCacheDirectory(_ directory: CacheDirectory) -> GrowthBookBuilder {
-        setCacheDirectoryURL(directory.url)
+    public func setCacheDirectory(_ directory: CacheDirectory) -> GrowthBookBuilder {
+        let cacheDirectorySuffix: String
+        if let clientKey = growthBookBuilderModel.clientKey {
+            let hashedClientKey: String = CachingManager.keyHash(clientKey)
+            cacheDirectorySuffix = "-hashedClientKey"
+        } else {
+            cacheDirectorySuffix = ""
+        }
+
+        let directoryURL: URL = directory.url.appendingPathComponent("GrowthBook-Cache\(cacheDirectorySuffix)", isDirectory: true)
+
+        return setCacheDirectoryURL(directoryURL)
     }
 
     @objc public func setCacheDirectoryURL(_ directoryURL: URL) -> GrowthBookBuilder {
@@ -146,13 +156,26 @@ struct GrowthBookCacheOptions {
             backgroundSync: growthBookBuilderModel.backgroundSync,
             remoteEval: growthBookBuilderModel.remoteEval
         )
+        
+
+        let cacheDirectoryURL: URL
+        if let clientKey = growthBookBuilderModel.clientKey {
+            let lastPathComponent: String = cacheOptions.directoryURL.lastPathComponent
+            let hashedClientKey: String = CachingManager.keyHash(clientKey)
+            cacheDirectoryURL = cacheOptions.directoryURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("\(lastPathComponent)-\(hashedClientKey)")
+        } else {
+            cacheDirectoryURL = cacheOptions.directoryURL
+        }
 
         let cachingManager: GrowthBookSDKCachingManagerInterface = GrowthBookSDKCachingManager.withFileStorage(
-            directoryURL: cacheOptions.directoryURL,
+            directoryURL: cacheDirectoryURL,
             featuresCacheFilename: cacheOptions.featureCacheFilename,
             savedGroupsCacheFilename: cacheOptions.savedGroupsCacheFilename,
             fileManager: .default
         )
+
         if let features = growthBookBuilderModel.features {
             try? cachingManager.featuresCache.setEncodedFeaturesRawData(features)
         }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -137,8 +137,8 @@ struct GrowthBookCacheOptions {
     }
 
     @objc public func setCacheDirectoryURL(_ directoryURL: URL) -> GrowthBookBuilder {
-        cacheOptions = cacheOptions.settingDirectoryURL(directoryURL)
-        (growthBookBuilderModel.stickyBucketService as? StickyBucketFileStorageCacheInterface)?.updateCacheDirectoryURL(directoryURL)
+        self.cacheOptions = cacheOptions.settingDirectoryURL(directoryURL)
+        growthBookBuilderModel.stickyBucketService?.updateCacheDirectoryURL(directoryURL)
         return self
     }
 
@@ -163,10 +163,15 @@ struct GrowthBookCacheOptions {
             let lastPathComponent: String = cacheOptions.directoryURL.lastPathComponent
             let hashedClientKey: String = CachingManager.keyHash(clientKey)
             cacheDirectoryURL = cacheOptions.directoryURL
-                .deletingLastPathComponent()
-                .appendingPathComponent("\(lastPathComponent)-\(hashedClientKey)")
+                .appendingPathComponent("\(hashedClientKey)")
         } else {
             cacheDirectoryURL = cacheOptions.directoryURL
+        }
+
+        if let stickyBucketService = growthBookBuilderModel.stickyBucketService {
+            stickyBucketService.updateCacheDirectoryURL(
+                cacheDirectoryURL.appendingPathComponent("sticky_bucket", isDirectory: true)
+            )
         }
 
         let cachingManager: GrowthBookSDKCachingManagerInterface = GrowthBookSDKCachingManager.withFileStorage(
@@ -365,6 +370,7 @@ struct GrowthBookCacheOptions {
     private func refreshStickyBucketService(_ data: FeaturesDataModel? = nil) {
         if (gbContext.stickyBucketService != nil) {
             Utils.refreshStickyBuckets(context: evalContext!, attributes: evalContext!.userContext.attributes, data: data)
+            gbContext.stickyBucketAssignmentDocs = evalContext?.options.stickyBucketAssignmentDocs
         }
     }
 }

--- a/Sources/CommonMain/JsonManager/JsonManager.swift
+++ b/Sources/CommonMain/JsonManager/JsonManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // MARK: - Error
-public enum SwiftyJSONError: Int, Swift.Error {
+public enum SwiftyJSONError: Int, Swift.Error, Sendable {
     case unsupportedType = 999
     case indexOutOfBounds = 900
     case elementTooDeep = 902
@@ -38,7 +38,7 @@ extension SwiftyJSONError: CustomNSError {
 }
 
 // MARK: - JSON Type
-public enum Type: Int {
+public enum Type: Int, Sendable {
     case number
     case string
     case bool
@@ -312,7 +312,7 @@ extension JSON: Swift.Collection {
 /**
  *  To mark both String and Int can be used in subscript.
  */
-public enum JSONKey {
+public enum JSONKey: Sendable {
     case index(Int)
     case key(String)
 }
@@ -538,9 +538,9 @@ extension JSON: Swift.RawRepresentable {
         }
     }
 
-    public func rawString(_ options: [writingOptionsKeys: Any]) -> String? {
+    public func rawString(_ options: [WritingOptionsKeys: Any]) -> String? {
         let encoding = options[.encoding] as? String.Encoding ?? String.Encoding.utf8
-        let maxObjectDepth = options[.maxObjextDepth] as? Int ?? 10
+        let maxObjectDepth = options[.maxObjectDepth] as? Int ?? 10
         do {
             return try _rawString(encoding, options: options, maxObjectDepth: maxObjectDepth)
         } catch {
@@ -549,7 +549,7 @@ extension JSON: Swift.RawRepresentable {
         }
     }
 
-    fileprivate func _rawString(_ encoding: String.Encoding = .utf8, options: [writingOptionsKeys: Any], maxObjectDepth: Int = 10) throws -> String? {
+    fileprivate func _rawString(_ encoding: String.Encoding = .utf8, options: [WritingOptionsKeys: Any], maxObjectDepth: Int = 10) throws -> String? {
         guard maxObjectDepth > 0 else { throw SwiftyJSONError.invalidJSON }
         switch type {
         case .dictionary:
@@ -1253,11 +1253,17 @@ func >= (lhs: NSNumber, rhs: NSNumber) -> Bool {
     }
 }
 
-public enum writingOptionsKeys {
+@available(*, deprecated, renamed: "WritingOptionsKeys", message: "Use WritingOptionsKeys instead")
+public typealias writingOptionsKeys = WritingOptionsKeys
+
+public enum WritingOptionsKeys: Sendable {
     case jsonSerialization
     case castNilToNSNull
-    case maxObjextDepth
+    case maxObjectDepth
     case encoding
+
+    @available(*, deprecated, renamed: "maxObjectDepth", message: "Use .maxObjectDepth instead")
+    public static var maxObjextDepth: Self { .maxObjectDepth }
 }
 
 // MARK: - JSON: Codable

--- a/Sources/CommonMain/LoggingManager/LoggingManager.swift
+++ b/Sources/CommonMain/LoggingManager/LoggingManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Level: Int {
+public enum Level: Int, Sendable {
     case trace, debug, info, warning, error
 
     var description: String {

--- a/Sources/CommonMain/LoggingManager/Theme.swift
+++ b/Sources/CommonMain/LoggingManager/Theme.swift
@@ -49,11 +49,14 @@ open class Theme: Themes {
      - returns: A string representation of the hex color.
      */
     private static func formatHex(_ hex: String) -> String {
+        let allowedHexCount = hex.hasPrefix("#") ? 7 : 6
+        assert(hex.count == allowedHexCount, "Invalid hex color format: \(hex)")
+
         let scanner = Scanner(string: hex)
-        var hex: UInt32 = 0
+        var hex: UInt64 = 0
 
         scanner.charactersToBeSkipped = CharacterSet(charactersIn: "#")
-        scanner.scanHexInt32(&hex)
+        scanner.scanHexInt64(&hex)
 
         let r = (hex & 0xFF0000) >> 16
         let g = (hex & 0xFF00) >> 8

--- a/Sources/CommonMain/Model/StickyAssignmentsDocument.swift
+++ b/Sources/CommonMain/Model/StickyAssignmentsDocument.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public struct StickyAssignmentsDocument: Codable, Equatable {
-    var attributeName: String
-    var attributeValue: String
-    var assignments: [String: String]
+public struct StickyAssignmentsDocument: Codable, Equatable, Sendable {
+    public var attributeName: String
+    public var attributeValue: String
+    public var assignments: [String: String]
     
     init(attributeName: String, attributeValue: String, assignments: [String : String]) {
         self.attributeName = attributeName

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -54,7 +54,12 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
         self.onConnect = onConnect
     }
 
+    @available(*, deprecated, renamed: "onDisconnect", message: "Use `onDisconnect` instead")
     public func onDissconnect(onDisconnect: @escaping ((Int?, Bool?, NSError?) -> ())) {
+        self.onDisconnect(onDisconnect: onDisconnect)
+    }
+
+    public func onDisconnect(onDisconnect: @escaping ((Int?, Bool?, NSError?) -> ())) {
         self.onDisconnect = onDisconnect
     }
 
@@ -160,9 +165,7 @@ extension SSEHandler {
     
     private func shouldReconnect(statusCode: Int) -> Bool {
         switch statusCode {
-        case 200:
-            return true
-        case _ where statusCode > 200 && statusCode < 300:
+        case 200..<300:
             return true
         default:
             return false

--- a/Sources/CommonMain/StickyBucket/StickyBucketService.swift
+++ b/Sources/CommonMain/StickyBucket/StickyBucketService.swift
@@ -15,7 +15,7 @@ public class StickyBucketService: StickyBucketServiceProtocol {
     private let prefix: String
     let cache: StickyBucketCacheInterface?
 
-    @available(*, deprecated, message: "Use init(prefix:cacheStorage:) instead")
+    @available(*, deprecated, message: "Use init(prefix:cache:) instead")
     public init(prefix: String = "gbStickyBuckets__", localStorage: CachingLayer? = nil) {
         self.prefix = prefix
         self.cache = localStorage.map(CachingLayerWrapper.init(_:))
@@ -91,8 +91,7 @@ extension CachingLayerWrapper: StickyBucketCacheInterface {
     }
 
     func clearCache() {
-        let url = CacheDirectory.applicationSupport.url.appendingPathComponent("GrowthBook-Cache")
-        try? FileManager.default.removeItem(atPath: url.path)
+        (cachingLayer as? CachingManager)?.clearCache()
     }
 }
 

--- a/Sources/CommonMain/StickyBucket/StickyBucketService.swift
+++ b/Sources/CommonMain/StickyBucket/StickyBucketService.swift
@@ -4,37 +4,38 @@ public protocol StickyBucketServiceProtocol {
     func getAssignments(attributeName: String, attributeValue: String) -> StickyAssignmentsDocument?
     func saveAssignments(doc: StickyAssignmentsDocument)
     func getAllAssignments(attributes: [String: String]) -> [String: StickyAssignmentsDocument]
+    func clearCache() throws
+}
+
+public protocol StickyBucketServiceWithFileCacheProtocol: StickyBucketCacheInterface {
+    func updateCacheDirectoryURL(_ directoryURL: URL)
 }
 
 public class StickyBucketService: StickyBucketServiceProtocol {
     private let prefix: String
-    private let localStorage: CachingLayer?
-    
+    let cache: StickyBucketCacheInterface?
+
+    @available(*, deprecated, message: "Use init(prefix:cacheStorage:) instead")
     public init(prefix: String = "gbStickyBuckets__", localStorage: CachingLayer? = nil) {
         self.prefix = prefix
-        self.localStorage = localStorage
+        self.cache = localStorage.map(CachingLayerWrapper.init(_:))
     }
-    
+
+    public init(prefix: String = "gbStickyBuckets__", cache: StickyBucketCacheInterface?) {
+        self.prefix = prefix
+        self.cache = cache
+    }
+
     public func getAssignments(attributeName: String, attributeValue: String) -> StickyAssignmentsDocument? {
         let key = "\(attributeName)||\(attributeValue)"
-        
-        guard let localStorage = localStorage else { return nil }
-                
-        if
-            let data = localStorage.getContent(fileName: prefix + key),
-            let jsonPetitions = try? JSONDecoder().decode(StickyAssignmentsDocument.self, from: data) {
-            return jsonPetitions
-        }
 
-        return nil
+        return try? cache?.stickyAssignment(for: prefix + key)
     }
     
     public func saveAssignments(doc: StickyAssignmentsDocument) {
         let key = "\(doc.attributeName)||\(doc.attributeValue)"
-        
-        guard let localStorage = localStorage, let docData = try? JSONEncoder().encode(doc) else { return }
 
-        localStorage.saveContent(fileName: prefix + key, content: docData)
+        try? cache?.updateStickyAssignment(doc, for: prefix + key)
     }
     
     public func getAllAssignments(attributes: [String : String]) -> [String : StickyAssignmentsDocument] {
@@ -49,5 +50,54 @@ public class StickyBucketService: StickyBucketServiceProtocol {
         }
         
         return docs
+    }
+
+    public func clearCache() throws {
+        try cache?.clearCache()
+    }
+}
+
+extension StickyBucketService {
+    public func updateCacheDirectoryURL(_ directoryURL: URL) {
+        (cache as? StickyBucketFileStorageCacheInterface)?.updateCacheDirectoryURL(directoryURL)
+    }
+}
+
+private struct CachingLayerWrapper {
+    private let cachingLayer: CachingLayer
+
+    init(_ cachingLayer: CachingLayer) {
+        self.cachingLayer = cachingLayer
+    }
+}
+
+extension CachingLayerWrapper: StickyBucketCacheInterface {
+    func stickyAssignment(for key: String) throws -> StickyAssignmentsDocument? {
+        guard
+            let data = cachingLayer.getContent(fileName: key),
+            let jsonPetitions = try? JSONDecoder().decode(StickyAssignmentsDocument.self, from: data)
+        else {
+            return .none
+        }
+        return jsonPetitions
+    }
+
+    func updateStickyAssignment(_ value: StickyAssignmentsDocument?, for key: String) throws {
+        guard let value, let docData = try? JSONEncoder().encode(value) else {
+            return
+        }
+
+        cachingLayer.saveContent(fileName: key, content: docData)
+    }
+
+    func clearCache() {
+        let url = CacheDirectory.applicationSupport.url.appendingPathComponent("GrowthBook-Cache")
+        try? FileManager.default.removeItem(atPath: url.path)
+    }
+}
+
+extension CachingLayerWrapper: StickyBucketFileStorageCacheInterface {
+    func updateCacheDirectoryURL(_ directoryURL: URL) {
+        CachingManager.shared.updateCacheDirectoryURL(directoryURL)
     }
 }

--- a/Sources/CommonMain/StickyBucket/StickyBucketService.swift
+++ b/Sources/CommonMain/StickyBucket/StickyBucketService.swift
@@ -5,9 +5,6 @@ public protocol StickyBucketServiceProtocol {
     func saveAssignments(doc: StickyAssignmentsDocument)
     func getAllAssignments(attributes: [String: String]) -> [String: StickyAssignmentsDocument]
     func clearCache() throws
-}
-
-public protocol StickyBucketServiceWithFileCacheProtocol: StickyBucketCacheInterface {
     func updateCacheDirectoryURL(_ directoryURL: URL)
 }
 
@@ -59,7 +56,9 @@ public class StickyBucketService: StickyBucketServiceProtocol {
 
 extension StickyBucketService {
     public func updateCacheDirectoryURL(_ directoryURL: URL) {
-        (cache as? StickyBucketFileStorageCacheInterface)?.updateCacheDirectoryURL(directoryURL)
+        if let cache = cache as? StickyBucketFileStorageCacheInterface {
+            cache.updateCacheDirectoryURL(directoryURL)
+        }
     }
 }
 

--- a/Sources/CommonMain/StickyBucket/StickyBucketService.swift
+++ b/Sources/CommonMain/StickyBucket/StickyBucketService.swift
@@ -31,8 +31,16 @@ public class StickyBucketService: StickyBucketServiceProtocol {
     
     public func saveAssignments(doc: StickyAssignmentsDocument) {
         let key = "\(doc.attributeName)||\(doc.attributeValue)"
+        // While we have multi-context SDK need to fetch assigned assignments and merge.
+        // When there will be a singe-context SDK we can put merge logic to the User Context.
 
-        try? cache?.updateStickyAssignment(doc, for: prefix + key)
+        var newDoc = doc
+
+        if let previousDoc = try? cache?.stickyAssignment(for: prefix + key) {
+            newDoc.assignments = previousDoc.assignments.merging(newDoc.assignments) { (_, new) in new }
+        }
+
+        try? cache?.updateStickyAssignment(newDoc, for: prefix + key)
     }
     
     public func getAllAssignments(attributes: [String : String]) -> [String : StickyAssignmentsDocument] {

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -11,7 +11,7 @@ public enum Constants {
 }
 
 /// Type Alias for Feature in GrowthBook
-typealias Features = [String: Feature]
+public typealias Features = [String: Feature]
 
 /// Type Alias for Condition Element in GrowthBook Rules
 typealias Condition = JSON
@@ -45,7 +45,7 @@ public typealias ExperimentRunCallback = (Experiment, ExperimentResult) -> Void
 typealias NameSpace = (String, Float, Float)
 
 /// Double Struct for GrowthBook Ranges
-public struct BucketRange: Codable {
+public struct BucketRange: Codable, Sendable {
     let number1: Float
     let number2: Float
     
@@ -66,7 +66,7 @@ public struct BucketRange: Codable {
 }
 
 /// GrowthBook Error Class to handle any error / exception scenario
-@objc public enum SDKError: NSInteger, Error {
+@objc public enum SDKError: NSInteger, Error, Sendable {
     case failedToLoadData = 0
     case failedParsedData = 1
     case failedMissingKey = 2
@@ -75,7 +75,7 @@ public struct BucketRange: Codable {
 }
 
 /// Meta info about the variations
-public struct VariationMeta: Codable {
+public struct VariationMeta: Codable, Sendable {
     /// Used to implement holdout groups
     let passthrough: Bool?
     /// A unique key for this variation

--- a/Sources/CommonMain/Utils/Logger.swift
+++ b/Sources/CommonMain/Utils/Logger.swift
@@ -4,7 +4,7 @@ import Foundation
 // GrowthBook default logger
 var logger = Logger()
 
-@objc public enum LoggerLevel: NSInteger {
+@objc public enum LoggerLevel: NSInteger, Sendable {
     case trace = 0
     case debug = 1
     case info = 2

--- a/Sources/CommonMain/Utils/Protected.swift
+++ b/Sources/CommonMain/Utils/Protected.swift
@@ -1,0 +1,74 @@
+//
+//  Protected.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 1/21/25.
+//
+
+import Foundation
+
+/// Synchronous thread-safe read/write accessor to the wrapped value.
+final class Protected<Value> {
+    #if compiler(>=6)
+    private nonisolated(unsafe) var value: Value
+    #else
+    private var value: Value
+    #endif
+
+    private let lock: NSLock = .init()
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    /// Synchronously read or transform the contained value.
+    ///
+    /// - Parameter closure: The closure to execute.
+    ///
+    /// - Returns:           The return value of the closure passed.
+    func read() -> Value {
+        read { value in value }
+    }
+
+    /// Synchronously read or transform the contained value.
+    ///
+    /// - Parameter closure: The closure to execute.
+    ///
+    /// - Returns:           The return value of the closure passed.
+    func read<U>(_ closure: (Value) throws -> U) rethrows -> U {
+        try lock.read { try closure(self.value) }
+    }
+
+    /// Synchronously modify the protected value.
+    ///
+    /// - Parameter closure: The closure to execute.
+    ///
+    /// - Returns:           The modified value.
+    @discardableResult
+    func write<U>(_ closure: (inout Value) throws -> U) rethrows -> U {
+        try lock.write { try closure(&self.value) }
+    }
+
+    /// Synchronously update the protected value.
+    ///
+    /// - Parameter value: The `Value`.
+    func write(_ value: Value) {
+        write { $0 = value }
+    }
+}
+
+#if compiler(>=6)
+extension Protected: Sendable {}
+#else
+extension Protected: @unchecked Sendable {}
+#endif
+
+private extension NSLocking {
+    func read<R>(_ closure: () throws -> R) rethrows -> R {
+        try withLock { try closure() }
+    }
+
+    func write<R>(_ closure: () throws -> R) rethrows -> R {
+        try withLock { try closure() }
+    }
+}

--- a/Sources/CommonMain/Utils/String+Hash.swift
+++ b/Sources/CommonMain/Utils/String+Hash.swift
@@ -1,0 +1,35 @@
+//
+//  String+Hash.swift
+//  GrowthBook-IOS
+//
+//  Created by Vitalii Budnik on 3/5/25.
+//
+
+import CommonCrypto
+import CryptoKit
+
+extension String {
+    var sha256HashString: String {
+        guard let data = data(using: .utf8) else { return "" }
+
+        let hashBytes: [UInt8]
+
+        if #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) {
+            hashBytes = [UInt8](SHA256.hash(data: data))
+        } else {
+            var hashedBytes: [UInt8] = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+            data.withUnsafeBytes {
+                _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hashedBytes)
+            }
+            hashBytes = hashedBytes
+        }
+
+        return hashBytes.hexString
+    }
+}
+
+extension [UInt8] {
+    fileprivate var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -218,7 +218,7 @@ public class Utils {
         expHashAttribute: String?,
         expFallbackAttribute: String? = nil
     ) -> [String: String] {
-        
+
         guard let stickyBucketAssignmentDocs = context.userContext.stickyBucketAssignmentDocs else {
             return [:]
         }
@@ -379,11 +379,21 @@ public class Utils {
     }
     
     static func initializeEvalContext(context: Context) -> EvalContext {
-        let options = MultiUserOptions(apiHost: context.apiHost, clientKey: context.clientKey, encryptionKey: context.encryptionKey, isEnabled: context.isEnabled, attributes: context.attributes, forcedVariations: context.forcedVariations, isQaMode: context.isQaMode, trackingClosure: context.trackingClosure
+        let options = MultiUserOptions(
+            apiHost: context.apiHost,
+            clientKey: context.clientKey,
+            encryptionKey: context.encryptionKey,
+            isEnabled: context.isEnabled,
+            attributes: context.attributes,
+            forcedVariations: context.forcedVariations,
+            stickyBucketAssignmentDocs: context.stickyBucketAssignmentDocs,
+            stickyBucketIdentifierAttributes: context.stickyBucketIdentifierAttributes,
+            stickyBucketService: context.stickyBucketService,
+            isQaMode: context.isQaMode,
+            trackingClosure: context.trackingClosure
         )
-        
+
         let globalContext = GlobalContext(features: context.features, savedGroups: context.savedGroups)
-        
         
         // should create manual force features
         let userContext = UserContext(attributes: context.attributes, stickyBucketAssignmentDocs: context.stickyBucketAssignmentDocs, forcedVariations: context.forcedVariations, forcedFeatureValues: nil)


### PR DESCRIPTION
- `||` needs to be escaped in shell. 
- Attribute name and attribute value can contain some characters not supported by FS.

Using hash instead of plain string.