### PR TITLE
Improve caching: custom CachingLayer and encryption by default

### DIFF
--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -8,7 +8,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     var isError: Bool = false
     var hasFeatures: Bool = false
     
-    let cachingManager = CachingManager()
+    let cachingManager: CachingLayer = CachingManager()
     
     override func setUp() {
         super.setUp()

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -87,7 +87,8 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         
         let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponseEncryptedFeatures, error: nil)), cachingManager: cachingManager)
         
-        viewModel.encryptionKey = "3tfeoyW0wlo47bDnbWDkxg=="
+        let encryptionKey = "3tfeoyW0wlo47bDnbWDkxg=="
+        viewModel.encryptionKey = encryptionKey
         viewModel.fetchFeatures(apiUrl: "")
 
         let cachingManager: CachingLayer = CachingManager()
@@ -97,7 +98,10 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
             return
         }
         
-        if let _ = try? JSONDecoder().decode(Features.self, from: featureData) {
+        let crypto: CryptoProtocol = Crypto()
+        if let encryptedString = String(data: featureData, encoding: .utf8), crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) != nil {
+            XCTAssertTrue(true)
+        } else if let _ = try? JSONDecoder().decode(Features.self, from: featureData) {
             XCTAssertTrue(true)
         } else {
             XCTFail()

--- a/GrowthBookTests/GrowthBookSDKBuilderTests.swift
+++ b/GrowthBookTests/GrowthBookSDKBuilderTests.swift
@@ -9,7 +9,7 @@ class GrowthBookSDKBuilderTests: XCTestCase {
     let testAttributes: JSON = JSON()
     let testKeyString = "Ns04T5n9+59rl2x3SlNHtQ=="
     
-    let cachingManager = CachingManager(apiKey: "4r23r324f23")
+    let cachingManager: CachingLayer = CachingManager(apiKey: "4r23r324f23")
     
     final class RefreshFlag: @unchecked Sendable {
         private let lock = NSLock()

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -2,10 +2,13 @@ import Foundation
 import CommonCrypto
 
 /// Interface for Caching Layer
-public protocol CachingLayer: AnyObject {
+@objc public protocol CachingLayer: AnyObject {
     func saveContent(fileName: String, content: Data)
     func getContent(fileName: String) -> Data?
     func setCacheKey(_ key: String)
+    func clearCache()
+    func setSystemCacheDirectory(_ directory: CacheDirectory)
+    func setCustomCachePath(_ path: String)
 }
 
 /// This is actual implementation of Caching Layer in iOS
@@ -34,14 +37,6 @@ public protocol CachingLayer: AnyObject {
         }
         let key = hash.map { String(format: "%02x", $0) }.joined()
         return String(key.prefix(5))
-    }
-    
-    @objc func getData(fileName: String) -> Data? {
-        return getContent(fileName: fileName)
-    }
-
-    @objc func putData(fileName: String, content: Data) {
-        saveContent(fileName: fileName, content: content)
     }
 
     /// Set a custom cache saving directory

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -15,9 +15,9 @@ class FeaturesViewModel {
     let dataSource: FeaturesDataSource
     var encryptionKey: String?
     /// Caching Manager
-    let manager: CachingManager
+    let manager: CachingLayer
         
-    init(delegate: FeaturesFlowDelegate, dataSource: FeaturesDataSource, cachingManager: CachingManager) {
+    init(delegate: FeaturesFlowDelegate, dataSource: FeaturesDataSource, cachingManager: CachingLayer) {
         self.delegate = delegate
         self.dataSource = dataSource
         self.manager = cachingManager
@@ -42,7 +42,7 @@ class FeaturesViewModel {
     
     private func fetchCachedFeatures() {
         // Check for cache data
-        if let json = manager.getData(fileName: Constants.featureCache) {
+        if let json = manager.getContent(fileName: Constants.featureCache) {
             let decoder = JSONDecoder()
             if let features = try? decoder.decode(Features.self, from: json) {
                 // Call Success Delegate with mention of data available but its not remote
@@ -58,7 +58,7 @@ class FeaturesViewModel {
     /// Fetch Features
     func fetchFeatures(apiUrl: String?, remoteEval: Bool = false, payload: RemoteEvalParams? = nil) {
         // Check for cache data
-        if let json = manager.getData(fileName: Constants.featureCache) {
+        if let json = manager.getContent(fileName: Constants.featureCache) {
             let decoder = JSONDecoder()
             if let features = try? decoder.decode(Features.self, from: json) {
                 // Call Success Delegate with mention of data available but its not remote
@@ -112,7 +112,7 @@ class FeaturesViewModel {
                     let crypto: CryptoProtocol = Crypto()
                     if let features = crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) {
                         if let featureData = try? JSONEncoder().encode(features) {
-                            manager.putData(fileName: Constants.featureCache, content: featureData)
+                            manager.saveContent(fileName: Constants.featureCache, content: featureData)
                         } else {
                             logger.error("Failed encode features")
                         }
@@ -129,7 +129,7 @@ class FeaturesViewModel {
                 }
             } else if let features = jsonPetitions.features {
                 if let featureData = try? JSONEncoder().encode(features) {
-                    manager.putData(fileName: Constants.featureCache, content: featureData)
+                    manager.saveContent(fileName: Constants.featureCache, content: featureData)
                 }
                 delegate?.featuresFetchedSuccessfully(features: features, isRemote: true)
             } else {
@@ -142,7 +142,7 @@ class FeaturesViewModel {
                 let crypto = Crypto()
                 if let savedGroups = crypto.getSavedGroupsFromEncryptedFeatures(encryptedString: encryptedSavedGroups, encryptionKey: encryptionKey) {
                     if let encryptedSavedGroups = try? JSONEncoder().encode(savedGroups) {
-                        manager.putData(fileName: Constants.savedGroupsCache, content: encryptedSavedGroups)
+                        manager.saveContent(fileName: Constants.savedGroupsCache, content: encryptedSavedGroups)
                     } else {
                         logger.error("Failed encode saved groups")
                     }
@@ -154,7 +154,7 @@ class FeaturesViewModel {
                 }
             } else if let savedGroups = jsonPetitions.savedGroups {
                 if let savedGroupsData = try? JSONEncoder().encode(savedGroups) {
-                    manager.putData(fileName: Constants.savedGroupsCache, content: savedGroupsData)
+                    manager.saveContent(fileName: Constants.savedGroupsCache, content: savedGroupsData)
                 }
                 delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: true)
             }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -38,7 +38,7 @@ public struct GrowthBookModel {
     private var refreshHandler: CacheRefreshHandler?
     private var networkDispatcher: NetworkProtocol = CoreNetworkClient()
     
-    private var cachingManager: CachingManager
+    private var cachingManager: CachingLayer
 
     @objc public init(apiHost: String? = nil, clientKey: String? = nil, encryptionKey: String? = nil, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool = false, remoteEval: Bool = false) {
         growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval)
@@ -67,6 +67,12 @@ public struct GrowthBookModel {
     /// Set Network Client - Network Client for Making API Calls
     @objc public func setNetworkDispatcher(networkDispatcher: NetworkProtocol) -> GrowthBookBuilder {
         self.networkDispatcher = networkDispatcher
+        return self
+    }
+    
+    /// Set Caching Manager - Caching Client for saving fetched features
+    @objc public func setCachingManager(cachingManager: CachingLayer) -> GrowthBookBuilder {
+        self.cachingManager = cachingManager
         return self
     }
     
@@ -148,7 +154,7 @@ public struct GrowthBookModel {
     private var attributeOverrides: JSON = JSON()
     private var savedGroupsValues: JSON?
     private var evalContext: EvalContext? = nil
-    var cachingManager: CachingManager
+    var cachingManager: CachingLayer
 
     init(context: Context,
          refreshHandler: CacheRefreshHandler? = nil,
@@ -156,7 +162,7 @@ public struct GrowthBookModel {
          networkDispatcher: NetworkProtocol = CoreNetworkClient(),
          features: Features? = nil,
          savedGroups: JSON? = nil,
-         cachingManager: CachingManager) {
+         cachingManager: CachingLayer) {
         gbContext = context
         self.refreshHandler = refreshHandler
         self.networkDispatcher = networkDispatcher

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -72,6 +72,7 @@ public struct BucketRange: Codable {
     case failedMissingKey = 2
     case failedEncryptedFeatures = 3
     case failedEncryptedSavedGroups = 4
+    case failedParsedEncryptedData = 5
 }
 
 /// Meta info about the variations


### PR DESCRIPTION
We are trying to secure our feature flags, thats why we implemented remote eval and encryption, but then suddenly found, that caching on a client is done without encryption in plain JSON, which can be easily faked.

So I found in the sources that the SDK already has CachingLayer protocol, but for some reason it wasn't public. If it was I would probably just implement custom caching mechanism with encryption.
After reading the code (for the 232 time lol), I thought that implementing encrypted cache is pretty easy, so here is the PR, which proposes two changes:
1. A way to set a custom CachingManager/Layer
2. Encrypted cache if encryptionKey is provided

This change will result in a `Failed get features from cached encrypted features` for the first start after update for an old user, but it seems ok for me.