### PR TITLE
Feature/bearer token

### DIFF
--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -25,6 +25,9 @@ public struct GrowthBookModel {
     var stickyBucketService: StickyBucketServiceProtocol?
     var backgroundSync: Bool
     var remoteEval: Bool
+    var tokenProvider: (() -> String?)? = nil
+    var onTokenExpired: (() -> Void)? = nil
+    var defaultHeaders: [String: String]? = nil
 }
 
 /// GrowthBookBuilder - inItializer for GrowthBook SDK for Apps
@@ -40,21 +43,41 @@ public struct GrowthBookModel {
     
     private var cachingManager: CachingManager
 
-    @objc public init(apiHost: String? = nil, clientKey: String? = nil, encryptionKey: String? = nil, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool = false, remoteEval: Bool = false) {
-        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval)
+    @objc public init(apiHost: String? = nil, clientKey: String? = nil, encryptionKey: String? = nil, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool = false, remoteEval: Bool = false, tokenProvider: (() -> String?)? = nil, onTokenExpired: (() -> Void)? = nil, defaultHeaders: [String: String]? = nil) {
+        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval,
+            tokenProvider: tokenProvider, onTokenExpired: onTokenExpired, defaultHeaders: defaultHeaders)
         self.refreshHandler = refreshHandler
+        self.networkDispatcher = CoreNetworkClient(
+                    tokenProvider: tokenProvider,
+                    onTokenExpired: onTokenExpired,
+                    defaultHeaders: defaultHeaders ?? [:]
+                )
         self.cachingManager = CachingManager(apiKey: clientKey)
     }
 
-    @objc public init(features: Data, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool, remoteEval: Bool = false) {
-        growthBookBuilderModel = GrowthBookModel(features: features, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval)
+    @objc public init(features: Data, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool, remoteEval: Bool = false, tokenProvider: (() -> String?)? = nil, onTokenExpired: (() -> Void)? = nil,
+        defaultHeaders: [String: String]? = nil) {
+        growthBookBuilderModel = GrowthBookModel(features: features, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval,
+            tokenProvider: tokenProvider, onTokenExpired: onTokenExpired, defaultHeaders: defaultHeaders)
         self.refreshHandler = refreshHandler
+        self.networkDispatcher = CoreNetworkClient(
+                tokenProvider: tokenProvider,
+                onTokenExpired: onTokenExpired,
+                defaultHeaders: defaultHeaders ?? [:]
+            )
         self.cachingManager = CachingManager()
     }
 
-    init(apiHost: String, clientKey: String, encryptionKey: String? = nil, attributes: JSON, trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler?, backgroundSync: Bool, remoteEval: Bool = false) {
-        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval)
+    init(apiHost: String, clientKey: String, encryptionKey: String? = nil, attributes: JSON, trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler?, backgroundSync: Bool, remoteEval: Bool = false, tokenProvider: (() -> String?)? = nil,
+        onTokenExpired: (() -> Void)? = nil, defaultHeaders: [String: String]? = nil) {
+        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval,
+            tokenProvider: tokenProvider, onTokenExpired: onTokenExpired, defaultHeaders: defaultHeaders)
         self.refreshHandler = refreshHandler
+        self.networkDispatcher = CoreNetworkClient(
+                tokenProvider: tokenProvider,
+                onTokenExpired: onTokenExpired,
+                defaultHeaders: defaultHeaders ?? [:]
+            )
         self.cachingManager = CachingManager(apiKey: clientKey)
     }
 

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -25,9 +25,8 @@ public struct GrowthBookModel {
     var stickyBucketService: StickyBucketServiceProtocol?
     var backgroundSync: Bool
     var remoteEval: Bool
-    var tokenProvider: (() -> String?)? = nil
-    var onTokenExpired: (() -> Void)? = nil
-    var defaultHeaders: [String: String]? = nil
+    var apiRequestHeaders: [String: String]? = nil
+    var streamingHostRequestHeaders: [String: String]? = nil
 }
 
 /// GrowthBookBuilder - inItializer for GrowthBook SDK for Apps
@@ -43,40 +42,32 @@ public struct GrowthBookModel {
     
     private var cachingManager: CachingManager
 
-    @objc public init(apiHost: String? = nil, clientKey: String? = nil, encryptionKey: String? = nil, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool = false, remoteEval: Bool = false, tokenProvider: (() -> String?)? = nil, onTokenExpired: (() -> Void)? = nil, defaultHeaders: [String: String]? = nil) {
-        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval,
-            tokenProvider: tokenProvider, onTokenExpired: onTokenExpired, defaultHeaders: defaultHeaders)
+    @objc public init(apiHost: String? = nil, clientKey: String? = nil, encryptionKey: String? = nil, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool = false, remoteEval: Bool = false, apiRequestHeaders: [String: String]? = nil, streamingHostRequestHeaders: [String: String]? = nil) {
+        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval, apiRequestHeaders: apiRequestHeaders, streamingHostRequestHeaders: streamingHostRequestHeaders)
         self.refreshHandler = refreshHandler
         self.networkDispatcher = CoreNetworkClient(
-                    tokenProvider: tokenProvider,
-                    onTokenExpired: onTokenExpired,
-                    defaultHeaders: defaultHeaders ?? [:]
+                    apiRequestHeaders: apiRequestHeaders ?? [:],
+                    streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
                 )
         self.cachingManager = CachingManager(apiKey: clientKey)
     }
 
