### PR TITLE
Make ExperimentHelper thread-safe with serial queue

### DIFF
--- a/Sources/CommonMain/Evaluators/ExperimentHelper.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentHelper.swift
@@ -4,16 +4,20 @@ internal class ExperimentHelper {
     static let shared = ExperimentHelper()
     
     private var trackedExperiments: Set<String> = Set<String>()
+    private let queue = DispatchQueue(label: "experimentHelper.queue")
     
     func isTracked(_ experiment: Experiment, _ result: ExperimentResult) -> Bool {
         let experimentKey = experiment.key
         
         let key = (result.hashAttribute ?? "") + String(result.valueHash ?? "") + experimentKey + String(result.variationId)
 
-        if trackedExperiments.contains(key) { return true }
-        
-        trackedExperiments.insert(key)
-        
-        return false
+        return queue.sync {
+    
+            if trackedExperiments.contains(key) { return true }
+            
+            trackedExperiments.insert(key)
+            
+            return false
+        }
     }
 }


### PR DESCRIPTION
### Context
In the app I am working on, we have been receiving `EXC_BAD_ACCESS` crashes from users at
`if trackedExperiments.contains(key) { return true }.`([ExperimentHelper.swift#L13](https://github.com/growthbook/growthbook-swift/blob/8a42b814582db7d26aed8081039a7cabbbeda79e/Sources/CommonMain/Evaluators/ExperimentHelper.swift#L13))

This seems to be caused by a race condition: one thread reading the `Set` while another is inserting to it.

### Fix
- Added a private serial `DispatchQueue` to guard all access to `trackedExperiments`.
