### PR TITLE
chore: public GrowthBookModel initializer

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		15147AEF2F7E746400FC9112 /* GrowthBookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15147AEE2F7E746300FC9112 /* GrowthBookModel.swift */; };
 		231FB2292910F78D0035546E /* json.json in Resources */ = {isa = PBXBuildFile; fileRef = 84391F2628016C85003309DC /* json.json */; };
 		5D5EAD1D2EF1DEA70049F432 /* LruETagCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5EAD1C2EF1DEA70049F432 /* LruETagCache.swift */; };
 		5D5EAD1F2EF1DED60049F432 /* LruETagCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5EAD1E2EF1DED60049F432 /* LruETagCacheTests.swift */; };
@@ -32,9 +33,12 @@
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
+		84A1B2C3D4E5F6A7B8C9D0E1F2 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1B2C3D4E5F6A7B8C9D0E1F3 /* ContextManager.swift */; };
 		84AE3B1A2BE2466C006BA49B /* RemoteEvalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AE3B182BE2466B006BA49B /* RemoteEvalModel.swift */; };
 		84AE3B1B2BE2466C006BA49B /* StickyAssignmentsDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AE3B192BE2466C006BA49B /* StickyAssignmentsDocument.swift */; };
+		84B2C3D4E5F6A7B8C9D0E1F2A3 /* GlobalConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B2C3D4E5F6A7B8C9D0E1F2A4 /* GlobalConfig.swift */; };
 		84BC2E9D294A11F100289BC2 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BC2E9C294A11F100289BC2 /* Crypto.swift */; };
+		84C3D4E5F6A7B8C9D0E1F2A3B4 /* EvaluationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C3D4E5F6A7B8C9D0E1F2A3B5 /* EvaluationData.swift */; };
 		84CDE32B2812F359008B3E6F /* GrowthBook.h in Headers */ = {isa = PBXBuildFile; fileRef = 84CDE32A2812F359008B3E6F /* GrowthBook.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84CDE3332812F454008B3E6F /* GrowthBookSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F627F845EB0072BFDC /* GrowthBookSDK.swift */; };
 		84CDE3342812F454008B3E6F /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843363F827F845EB0072BFDC /* NetworkClient.swift */; };
@@ -55,9 +59,6 @@
 		84CDE3432812F454008B3E6F /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640A27F845EB0072BFDC /* Context.swift */; };
 		84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E82C3C2BD2AF8F003F000B /* StickyBucketingTests.swift */; };
 		84FEA9F12BC9913700111EE2 /* StickyBucketService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FEA9EF2BC9913300111EE2 /* StickyBucketService.swift */; };
-		84A1B2C3D4E5F6A7B8C9D0E1F2 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A1B2C3D4E5F6A7B8C9D0E1F3 /* ContextManager.swift */; };
-		84B2C3D4E5F6A7B8C9D0E1F2A3 /* GlobalConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B2C3D4E5F6A7B8C9D0E1F2A4 /* GlobalConfig.swift */; };
-		84C3D4E5F6A7B8C9D0E1F2A3B4 /* EvaluationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C3D4E5F6A7B8C9D0E1F2A3B5 /* EvaluationData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +86,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		15147AEE2F7E746300FC9112 /* GrowthBookModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookModel.swift; sourceTree = "<group>"; };
 		5D5EAD1C2EF1DEA70049F432 /* LruETagCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LruETagCache.swift; sourceTree = "<group>"; };
 		5D5EAD1E2EF1DED60049F432 /* LruETagCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LruETagCacheTests.swift; sourceTree = "<group>"; };
 		84095C772817EAB700ADDF19 /* JsonManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonManager.swift; sourceTree = "<group>"; };
@@ -129,17 +131,17 @@
 		849952502ACDB676003BBCF7 /* SSEHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSEHandler.swift; sourceTree = "<group>"; };
 		849952562ADD6D66003BBCF7 /* EventModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventModel.swift; sourceTree = "<group>"; };
 		849952582ADD704A003BBCF7 /* EventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
+		84A1B2C3D4E5F6A7B8C9D0E1F3 /* ContextManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextManager.swift; sourceTree = "<group>"; };
 		84AE3B182BE2466B006BA49B /* RemoteEvalModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteEvalModel.swift; sourceTree = "<group>"; };
 		84AE3B192BE2466C006BA49B /* StickyAssignmentsDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickyAssignmentsDocument.swift; sourceTree = "<group>"; };
+		84B2C3D4E5F6A7B8C9D0E1F2A4 /* GlobalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalConfig.swift; sourceTree = "<group>"; };
 		84BC2E9C294A11F100289BC2 /* Crypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Crypto.swift; sourceTree = "<group>"; };
+		84C3D4E5F6A7B8C9D0E1F2A3B5 /* EvaluationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationData.swift; sourceTree = "<group>"; };
 		84CDE3282812F359008B3E6F /* GrowthBook.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GrowthBook.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84CDE32A2812F359008B3E6F /* GrowthBook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook.h; sourceTree = "<group>"; };
 		84E82C3C2BD2AF8F003F000B /* StickyBucketingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyBucketingTests.swift; sourceTree = "<group>"; };
 		84F51E9627F419B000994D1C /* GrowthBook_IOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GrowthBook_IOS.h; sourceTree = "<group>"; };
 		84FEA9EF2BC9913300111EE2 /* StickyBucketService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickyBucketService.swift; sourceTree = "<group>"; };
-		84A1B2C3D4E5F6A7B8C9D0E1F3 /* ContextManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextManager.swift; sourceTree = "<group>"; };
-		84B2C3D4E5F6A7B8C9D0E1F2A4 /* GlobalConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalConfig.swift; sourceTree = "<group>"; };
-		84C3D4E5F6A7B8C9D0E1F2A3B5 /* EvaluationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,6 +194,7 @@
 				84095C83281812EA00ADDF19 /* LoggingManager */,
 				84095C762817EA6400ADDF19 /* JsonManager */,
 				843363F627F845EB0072BFDC /* GrowthBookSDK.swift */,