-    @objc public init(features: Data, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool, remoteEval: Bool = false, tokenProvider: (() -> String?)? = nil, onTokenExpired: (() -> Void)? = nil,
-        defaultHeaders: [String: String]? = nil) {
-        growthBookBuilderModel = GrowthBookModel(features: features, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval,
-            tokenProvider: tokenProvider, onTokenExpired: onTokenExpired, defaultHeaders: defaultHeaders)
+    @objc public init(features: Data, attributes: [String: Any], trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler? = nil, backgroundSync: Bool, remoteEval: Bool = false, apiRequestHeaders: [String: String]? = nil, streamingHostRequestHeaders: [String: String]? = nil) {
+        growthBookBuilderModel = GrowthBookModel(features: features, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval, apiRequestHeaders: apiRequestHeaders, streamingHostRequestHeaders: streamingHostRequestHeaders)
         self.refreshHandler = refreshHandler
         self.networkDispatcher = CoreNetworkClient(
-                tokenProvider: tokenProvider,
-                onTokenExpired: onTokenExpired,
-                defaultHeaders: defaultHeaders ?? [:]
+                apiRequestHeaders: apiRequestHeaders ?? [:],
+                streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
             )
         self.cachingManager = CachingManager()
     }
 
-    init(apiHost: String, clientKey: String, encryptionKey: String? = nil, attributes: JSON, trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler?, backgroundSync: Bool, remoteEval: Bool = false, tokenProvider: (() -> String?)? = nil,
-        onTokenExpired: (() -> Void)? = nil, defaultHeaders: [String: String]? = nil) {
-        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval,
-            tokenProvider: tokenProvider, onTokenExpired: onTokenExpired, defaultHeaders: defaultHeaders)
+    init(apiHost: String, clientKey: String, encryptionKey: String? = nil, attributes: JSON, trackingCallback: @escaping TrackingCallback, refreshHandler: CacheRefreshHandler?, backgroundSync: Bool, remoteEval: Bool = false, apiRequestHeaders: [String: String]? = nil, streamingHostRequestHeaders: [String: String]? = nil) {
+        growthBookBuilderModel = GrowthBookModel(apiHost: apiHost, clientKey: clientKey, encryptionKey: encryptionKey, attributes: JSON(attributes), trackingClosure: trackingCallback, backgroundSync: backgroundSync, remoteEval: remoteEval, apiRequestHeaders: apiRequestHeaders, streamingHostRequestHeaders: streamingHostRequestHeaders)
         self.refreshHandler = refreshHandler
         self.networkDispatcher = CoreNetworkClient(
-                tokenProvider: tokenProvider,
-                onTokenExpired: onTokenExpired,
-                defaultHeaders: defaultHeaders ?? [:]
+                apiRequestHeaders: apiRequestHeaders ?? [:],
+                streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
             )
         self.cachingManager = CachingManager(apiKey: clientKey)
     }
@@ -328,6 +319,20 @@ public struct GrowthBookModel {
     @objc public func setForcedVariations(forcedVariations: Any) {
         gbContext.forcedVariations = JSON(forcedVariations)
         refreshForRemoteEval()
+    }
+    
+    /// Updates API request headers for dynamic header management
+    @objc public func updateApiRequestHeaders(_ headers: [String: String]) {
+        if let networkClient = networkDispatcher as? CoreNetworkClient {
+            networkClient.apiRequestHeaders = headers
+        }
+    }
+    
+    /// Updates streaming host request headers for SSE connections
+    @objc public func updateStreamingHostRequestHeaders(_ headers: [String: String]) {
+        if let networkClient = networkDispatcher as? CoreNetworkClient {
+            networkClient.streamingHostRequestHeaders = headers
+        }
     }
     
     @objc func featuresAPIModelSuccessfully(model: FeaturesDataModel) {

--- a/Sources/CommonMain/Network/NetworkClient.swift
+++ b/Sources/CommonMain/Network/NetworkClient.swift
@@ -59,7 +59,7 @@ class CoreNetworkClient: NetworkProtocol {
                 return
             }
             
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 403 {
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 401 {
                 self.onTokenExpired?()
                 return
             }


### PR DESCRIPTION
This update adds support for passing an authentication token through a `tokenProvider` closure, which automatically sets the `Authorization` header on network requests. It also enables providing custom HTTP headers via a `defaultHeaders` dictionary in the `CoreNetworkClient`. Additionally, an `onTokenExpired` callback has been introduced, which is triggered when the server responds with a 401 status code, allowing the client to handle token refresh logic seamlessly.

After this PR, the `GrowthBookBuilder` initializer will support passing `tokenProvider`, `onTokenExpired`, and `defaultHeaders` like this:

```swift
GrowthBookBuilder(
    ...,
    tokenProvider: {
        return TokenStorage.shared.token
    },
    onTokenExpired: {
        TokenStorage.shared.updateToken()
    },
    defaultHeaders: [
        "Cache-Control": "no-cache",
        "Connection": "keep-alive"
    ]
)
```

This enables the SDK to automatically include the provided token in all requests, handle 401 responses by invoking the refresh callback, and send any additional custom headers as needed.

