### PR TITLE
Update EvalContext after feature fetch to prevent stale state

### DIFF
--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -329,6 +329,8 @@ public struct GrowthBookModel {
 
     @objc public func featuresFetchedSuccessfully(features: [String: Feature], isRemote: Bool) {
         gbContext.features = features
+        evalContext = Utils.initializeEvalContext(context: gbContext)
+        refreshStickyBucketService()
         if isRemote {
             refreshHandler?(true)
         }
@@ -340,6 +342,8 @@ public struct GrowthBookModel {
         guard let features = crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) else { return }
         
         gbContext.features = features
+        evalContext = Utils.initializeEvalContext(context: gbContext)
+        refreshStickyBucketService()
     }
 
     @objc public func featuresFetchFailed(error: SDKError, isRemote: Bool) {


### PR DESCRIPTION
This PR addresses a critical issue where the SDK fails to reflect new feature flag values immediately after the feature payload is updated (e.g., following a successful `backgroundSync`, SSE push, or manual `refreshCache()` call).

---

## ❌ The Problem: Stale Evaluation Context
The core issue was that while the **global** feature data (`gbContext.features`) was successfully updated upon a successful fetch (in `featuresFetchedSuccessfully`), the evaluation context (`evalContext`)—which is used by all feature checks (`evalFeature`, `isOn`)—was **not being reinitialized**.

This meant the SDK continued to use the old feature list in memory, leading to **stale feature results** until the application was completely restarted.

---

## ✅ The Solution: Context Reinitialization
We introduce mandatory reinitialization of the `evalContext` and updates to the **Sticky Bucket Service** in all methods that update the core feature data.

1.  `featuresFetchedSuccessfully` (Remote Fetch/SSE):
    * The `evalContext` is now reinitialized using the fresh `gbContext`.
    * **`refreshStickyBucketService()`** is called to ensure that any new or modified experiments use the correct, updated bucketing logic. This ensures full state consistency.

2.  `setEncryptedFeatures` (Manual Update):
    * This method suffered from the same bug. We now apply the same fix here, ensuring that manually set features are **immediately** available for evaluation.

---

## 📢 Impact

* **Enables Live Updates:** This fix is critical for all features that rely on real-time updates, such as **Server-Sent Events (SSE)**. The UI can now accurately reflect feature changes **without an app restart**.
* **Data Consistency:** Guarantees that the feature evaluation logic (`evalContext`) is always in sync with the latest loaded features, preventing discrepancies in experiment assignments.