+				15147AEE2F7E746300FC9112 /* GrowthBookModel.swift */,
 				84A1B2C3D4E5F6A7B8C9D0E1F3 /* ContextManager.swift */,
 				843363F727F845EB0072BFDC /* Network */,
 				843363F927F845EB0072BFDC /* Features */,
@@ -512,6 +515,7 @@
 				84CDE3422812F454008B3E6F /* Experiment.swift in Sources */,
 				849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */,
 				84CDE3432812F454008B3E6F /* Context.swift in Sources */,
+				15147AEF2F7E746400FC9112 /* GrowthBookModel.swift in Sources */,
 				84A1B2C3D4E5F6A7B8C9D0E1F2 /* ContextManager.swift in Sources */,
 				84B2C3D4E5F6A7B8C9D0E1F2A3 /* GlobalConfig.swift in Sources */,
 				84C3D4E5F6A7B8C9D0E1F2A3B4 /* EvaluationData.swift in Sources */,

--- a/Sources/CommonMain/GrowthBookModel.swift
+++ b/Sources/CommonMain/GrowthBookModel.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public struct GrowthBookModel {
+    /// API Host.
+    public var apiHost: String?
+    /// Streaming Host.
+    public var streamingHost: String?
+    /// Growthbook client key.
+    public var clientKey: String?
+    /// Encryption key.
+    public var encryptionKey: String?
+    /// Features.
+    public var features: Data?
+    /// Attributes used for evaluation.
+    public var attributes: JSON
+    /// Tracking closure that will be called when an experiment evaluation is completed.
+    public var trackingClosure: TrackingCallback
+    /// Log level.
+    public var logLevel: Level = .info
+    /// If `true`, the SDK will be in QA mode.
+    public var isQaMode: Bool = false
+    /// If `true`, the SDK will be enabled.
+    public var isEnabled: Bool = true
+    /// Forced experiment **variations**.
+    public var forcedVariations: JSON?
+    /// Cache directory.
+    public var cacheDirectory: CacheDirectory = .applicationSupport
+    /// Sticky bucket service.
+    public var stickyBucketService: StickyBucketServiceProtocol?
+    /// If `true`, the SDK will sync features in the background with the `streamingHost` via SSE.
+    public var backgroundSync: Bool
+    /// If `true`, features fetched remotely are cached but not applied to the running SDK.
+    public var stableSession: Bool = false
+    /// If `true`, the SDK will use remote features evaluation.
+    public var remoteEval: Bool
+    /// Additional API request headers.
+    public var apiRequestHeaders: [String: String]? = nil
+    /// Additional streaming host request headers.
+    public var streamingHostRequestHeaders: [String: String]? = nil
+    /// Forced feature **values**.
+    public var forcedFeatureValues: JSON?
+
+    /// Initialize GrowthBookModel.
+    ///
+    /// - Parameters:
+    ///   - apiHost: API Host.
+    ///   - streamingHost: Streaming Host.
+    ///   - clientKey: Growthbook client key.
+    ///   - encryptionKey: Encryption key.
+    ///   - features: Features.
+    ///   - attributes: Attributes used for evaluation.
+    ///   - trackingClosure: Tracking closure that will be called when an experiment evaluation is completed.
+    ///   - logLevel: Log Level.
+    ///   - isQaMode: If `true`, the SDK will be in QA mode.
+    ///   - isEnabled: If `true`, the SDK will be enabled.
+    ///   - forcedVariations: Forced experiment **variations**.
+    ///   - cacheDirectory: Cache directory.
+    ///   - stickyBucketService: Sticky Bucket service.
+    ///   - backgroundSync: If `true`, the SDK will sync features in the background with the `streamingHost` via SSE.
+    ///   - stableSession: If `true`, features fetched remotely are cached but not applied to the running SDK.
+    ///   - remoteEval: If `true`, the SDK will use remote features evaluation.
+    ///   - apiRequestHeaders: Additional API request headers.
+    ///   - streamingHostRequestHeaders: Additional streaming host request headers.
+    ///   - forcedFeatureValues: Forced feature **values**.
+    public init(
+        apiHost: String? = nil,
+        streamingHost: String? = nil,
+        clientKey: String? = nil,
+        encryptionKey: String? = nil,
+        features: Data? = nil,
+        attributes: JSON = [:],
+        trackingClosure: @escaping TrackingCallback = { _, _ in },
+        logLevel: Level = .info,
+        isQaMode: Bool = false,
+        isEnabled: Bool = true,
+        forcedVariations: JSON? = nil,
+        cacheDirectory: CacheDirectory = .applicationSupport,
+        stickyBucketService: StickyBucketServiceProtocol? = nil,
+        backgroundSync: Bool = false,
+        stableSession: Bool = false,
+        remoteEval: Bool = false,
+        apiRequestHeaders: [String: String]? = nil,
+        streamingHostRequestHeaders: [String: String]? = nil,
+        forcedFeatureValues: JSON? = nil
+    ) {
+        self.apiHost = apiHost
+        self.streamingHost = streamingHost
+        self.clientKey = clientKey
+        self.encryptionKey = encryptionKey
+        self.features = features
+        self.attributes = attributes
+        self.trackingClosure = trackingClosure
+        self.logLevel = logLevel
+        self.isQaMode = isQaMode
+        self.isEnabled = isEnabled
+        self.forcedVariations = forcedVariations
+        self.cacheDirectory = cacheDirectory
+        self.stickyBucketService = stickyBucketService
+        self.backgroundSync = backgroundSync
+        self.stableSession = stableSession
+        self.remoteEval = remoteEval
+        self.apiRequestHeaders = apiRequestHeaders
+        self.streamingHostRequestHeaders = streamingHostRequestHeaders
+        self.forcedFeatureValues = forcedFeatureValues
+    }
+}

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -10,28 +10,6 @@ protocol GrowthBookProtocol: AnyObject {
     func initializer() -> GrowthBookSDK
 }
 
