### PR TITLE
Fix/multirange namespace decode

### DIFF
--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -137,6 +137,32 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertFalse(hasFeatures)
     }
 
+    /// Regression test: payloads that include `filters` with array-encoded `ranges`
+    /// (e.g. `[[0, 0.75]]`) were causing a full decode failure because BucketRange's
+    /// synthesised Codable expected a keyed object, not a bare `[Float, Float]` array.
+    func testSuccessWithFiltersPayload() throws {
+        isSuccess = false
+        isError = true
+
+        let viewModel = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(
+                dispatcher: MockNetworkClient(
+                    successResponse: MockResponse().successResponseWithFilters,
+                    error: nil
+                )
+            ),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+
+        viewModel.fetchFeatures(apiUrl: "")
+
+        XCTAssertTrue(isSuccess, "Expected successful feature fetch with filters payload")
+        XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
+    }
+
     func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {
         isSuccess = true
         isError = false

--- a/GrowthBookTests/MockNetworkClient.swift
+++ b/GrowthBookTests/MockNetworkClient.swift
@@ -199,6 +199,55 @@ class MockResponse {
     }
     """.trimmingCharacters(in: .whitespaces)
     
+    /// Reproduces the payload shape reported by users after multiRange namespace support
+    /// was introduced: feature rules may now carry a `filters` array whose `ranges` items
+    /// are bare JSON arrays `[start, end]` rather than keyed objects.
+    let successResponseWithFilters = """
+    {
+        "status": 200,
+        "features": {
+            "experiment_feature": {
+                "defaultValue": "control",
+                "rules": [
+                    {
+                        "condition": {
+                            "lang": "en"
+                        },
+                        "coverage": 1,
+                        "hashAttribute": "id",
+                        "bucketVersion": 1,
+                        "filters": [
+                            {
+                                "attribute": "id",
+                                "seed": "04a30ae4-80d2-42e5-a9b2-9dea31b6d174",
+                                "hashVersion": 2,
+                                "ranges": [
+                                    [0, 0.75]
+                                ]
+                            }
+                        ],
+                        "seed": "42ace165-6b06-4404-8f98-3f115789d44e",
+                        "hashVersion": 2,
+                        "variations": ["control", "variant"],
+                        "weights": [0.5, 0.5],
+                        "key": "experiment_feature",
+                        "meta": [
+                            {"key": "0", "name": "Control"},
+                            {"key": "1", "name": "Variant"}
+                        ],
+                        "phase": "1",
+                        "name": "Experiment with multiRange filters"
+                    }
+                ]
+            },
+            "simple_feature": {
+                "defaultValue": false
+            }
+        },
+        "savedGroups": {}
+    }
+    """.trimmingCharacters(in: .whitespaces)
+
     let successResponseEncryptedFeatures = """
         {
             "status":200,

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -524,7 +524,7 @@ public struct GrowthBookModel {
 
     @objc public func featuresFetchFailed(error: SDKError, isRemote: Bool) {
         if isRemote {
-            refreshHandler?(.failedToFetchData)
+            refreshHandler?(error)
         }
     }
 
@@ -533,7 +533,7 @@ public struct GrowthBookModel {
     }
 
     @objc public func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {
-        refreshHandler?(.failedToFetchData)
+        refreshHandler?(error)
     }
 
     public func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -63,6 +63,20 @@ public struct BucketRange: Codable {
             self.number2 = json.arrayValue[1].floatValue
         }
     }
+
+    /// The wire format is a two-element JSON array `[start, end]`, e.g. `[0, 0.75]`.
+    /// Swift's synthesised Codable would look for keyed fields, so we implement manually.
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        number1 = try container.decode(Float.self)
+        number2 = try container.decode(Float.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(number1)
+        try container.encode(number2)
+    }
 }
 
 public enum SDKErrorCode: String {


### PR DESCRIPTION
## Changes

1.  BucketRange custom `Codable` - root cause: Swift's synthesized Decodable for BucketRange looked for a keyed object {"number1": 0, "number2": 0.75}
2. `refreshHandler` will receive the actual error code instead of swallowing it in the SDK. 