### PR TITLE
fix: include forcedFeatures in evaluation

### DIFF
--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -3,11 +3,12 @@ import Foundation
 /// GrowthBookBuilder - Root Class for SDK Initializers for GrowthBook SDK
 protocol GrowthBookProtocol: AnyObject {
     var growthBookBuilderModel: GrowthBookModel { get set }
-
+    
     func setForcedVariations(forcedVariations: [String: Int]) -> GrowthBookBuilder
     func setQAMode(isEnabled: Bool) -> GrowthBookBuilder
     func setEnabled(isEnabled: Bool) -> GrowthBookBuilder
     func initializer() -> GrowthBookSDK
+    
 }
 
 public struct GrowthBookModel {
@@ -19,6 +20,7 @@ public struct GrowthBookModel {
     var attributes: JSON
     var trackingClosure: TrackingCallback
     var logLevel: Level = .info
+    
     var isQaMode: Bool = false
     var isEnabled: Bool = true
     var forcedVariations: JSON?
@@ -28,6 +30,7 @@ public struct GrowthBookModel {
     var remoteEval: Bool
     var apiRequestHeaders: [String: String]? = nil
     var streamingHostRequestHeaders: [String: String]? = nil
+    var forcedFeatureValues: JSON?
 }
 
 /// GrowthBookBuilder - inItializer for GrowthBook SDK for Apps
@@ -37,13 +40,13 @@ public struct GrowthBookModel {
 /// - Tracking Closure - Track Events for Experiments
 @objc public class GrowthBookBuilder: NSObject, GrowthBookProtocol {
     var growthBookBuilderModel: GrowthBookModel
-
+    
     private var refreshHandler: CacheRefreshHandler?
     private var networkDispatcher: NetworkProtocol = CoreNetworkClient()
     
     private var cachingManager: CachingLayer
     private var evalContext: EvalContext?
-
+    
     @objc public init(
         apiHost: String? = nil,
         clientKey: String? = nil,
@@ -70,12 +73,12 @@ public struct GrowthBookModel {
             streamingHostRequestHeaders: streamingHostRequestHeaders)
         self.refreshHandler = refreshHandler
         self.networkDispatcher = CoreNetworkClient(
-                    apiRequestHeaders: apiRequestHeaders ?? [:],
-                    streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
-                )
+            apiRequestHeaders: apiRequestHeaders ?? [:],
+            streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
+        )
         self.cachingManager = CachingManager(apiKey: clientKey)
     }
-
+    
     @objc public init(
         features: Data,
         attributes: [String: Any],
@@ -97,12 +100,12 @@ public struct GrowthBookModel {
         )
         self.refreshHandler = refreshHandler
         self.networkDispatcher = CoreNetworkClient(
-                apiRequestHeaders: apiRequestHeaders ?? [:],
-                streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
-            )
+            apiRequestHeaders: apiRequestHeaders ?? [:],
+            streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
+        )
         self.cachingManager = CachingManager()
     }
-
+    
     init(
         apiHost: String,
         clientKey: String,
@@ -128,18 +131,18 @@ public struct GrowthBookModel {
         )
         self.refreshHandler = refreshHandler
         self.networkDispatcher = CoreNetworkClient(
-                apiRequestHeaders: apiRequestHeaders ?? [:],
-                streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
-            )
+            apiRequestHeaders: apiRequestHeaders ?? [:],
+            streamingHostRequestHeaders: streamingHostRequestHeaders ?? [:]
+        )
         self.cachingManager = CachingManager(apiKey: clientKey)
     }
-
+    
     /// Set Refresh Handler - Will be called when cache is refreshed
     @objc public func setRefreshHandler(refreshHandler: @escaping CacheRefreshHandler) -> GrowthBookBuilder {
         self.refreshHandler = refreshHandler
         return self
     }
-
+    
     /// Set Network Client - Network Client for Making API Calls
     @objc public func setNetworkDispatcher(networkDispatcher: NetworkProtocol) -> GrowthBookBuilder {
         self.networkDispatcher = networkDispatcher
@@ -156,17 +159,17 @@ public struct GrowthBookModel {
         growthBookBuilderModel.stickyBucketService = StickyBucketService(cacheKey: growthBookBuilderModel.clientKey)
         return self
     }
-
+    
     @objc public func setStickyBucketService(stickyBucketService: StickyBucketServiceProtocol) -> GrowthBookBuilder {
         growthBookBuilderModel.stickyBucketService = stickyBucketService
         return self
     }
-
+    
     @objc public func setStickyBucketService(cacheKey: String) -> GrowthBookBuilder {
         growthBookBuilderModel.stickyBucketService = StickyBucketService(cacheKey: cacheKey)
         return self
     }
-
+    
     /// Set log level for SDK Logger
     ///
     /// By default log level is set to `info`
@@ -179,12 +182,12 @@ public struct GrowthBookModel {
         growthBookBuilderModel.forcedVariations = JSON(forcedVariations)
         return self
     }
-
+    
     @objc public func setQAMode(isEnabled: Bool) -> GrowthBookBuilder {
         growthBookBuilderModel.isQaMode = isEnabled
         return self
     }
-
+    
     @objc public func setEnabled(isEnabled: Bool) -> GrowthBookBuilder {
         growthBookBuilderModel.isEnabled = isEnabled
         return self
@@ -204,7 +207,12 @@ public struct GrowthBookModel {
         growthBookBuilderModel.streamingHost = streamingHost
         return self
     }
-
+    
+    @objc public func setForcedFeatures(forcedFeatures: [String: Any]) -> GrowthBookBuilder {
+        growthBookBuilderModel.forcedFeatureValues = JSON(forcedFeatures)
+        return self
+    }
+    
     @objc public func initializer() -> GrowthBookSDK {
         let gbContext = Context(
             apiHost: growthBookBuilderModel.apiHost,
@@ -218,7 +226,8 @@ public struct GrowthBookModel {
             isQaMode: growthBookBuilderModel.isQaMode,
             trackingClosure: growthBookBuilderModel.trackingClosure,
             backgroundSync: growthBookBuilderModel.backgroundSync,
-            remoteEval: growthBookBuilderModel.remoteEval
+            remoteEval: growthBookBuilderModel.remoteEval,
+            forcedFeatureValues: growthBookBuilderModel.forcedFeatureValues
         )
         
         if let clientKey = growthBookBuilderModel.clientKey {
@@ -228,7 +237,7 @@ public struct GrowthBookModel {
         if let features = growthBookBuilderModel.features {
             cachingManager.saveContent(fileName: Constants.featureCache, content: features)
         }
-
+        
         return GrowthBookSDK(context: gbContext, refreshHandler: refreshHandler, networkDispatcher: networkDispatcher, cachingManager: cachingManager)
     }
 }
@@ -242,12 +251,11 @@ public struct GrowthBookModel {
     private var networkDispatcher: NetworkProtocol
     public var gbContext: Context
     private var featureVM: FeaturesViewModel!
-    private var forcedFeatures: JSON = JSON()
     private var attributeOverrides: JSON = JSON()
     private var savedGroupsValues: JSON?
     private var evalContext: EvalContext!
     var cachingManager: CachingLayer
-
+    
     init(context: Context,
          refreshHandler: CacheRefreshHandler? = nil,
          logLevel: Level = .info,
@@ -272,7 +280,7 @@ public struct GrowthBookModel {
         if let savedGroups {
             context.savedGroups = savedGroups
         }
-                
+        
         // if the SSE URL is available and background sync variable is set to true, then we have to connect to SSE Server
         if let sseURL = context.getSSEUrl(), context.backgroundSync {
             featureVM.connectBackgroundSync(sseUrl: sseURL)
@@ -291,9 +299,9 @@ public struct GrowthBookModel {
             }
         }
         refreshStickyBucketService()
-
-    }
         
+    }
+    
     /// Manually Refresh Cache
     @objc public func refreshCache() {
         if gbContext.remoteEval {
@@ -307,7 +315,7 @@ public struct GrowthBookModel {
     @objc public func clearCache() {
         cachingManager.clearCache()
     }
-
+    
     /// Get Context - Holding the complete data regarding cached features & attributes etc.
     @objc public func getGBContext() -> Context {
         return gbContext
@@ -316,7 +324,7 @@ public struct GrowthBookModel {
     public func getGBAttributes() -> JSON {
         return gbContext.attributes
     }
-
+    
     /// Get Cached Features
     @objc public func getFeatures() -> [String: Feature] {
         return gbContext.features
@@ -329,7 +337,7 @@ public struct GrowthBookModel {
     @objc public func clearSubscriptions() {
         self.subscriptions.removeAll()
     }
-
+    
     /// Get the value of the feature with a fallback
     public func getFeatureValue(feature id: String, default defaultValue: JSON) -> JSON {
         let context = getEvalContext()
@@ -339,7 +347,7 @@ public struct GrowthBookModel {
         gbContext.stickyBucketAssignmentDocs = context.userContext.stickyBucketAssignmentDocs
         return result.value ?? defaultValue
     }
-
+    
     @objc public func featuresFetchedSuccessfully(features: [String: Feature], isRemote: Bool) {
         gbContext.features = features
         evalContext = Utils.initializeEvalContext(context: gbContext)
@@ -358,7 +366,7 @@ public struct GrowthBookModel {
         evalContext = Utils.initializeEvalContext(context: gbContext)
         refreshStickyBucketService()
     }
-
+    
     @objc public func featuresFetchFailed(error: SDKError, isRemote: Bool) {
         if isRemote {
             refreshHandler?(false)
@@ -377,14 +385,14 @@ public struct GrowthBookModel {
             attributes: evalContext.userContext.attributes,
             stickyBucketAssignmentDocs: evalContext.userContext.stickyBucketAssignmentDocs,
             forcedVariations: evalContext.userContext.forcedVariations,
-            forcedFeatureValues: evalContext.userContext.forcedFeatureValues
+            forcedFeatureValues: gbContext.forcedFeatureValues
         )
     }
     
     @objc public func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {
         refreshHandler?(false)
     }
-
+    
     public func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
         gbContext.savedGroups = savedGroups
         refreshHandler?(true)
@@ -393,10 +401,14 @@ public struct GrowthBookModel {
     /// If remote eval is enabled, send needed data to backend to proceed remote evaluation
     @objc public func refreshForRemoteEval() {
         if !gbContext.remoteEval { return }
-        let payload = RemoteEvalParams(attributes: gbContext.attributes, forcedFeatures: self.forcedFeatures, forcedVariations: gbContext.forcedVariations )
+        let forcedFeaturesArray = convertForcedFeaturesToArray(gbContext.forcedFeatureValues)
+        let forcedFeaturesJson = JSON(forcedFeaturesArray ?? [])
+        
+        
+        let payload = RemoteEvalParams(attributes: gbContext.attributes, forcedFeatures: forcedFeaturesJson, forcedVariations: gbContext.forcedVariations )
         featureVM.fetchFeatures(apiUrl: gbContext.getRemoteEvalUrl(), remoteEval: gbContext.remoteEval, payload: payload)
     }
-
+    
     /// The feature method takes a single string argument, which is the unique identifier for the feature and returns a FeatureResult object.
     @objc public func evalFeature(id: String) -> FeatureResult {
         let context = getEvalContext()
@@ -406,12 +418,12 @@ public struct GrowthBookModel {
         gbContext.stickyBucketAssignmentDocs = context.userContext.stickyBucketAssignmentDocs
         return result
     }
-
+    
     /// The isOn method takes a single string argument, which is the unique identifier for the feature and returns the feature state on/off
     @objc public func isOn(feature id: String) -> Bool {
         return evalFeature(id: id).isOn
     }
-
+    
     /// The run method takes an Experiment object and returns an experiment result
     @objc public func run(experiment: Experiment) -> ExperimentResult {
         let context = getEvalContext()
@@ -429,9 +441,10 @@ public struct GrowthBookModel {
     
     /// The setForcedFeatures method updates forced features
     @objc public func setForcedFeatures(forcedFeatures: Any) {
-        self.forcedFeatures = JSON(forcedFeatures)
+        gbContext.forcedFeatureValues = JSON(forcedFeatures)
+        refreshForRemoteEval()
     }
-
+    
     /// The setAttributes method replaces the Map of user attributes that are used to assign variations
     @objc public func setAttributes(attributes: Any) {
         gbContext.attributes = JSON(attributes)
@@ -485,5 +498,17 @@ public struct GrowthBookModel {
         if (evalContext != nil && evalContext.options.stickyBucketService != nil) {
             Utils.refreshStickyBuckets(context: getEvalContext(), attributes: evalContext.userContext.attributes, data: data)
         }
+    }
+    
+    private func convertForcedFeaturesToArray(_ forcedFeatures: JSON?) -> [[JSON]]? {
+        guard let features = forcedFeatures?.dictionaryValue, !features.isEmpty else {
+            return nil
+        }
+        
+        let result = features.map { key, value -> [JSON] in
+            return [JSON(key), value]
+        }
+        
+        return result
     }
 }

--- a/Sources/CommonMain/Model/Context.swift
+++ b/Sources/CommonMain/Model/Context.swift
@@ -37,6 +37,8 @@ import Foundation
     public var savedGroups: JSON?
     
     public var url: String? = nil
+    
+    public var forcedFeatureValues: JSON? = nil
 
     init(apiHost: String?,
          streamingHost: String?,
@@ -54,7 +56,8 @@ import Foundation
          backgroundSync: Bool = false,
          remoteEval: Bool = false,
          savedGroups: JSON? = nil,
-         url: String? = nil) {
+         url: String? = nil,
+         forcedFeatureValues: JSON? = nil) {
         self.apiHost = apiHost
         self.streamingHost = streamingHost
         self.clientKey = clientKey
@@ -72,6 +75,7 @@ import Foundation
         self.remoteEval = remoteEval
         self.savedGroups = savedGroups
         self.url = url
+        self.forcedFeatureValues = forcedFeatureValues
     }
     
     @objc public func getFeaturesURL() -> String? {

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -449,7 +449,7 @@ public class Utils {
             let globalContext = GlobalContext(features: context.features, savedGroups: context.savedGroups)
         
         // should create manual force features
-        let userContext = UserContext(attributes: context.attributes, stickyBucketAssignmentDocs: context.stickyBucketAssignmentDocs, forcedVariations: context.forcedVariations, forcedFeatureValues: nil)
+            let userContext = UserContext(attributes: context.attributes, stickyBucketAssignmentDocs: context.stickyBucketAssignmentDocs, forcedVariations: context.forcedVariations, forcedFeatureValues: context.forcedFeatureValues)
         
         let evalContext = EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
         return evalContext


### PR DESCRIPTION
- Add forcedFeatures to Context and UserContext during SDK initialization
- Refactor refreshForRemoteEval to correctly handle forcedFeatures
- Convert forcedFeatures from dictionary to array of key-value pairs when sending payload
- Ensure only forcedFeatures are converted to array-of-arrays format, other fields remain as JSON objects