-public struct GrowthBookModel {
-    var apiHost: String?
-    var streamingHost: String?
-    var clientKey: String?
-    var encryptionKey: String?
-    var features: Data?
-    var attributes: JSON
-    var trackingClosure: TrackingCallback
-    var logLevel: Level = .info
-    var isQaMode: Bool = false
-    var isEnabled: Bool = true
-    var forcedVariations: JSON?
-    var cacheDirectory: CacheDirectory = .applicationSupport
-    var stickyBucketService: StickyBucketServiceProtocol?
-    var backgroundSync: Bool
-    var stableSession: Bool = false
-    var remoteEval: Bool
-    var apiRequestHeaders: [String: String]? = nil
-    var streamingHostRequestHeaders: [String: String]? = nil
-    var forcedFeatureValues: JSON?
-}
-
 /// GrowthBookBuilder - inItializer for GrowthBook SDK for Apps
 /// - HostURL - Server URL
 /// - EncryptionKey - Key for decrypting encrypted feature from API
@@ -44,6 +22,43 @@ public struct GrowthBookModel {
     private var networkDispatcher: NetworkProtocol = CoreNetworkClient()
     private var cachingManager: CachingLayer
     private var ttlSeconds: Int
+
+    @nonobjc public init(
+        growthBookBuilderModel: GrowthBookModel,
+        networkDispatcher: NetworkProtocol,
+        ttlSeconds: Int = 60,
+        cachingManager: CachingLayer,
+        refreshHandler: CacheRefreshHandler? = nil) {
+
+        self.growthBookBuilderModel = growthBookBuilderModel
+        self.refreshHandler = refreshHandler
+        self.networkDispatcher = networkDispatcher
+        self.cachingManager = cachingManager
+        self.ttlSeconds = ttlSeconds
+
+        super.init()
+    }
+
+    @nonobjc public convenience init(
+        growthBookBuilderModel: GrowthBookModel,
+        apiRequestHeaders: [String: String] = [:],
+        streamingHostRequestHeaders: [String: String] = [:],
+        ttlSeconds: Int = 60,
+        refreshHandler: CacheRefreshHandler? = nil,
+        cachingManager: CachingLayer) {
+
+        let networkDispatcher = CoreNetworkClient(
+            apiRequestHeaders: apiRequestHeaders,
+            streamingHostRequestHeaders: streamingHostRequestHeaders
+        )
+        self.init(
+            growthBookBuilderModel: growthBookBuilderModel,
+            networkDispatcher: networkDispatcher,
+            ttlSeconds: ttlSeconds,
+            cachingManager: cachingManager,
+            refreshHandler: refreshHandler
+        )
+    }
 
     @objc public init(
         apiHost: String? = nil,


### PR DESCRIPTION
* Extract GrowthBookModel struct into a dedicated file 
* Make GrowthBookModel initializer public to allow external instantiation
* Add new **`@nonobjc`** public initializers to GrowthBookBuilder that accept a GrowthBookModel instance, providing extended dependency injection options.