### PR TITLE
fix: restore savedGroups from cache on app restart

### DIFF
--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -112,6 +112,32 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertFalse(isError)
     }
     
+    func testSavedGroupsRestoredFromCacheOnRestart() throws {
+        // Simulate first launch: fetch from network, savedGroups written to cache
+        let firstVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        firstVM.fetchFeatures(apiUrl: "")
+        XCTAssertTrue(isSuccess)
+
+        // Simulate app restart: new VM reads only from cache, no network
+        var savedGroupsFromCache: JSON? = nil
+        let captureDelegate = SavedGroupsCapture { savedGroupsFromCache = $0 }
+        let restartVM = FeaturesViewModel(
+            delegate: captureDelegate,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: SDKError.failedToLoadData)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        _ = restartVM
+
+        XCTAssertNotNil(savedGroupsFromCache, "savedGroups should be restored from cache on restart")
+        XCTAssertFalse(savedGroupsFromCache?.dictionaryValue.isEmpty ?? true, "savedGroups should not be empty")
+    }
+
     func test304NotModifiedTreatedAsSuccess() throws {
         // First fetch to populate cache
         let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)), cachingManager: cachingManager, ttlSeconds: ttlSeconds)
@@ -203,6 +229,22 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     }
     
     func featuresAPIModelSuccessfully(model: FeaturesDataModel) {
-        
+
+    }
+}
+
+private class SavedGroupsCapture: FeaturesFlowDelegate {
+    private let onSavedGroups: (JSON) -> Void
+
+    init(_ onSavedGroups: @escaping (JSON) -> Void) {
+        self.onSavedGroups = onSavedGroups
+    }
+
+    func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {}
+    func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+    func featuresFetchFailed(error: SDKError, isRemote: Bool) {}
+    func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
+        onSavedGroups(savedGroups)
     }
 }

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -94,6 +94,17 @@ class FeaturesViewModel {
             delegate?.featuresFetchFailed(error: .failedToLoadData, isRemote: isRemote)
             if logging { logger.info("Cache directory is empty. Nothing to fetch.") }
         }
+
+        if let savedGroupsData = manager.getContent(fileName: Constants.savedGroupsCache) {
+            if let encryptionKey, !encryptionKey.isEmpty {
+                if let encryptedString = String(data: savedGroupsData, encoding: .utf8),
+                   let savedGroups = Crypto().getSavedGroupsFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) {
+                    delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: isRemote)
+                }
+            } else if let savedGroups = try? JSONDecoder().decode(JSON.self, from: savedGroupsData) {
+                delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: isRemote)
+            }
+        }
     }
     
     


### PR DESCRIPTION
## Summary      
  - `fetchCachedFeatures` loaded features from disk cache on app restart but silently                                                                   
    ignored the `SavedGroupsCache` file, leaving `savedGroups` as `nil` until the
    first API response arrived                                                                                                                          
  - During this window, rules using `$notInGroup` evaluated to `true` for all users,
    causing force rules to apply globally regardless of group membership                                                                                
  - Fixed by also reading `savedGroups` from cache in `fetchCachedFeatures` (handles                                                                    
    both encrypted and non-encrypted formats)
  - Added regression test that simulates app restart and verifies `savedGroups` are                                                                     
    restored from cache without a network call   