### PR TITLE
set caches directory as default for tvOs

### DIFF
--- a/GrowthBookTests/CachingManagerTest.swift
+++ b/GrowthBookTests/CachingManagerTest.swift
@@ -52,4 +52,9 @@ class CachingManagerTest: XCTestCase {
             logger.error("Failed get raw data or parse json error: \(error.localizedDescription)")
         }
     }
+    
+    override func tearDown() {
+           manager.clearCache()
+           super.tearDown()
+       }
 }

--- a/GrowthBookTests/CachingManagerTest.swift
+++ b/GrowthBookTests/CachingManagerTest.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import GrowthBook
 
 class CachingManagerTest: XCTestCase {
-    let manager = CachingManager()
+    let manager = CachingManager(apiKey: "caching-test-key")
 
     func testCachingFileName() throws {
 

--- a/GrowthBookTests/CachingManagerTest.swift
+++ b/GrowthBookTests/CachingManagerTest.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import GrowthBook
 
 class CachingManagerTest: XCTestCase {
-    let manager = CachingManager(apiKey: "caching-test-key")
+    let manager = CachingManager(apiKey: "caching-test-api-key")
 
     func testCachingFileName() throws {
 

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -51,8 +51,6 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)), cachingManager: cachingManager)
         
         viewModel.fetchFeatures(apiUrl: "")
-
-        let cachingManager: CachingLayer = CachingManager()
         
         guard let featureData = cachingManager.getContent(fileName: Constants.featureCache) else {
             XCTFail()
@@ -89,8 +87,6 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         
         viewModel.encryptionKey = "3tfeoyW0wlo47bDnbWDkxg=="
         viewModel.fetchFeatures(apiUrl: "")
-
-        let cachingManager: CachingLayer = CachingManager()
         
         guard let featureData = cachingManager.getContent(fileName: Constants.featureCache) else {
             XCTFail()

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -8,7 +8,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     var isError: Bool = false
     var hasFeatures: Bool = false
     
-    let cachingManager = CachingManager()
+    let cachingManager = CachingManager(apiKey: "features-vm-test-api-key")
     
     override func setUp() {
         super.setUp()

--- a/GrowthBookTests/GrowthBookSDKBuilderTests.swift
+++ b/GrowthBookTests/GrowthBookSDKBuilderTests.swift
@@ -216,7 +216,6 @@ class GrowthBookSDKBuilderTests: XCTestCase {
                                             backgroundSync: false).setRefreshHandler(refreshHandler: { _ in
 
         }).setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil))
-            .setSystemCacheDirectory(.applicationSupport)
             .initializer()
         
         let fileName = "gb-features.txt"

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -11,7 +11,13 @@ public protocol CachingLayer: AnyObject {
 /// This is actual implementation of Caching Layer in iOS
 @objc public class CachingManager: NSObject, CachingLayer {
     
-    private var cacheDirectory = CacheDirectory.applicationSupport
+    private var cacheDirectory: CacheDirectory = {
+        #if os(tvOS)
+        return .caches
+        #else
+        return .applicationSupport
+        #endif
+    }()
     private var customCachePath: String?
     private var cacheKey: String = ""
     


### PR DESCRIPTION
The GrowthBook SDK currently uses .applicationSupport as the default cache directory, which is not writable on physical tvOS devices due to sandbox restrictions.
This PR changes the default cache directory to .caches on tvOS, fixing permission errors and ensuring the SDK works correctly on real Apple TV hardware while keeping .applicationSupport on other platforms.