### PR TITLE
chore: Exposing ExperimentReult initializer publicly

### DIFF
--- a/Sources/CommonMain/Model/Experiment.swift
+++ b/Sources/CommonMain/Model/Experiment.swift
@@ -224,7 +224,7 @@ import Foundation
     /// If sticky bucketing was used to assign a variation
     public let stickyBucketUsed: Bool?
 
-    init(inExperiment: Bool,
+    public init(inExperiment: Bool,
          variationId: Int,
          value: JSON,
          hashAttribute: String? = nil,


### PR DESCRIPTION
## 📝 Summary

This PR makes the initializer of  ExperimentResult  public. This change enables the construction of  ExperimentResult  instances outside of the GrowthBook Swift SDK module.

By exposing a `public` initializer, services and other layers in client applications can create and manipulate abstractions of `ExperimentResult` without requiring direct imports of the provider SDK. This effectively abstracts away the implementation details of the provider SDK and reduces coupling between modules.

## 🤔 Problem Being Addressed

- Swift member-wise initializers for structs are only `internal` by default, even if the struct itself is `public`.
- This restricts the ability to construct public data types outside of the defining module, preventing clean testing, mocking, or abstraction.

## 🧐 Rationale for a Public Initializer

- Exposes a clear, intentional API for instantiating `ExperimentResult` as part of a public model, supporting custom service abstractions and improved testability.
- Allows for the separation of concerns: provider SDK logic remains contained, and higher-level business logic can interact with simple models without direct SDK dependency.
- This change maintains strong encapsulation boundaries and directly supports modularity and long-term codebase scalability.

## 🧑‍💻 Changes

- Changed the access level of  `ExperimentResult`  initializer to  public 

## 🧪 Testing

1. Verified that the public initializer compiles and allows instantiation externally.
2. Ensure no downstream usage of  `ExperimentResult`  requires importing the SDK directly.

- [x] Unit tests run (and they pass)