### PR TITLE
feature/increase test coverage

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		8433160D2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */; };
 		8433160E2FA2B6AD00D1C388 /* ConstantsAndModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */; };
 		843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */; };
+		843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -116,6 +117,7 @@
 		8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
 		8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsStickyBucketTests.swift; sourceTree = "<group>"; };
 		8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluatorTests.swift; sourceTree = "<group>"; };
+		843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluatorTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -310,6 +312,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
 				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
 				8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */,
@@ -504,6 +507,7 @@
 				849114CA280DA73100C0B9A5 /* FeatureValueTests.swift in Sources */,
 				848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */,
 				843315FD2FA22A1B00D1C388 /* UtilsExtendedTests.swift in Sources */,
+				843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */,
 				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
 				8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */; };
 		843316142FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */; };
 		843316162FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */; };
+		843316182FA3FD1800D1C388 /* MiscCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -122,6 +123,7 @@
 		843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesViewModelExtendedTests.swift; sourceTree = "<group>"; };
+		843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscCoverageTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */,
 				843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */,
 				843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */,
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
@@ -514,6 +517,7 @@
 				849114CA280DA73100C0B9A5 /* FeatureValueTests.swift in Sources */,
 				848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */,
 				843315FD2FA22A1B00D1C388 /* UtilsExtendedTests.swift in Sources */,
+				843316182FA3FD1800D1C388 /* MiscCoverageTests.swift in Sources */,
 				843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */,
 				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */; };
 		843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */; };
 		843316142FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */; };
+		843316162FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -120,6 +121,7 @@
 		8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEvaluatorTests.swift; sourceTree = "<group>"; };
+		843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesViewModelExtendedTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */,
 				843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */,
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
@@ -504,6 +507,7 @@
 			files = (
 				849114C7280DA73000C0B9A5 /* FeaturesViewModelTests.swift in Sources */,
 				5D5EAD1F2EF1DED60049F432 /* LruETagCacheTests.swift in Sources */,
+				843316162FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift in Sources */,
 				843316062FA252B300D1C388 /* GrowthBookSDKTests.swift in Sources */,
 				849114C8280DA73000C0B9A5 /* ConditionTests.swift in Sources */,
 				849114C9280DA73000C0B9A5 /* ExperimentRunTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */; };
 		843316062FA252B300D1C388 /* GrowthBookSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */; };
 		843316082FA2704B00D1C388 /* FeatureModelInitJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316072FA2704B00D1C388 /* FeatureModelInitJsonTests.swift */; };
+		8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */; };
+		8433160D2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */; };
+		8433160E2FA2B6AD00D1C388 /* ConstantsAndModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -108,6 +111,9 @@
 		843315FC2FA22A1B00D1C388 /* UtilsExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsExtendedTests.swift; sourceTree = "<group>"; };
 		843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKTests.swift; sourceTree = "<group>"; };
 		843316072FA2704B00D1C388 /* FeatureModelInitJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureModelInitJsonTests.swift; sourceTree = "<group>"; };
+		843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsAndModelTests.swift; sourceTree = "<group>"; };
+		8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
+		8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsStickyBucketTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -302,6 +308,9 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
+				8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */,
+				8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */,
 				843316072FA2704B00D1C388 /* FeatureModelInitJsonTests.swift */,
 				843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */,
 				843315F82FA22A1B00D1C388 /* CommonTests.swift */,
@@ -494,6 +503,9 @@
 				843315FD2FA22A1B00D1C388 /* UtilsExtendedTests.swift in Sources */,
 				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
+				8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */,
+				8433160D2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift in Sources */,
+				8433160E2FA2B6AD00D1C388 /* ConstantsAndModelTests.swift in Sources */,
 				843316002FA22A1B00D1C388 /* StickyBucketServiceTests.swift in Sources */,
 				843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */,
 				843316082FA2704B00D1C388 /* FeatureModelInitJsonTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */; };
 		8433160D2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */; };
 		8433160E2FA2B6AD00D1C388 /* ConstantsAndModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */; };
+		843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -114,6 +115,7 @@
 		843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsAndModelTests.swift; sourceTree = "<group>"; };
 		8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
 		8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsStickyBucketTests.swift; sourceTree = "<group>"; };
+		8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluatorTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
 				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
 				8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */,
 				8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */,
@@ -513,6 +516,7 @@
 				849114CC280DA73100C0B9A5 /* UtilsTests.swift in Sources */,
 				84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */,
 				849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */,
+				843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
 			);

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8433160E2FA2B6AD00D1C388 /* ConstantsAndModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */; };
 		843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */; };
 		843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */; };
+		843316142FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -118,6 +119,7 @@
 		8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsStickyBucketTests.swift; sourceTree = "<group>"; };
 		8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluatorTests.swift; sourceTree = "<group>"; };
+		843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEvaluatorTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */,
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
 				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
@@ -519,6 +522,7 @@
 				849114CB280DA73100C0B9A5 /* TestHelper.swift in Sources */,
 				849114CC280DA73100C0B9A5 /* UtilsTests.swift in Sources */,
 				84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */,
+				843316142FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift in Sources */,
 				849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */,
 				843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		84095C902818245700ADDF19 /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C8E2818245100ADDF19 /* Formatter.swift */; };
 		84095C932818254400ADDF19 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C91281824DB00ADDF19 /* Theme.swift */; };
 		840E386F2B88BD75003DFC9F /* ExperimentHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 840E386E2B88BD75003DFC9F /* ExperimentHelper.swift */; };
+		843315FD2FA22A1B00D1C388 /* UtilsExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315FC2FA22A1B00D1C388 /* UtilsExtendedTests.swift */; };
+		843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315FA2FA22A1B00D1C388 /* FeatureModelTests.swift */; };
+		843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315F82FA22A1B00D1C388 /* CommonTests.swift */; };
+		843316002FA22A1B00D1C388 /* StickyBucketServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */; };
+		843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -94,6 +99,11 @@
 		84095C8E2818245100ADDF19 /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		84095C91281824DB00ADDF19 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		840E386E2B88BD75003DFC9F /* ExperimentHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentHelper.swift; sourceTree = "<group>"; };
+		843315F82FA22A1B00D1C388 /* CommonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTests.swift; sourceTree = "<group>"; };
+		843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptionUtilsTests.swift; sourceTree = "<group>"; };
+		843315FA2FA22A1B00D1C388 /* FeatureModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureModelTests.swift; sourceTree = "<group>"; };
+		843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyBucketServiceTests.swift; sourceTree = "<group>"; };
+		843315FC2FA22A1B00D1C388 /* UtilsExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsExtendedTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -288,6 +298,11 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843315F82FA22A1B00D1C388 /* CommonTests.swift */,
+				843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */,
+				843315FA2FA22A1B00D1C388 /* FeatureModelTests.swift */,
+				843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */,
+				843315FC2FA22A1B00D1C388 /* UtilsExtendedTests.swift */,
 				5D5EAD1E2EF1DED60049F432 /* LruETagCacheTests.swift */,
 				84391F2528016C5C003309DC /* Source */,
 				84391F0827FD64EB003309DC /* FeaturesViewModelTests.swift */,
@@ -469,6 +484,11 @@
 				849114C9280DA73000C0B9A5 /* ExperimentRunTests.swift in Sources */,
 				849114CA280DA73100C0B9A5 /* FeatureValueTests.swift in Sources */,
 				848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */,
+				843315FD2FA22A1B00D1C388 /* UtilsExtendedTests.swift in Sources */,
+				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
+				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
+				843316002FA22A1B00D1C388 /* StickyBucketServiceTests.swift in Sources */,
+				843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */,
 				849114CB280DA73100C0B9A5 /* TestHelper.swift in Sources */,
 				849114CC280DA73100C0B9A5 /* UtilsTests.swift in Sources */,
 				84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		843316002FA22A1B00D1C388 /* StickyBucketServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */; };
 		843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */; };
 		843316062FA252B300D1C388 /* GrowthBookSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */; };
+		843316082FA2704B00D1C388 /* FeatureModelInitJsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316072FA2704B00D1C388 /* FeatureModelInitJsonTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -106,6 +107,7 @@
 		843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyBucketServiceTests.swift; sourceTree = "<group>"; };
 		843315FC2FA22A1B00D1C388 /* UtilsExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsExtendedTests.swift; sourceTree = "<group>"; };
 		843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKTests.swift; sourceTree = "<group>"; };
+		843316072FA2704B00D1C388 /* FeatureModelInitJsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureModelInitJsonTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316072FA2704B00D1C388 /* FeatureModelInitJsonTests.swift */,
 				843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */,
 				843315F82FA22A1B00D1C388 /* CommonTests.swift */,
 				843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */,
@@ -493,6 +496,7 @@
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
 				843316002FA22A1B00D1C388 /* StickyBucketServiceTests.swift in Sources */,
 				843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */,
+				843316082FA2704B00D1C388 /* FeatureModelInitJsonTests.swift in Sources */,
 				849114CB280DA73100C0B9A5 /* TestHelper.swift in Sources */,
 				849114CC280DA73100C0B9A5 /* UtilsTests.swift in Sources */,
 				84E82C3D2BD2AF8F003F000B /* StickyBucketingTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315F82FA22A1B00D1C388 /* CommonTests.swift */; };
 		843316002FA22A1B00D1C388 /* StickyBucketServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */; };
 		843316012FA22A1B00D1C388 /* DecryptionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */; };
+		843316062FA252B300D1C388 /* GrowthBookSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
@@ -104,6 +105,7 @@
 		843315FA2FA22A1B00D1C388 /* FeatureModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureModelTests.swift; sourceTree = "<group>"; };
 		843315FB2FA22A1B00D1C388 /* StickyBucketServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyBucketServiceTests.swift; sourceTree = "<group>"; };
 		843315FC2FA22A1B00D1C388 /* UtilsExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsExtendedTests.swift; sourceTree = "<group>"; };
+		843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		843363FA27F845EB0072BFDC /* FeaturesDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesDataModel.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 		849114BE280DA71E00C0B9A5 /* GrowthBookTests */ = {
 			isa = PBXGroup;
 			children = (
+				843316052FA252B300D1C388 /* GrowthBookSDKTests.swift */,
 				843315F82FA22A1B00D1C388 /* CommonTests.swift */,
 				843315F92FA22A1B00D1C388 /* DecryptionUtilsTests.swift */,
 				843315FA2FA22A1B00D1C388 /* FeatureModelTests.swift */,
@@ -480,6 +483,7 @@
 			files = (
 				849114C7280DA73000C0B9A5 /* FeaturesViewModelTests.swift in Sources */,
 				5D5EAD1F2EF1DED60049F432 /* LruETagCacheTests.swift in Sources */,
+				843316062FA252B300D1C388 /* GrowthBookSDKTests.swift in Sources */,
 				849114C8280DA73000C0B9A5 /* ConditionTests.swift in Sources */,
 				849114C9280DA73000C0B9A5 /* ExperimentRunTests.swift in Sources */,
 				849114CA280DA73100C0B9A5 /* FeatureValueTests.swift in Sources */,

--- a/GrowthBookTests/CommonTests.swift
+++ b/GrowthBookTests/CommonTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+@testable import GrowthBook
+
+class CommonTests: XCTestCase {
+
+    // MARK: - fnv1 / fnv1a
+
+    func testFnv1aProducesKnownHash() {
+        // FNV-1a of empty string with 32-bit basis
+        let result = Common.fnv1a([UInt8](), offsetBasis: Common.offsetBasis32, prime: Common.prime32)
+        XCTAssertEqual(result, Common.offsetBasis32, "FNV-1a of empty input equals the offset basis")
+    }
+
+    func testFnv1ProducesKnownHash() {
+        let result = Common.fnv1([UInt8](), offsetBasis: Common.offsetBasis32, prime: Common.prime32)
+        XCTAssertEqual(result, Common.offsetBasis32)
+    }
+
+    func testFnv1aIsDifferentFromFnv1ForSameInput() {
+        let bytes: [UInt8] = Array("hello".utf8)
+        let fnv1result  = Common.fnv1(bytes,  offsetBasis: Common.offsetBasis32, prime: Common.prime32)
+        let fnv1aResult = Common.fnv1a(bytes, offsetBasis: Common.offsetBasis32, prime: Common.prime32)
+        XCTAssertNotEqual(fnv1result, fnv1aResult)
+    }
+
+    func testFnv1aIsDeterministic() {
+        let bytes: [UInt8] = Array("deterministic".utf8)
+        let first  = Common.fnv1a(bytes, offsetBasis: Common.offsetBasis32, prime: Common.prime32)
+        let second = Common.fnv1a(bytes, offsetBasis: Common.offsetBasis32, prime: Common.prime32)
+        XCTAssertEqual(first, second)
+    }
+
+    func testFnv1a64BitProducesLargerValue() {
+        let bytes: [UInt8] = Array("test".utf8)
+        let result64: UInt64 = Common.fnv1a(bytes, offsetBasis: Common.offsetBasis64, prime: Common.prime64)
+        XCTAssertGreaterThan(result64, 0)
+    }
+
+    // MARK: - isEqual
+
+    func testIsEqualStrings() {
+        XCTAssertTrue(Common.isEqual("hello", "hello"))
+        XCTAssertFalse(Common.isEqual("hello", "world"))
+    }
+
+    func testIsEqualInts() {
+        XCTAssertTrue(Common.isEqual(42, 42))
+        XCTAssertFalse(Common.isEqual(1, 2))
+    }
+
+    // MARK: - isIn (case-sensitive)
+
+    func testIsInStringFound() {
+        XCTAssertTrue(Common.isIn(actual: "b", expected: ["a", "b", "c"]))
+    }
+
+    func testIsInStringNotFound() {
+        XCTAssertFalse(Common.isIn(actual: "z", expected: ["a", "b", "c"]))
+    }
+
+    func testIsInIntFound() {
+        XCTAssertTrue(Common.isIn(actual: 2, expected: [1, 2, 3]))
+    }
+
+    func testIsInIntNotFound() {
+        XCTAssertFalse(Common.isIn(actual: 99, expected: [1, 2, 3]))
+    }
+
+    func testIsInArrayActualOverlapsExpected() {
+        XCTAssertTrue(Common.isIn(actual: ["x", "b"], expected: ["a", "b", "c"]))
+    }
+
+    func testIsInArrayActualNoOverlap() {
+        XCTAssertFalse(Common.isIn(actual: ["x", "y"], expected: ["a", "b", "c"]))
+    }
+
+    func testIsInJSONStringFound() {
+        let jsonExpected: [JSON] = [JSON("alpha"), JSON("beta"), JSON("gamma")]
+        XCTAssertTrue(Common.isIn(actual: JSON("beta"), expected: jsonExpected))
+    }
+
+    func testIsInJSONStringNotFound() {
+        let jsonExpected: [JSON] = [JSON("alpha"), JSON("beta")]
+        XCTAssertFalse(Common.isIn(actual: JSON("delta"), expected: jsonExpected))
+    }
+
+    func testIsInJSONArrayActualOverlaps() {
+        let jsonExpected: [JSON] = [JSON("a"), JSON("b"), JSON("c")]
+        let actual = JSON(["b", "x"])
+        XCTAssertTrue(Common.isIn(actual: actual, expected: jsonExpected))
+    }
+
+    // MARK: - isIn (case-insensitive)
+
+    func testIsInCaseInsensitiveStringMatch() {
+        let expected: [JSON] = [JSON("hello"), JSON("world")]
+        XCTAssertTrue(Common.isIn(actual: JSON("HELLO"), expected: expected, insensitive: true))
+    }
+
+    func testIsInCaseInsensitiveStringNoMatch() {
+        let expected: [JSON] = [JSON("hello"), JSON("world")]
+        XCTAssertFalse(Common.isIn(actual: JSON("foo"), expected: expected, insensitive: true))
+    }
+
+    func testIsInCaseInsensitivePlainStringActual() {
+        let expected: [JSON] = [JSON("Apple"), JSON("Banana")]
+        XCTAssertTrue(Common.isIn(actual: "APPLE", expected: expected, insensitive: true))
+    }
+
+    func testIsInCaseInsensitiveJSONArrayActual() {
+        let expected: [JSON] = [JSON("Cat"), JSON("Dog")]
+        let actual = JSON(["cat", "fish"])
+        XCTAssertTrue(Common.isIn(actual: actual, expected: expected, insensitive: true))
+    }
+
+    func testIsInCaseInsensitiveJSONArrayNoMatch() {
+        let expected: [JSON] = [JSON("Cat"), JSON("Dog")]
+        let actual = JSON(["fish", "bird"])
+        XCTAssertFalse(Common.isIn(actual: actual, expected: expected, insensitive: true))
+    }
+
+    // MARK: - isInAll
+
+    func testIsInAllEveryExpectedItemMatchesSomething() {
+        let actual = JSON(["a", "b", "c"])
+        let expected: [JSON] = [JSON("a"), JSON("b")]
+        let result = Common.isInAll(actual: actual, expected: expected, savedGroups: nil, insensitive: false) { _, _, _ in true }
+        XCTAssertTrue(result)
+    }
+
+    func testIsInAllReturnsFalseWhenOneExpectedItemHasNoMatch() {
+        let actual = JSON(["a"])
+        let expected: [JSON] = [JSON("a"), JSON("b")]
+        let result = Common.isInAll(actual: actual, expected: expected, savedGroups: nil, insensitive: false) { expectedItem, actualItem, _ in
+            expectedItem == actualItem
+        }
+        XCTAssertFalse(result)
+    }
+
+    func testIsInAllReturnsFalseForNonArray() {
+        let actual = JSON("not-an-array")
+        let expected: [JSON] = [JSON("anything")]
+        let result = Common.isInAll(actual: actual, expected: expected, savedGroups: nil, insensitive: false) { _, _, _ in true }
+        XCTAssertFalse(result)
+    }
+
+    func testIsInAllReturnsTrueForEmptyExpected() {
+        let actual = JSON(["a", "b"])
+        let result = Common.isInAll(actual: actual, expected: [], savedGroups: nil, insensitive: false) { _, _, _ in false }
+        XCTAssertTrue(result)
+    }
+}

--- a/GrowthBookTests/ConditionEvaluatorTests.swift
+++ b/GrowthBookTests/ConditionEvaluatorTests.swift
@@ -1,0 +1,379 @@
+import XCTest
+@testable import GrowthBook
+
+class ConditionEvaluatorTests: XCTestCase {
+
+    private let eval = ConditionEvaluator()
+
+    // MARK: - getAttributeType
+
+    func testGetAttributeTypeCoversAllIndices() {
+        XCTAssertEqual(getAttributeType(index: 0), "number")
+        XCTAssertEqual(getAttributeType(index: 1), "string")
+        XCTAssertEqual(getAttributeType(index: 2), "boolean")
+        XCTAssertEqual(getAttributeType(index: 3), "array")
+        XCTAssertEqual(getAttributeType(index: 4), "object")
+        XCTAssertEqual(getAttributeType(index: 5), "null")
+        XCTAssertEqual(getAttributeType(index: 6), "unknown")
+        XCTAssertEqual(getAttributeType(index: 99), "unknown")
+    }
+
+    // MARK: - isEvalCondition: $nor / $not
+
+    func testEvalConditionNorFalseWhenAllMatch() {
+        let attrs = JSON(["x": 1])
+        let cond = JSON(["$nor": [["x": 1]]])
+        XCTAssertFalse(eval.isEvalCondition(attributes: attrs, conditionObj: cond))
+    }
+
+    func testEvalConditionNorTrueWhenNoneMatch() {
+        let attrs = JSON(["x": 2])
+        let cond = JSON(["$nor": [["x": 1]]])
+        XCTAssertTrue(eval.isEvalCondition(attributes: attrs, conditionObj: cond))
+    }
+
+    func testEvalConditionNotTrueWhenInnerFails() {
+        let attrs = JSON(["x": 2])
+        let cond = JSON(["$not": ["x": 1]])
+        XCTAssertTrue(eval.isEvalCondition(attributes: attrs, conditionObj: cond))
+    }
+
+    func testEvalConditionNotFalseWhenInnerMatches() {
+        let attrs = JSON(["x": 1])
+        let cond = JSON(["$not": ["x": 1]])
+        XCTAssertFalse(eval.isEvalCondition(attributes: attrs, conditionObj: cond))
+    }
+
+    // MARK: - isEvalOr: empty array
+
+    func testEvalOrEmptyArrayReturnsTrue() {
+        XCTAssertTrue(eval.isEvalOr(attributes: JSON([:]), conditionObjs: [], savedGroups: nil))
+    }
+
+    // MARK: - getPath
+
+    func testGetPathDotNotation() {
+        let attrs = JSON(["user": ["id": "abc"]])
+        let result = eval.getPath(obj: attrs, key: "user.id")
+        XCTAssertEqual(result?.stringValue, "abc")
+    }
+
+    func testGetPathDotNotationMissing() {
+        let attrs = JSON(["user": ["id": "abc"]])
+        XCTAssertNil(eval.getPath(obj: attrs, key: "user.name"))
+    }
+
+    func testGetPathWhenIntermediateIsArray() {
+        let attrs = JSON(["items": [1, 2, 3]])
+        XCTAssertNil(eval.getPath(obj: attrs, key: "items.0"))
+    }
+
+    func testGetPathSimpleKey() {
+        let attrs = JSON(["country": "UA"])
+        XCTAssertEqual(eval.getPath(obj: attrs, key: "country")?.stringValue, "UA")
+    }
+
+    // MARK: - isEvalConditionValue: primitives and null
+
+    func testEvalConditionValueNullCondWithNilAttr() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON.null, attributeValue: nil))
+    }
+
+    func testEvalConditionValueNullCondWithNullAttr() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON.null, attributeValue: JSON.null))
+    }
+
+    func testEvalConditionValueNullCondWithNonNullAttr() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON.null, attributeValue: JSON("value")))
+    }
+
+    func testEvalConditionValueStringMatch() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON("en"), attributeValue: JSON("en")))
+    }
+
+    func testEvalConditionValueStringMismatch() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON("en"), attributeValue: JSON("de")))
+    }
+
+    func testEvalConditionValueNumberMatch() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON(42), attributeValue: JSON(42)))
+    }
+
+    func testEvalConditionValueNumberMismatch() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON(42), attributeValue: JSON(43)))
+    }
+
+    func testEvalConditionValueBoolMatch() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON(true), attributeValue: JSON(true)))
+    }
+
+    func testEvalConditionValueBoolMismatch() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON(true), attributeValue: JSON(false)))
+    }
+
+    func testEvalConditionValueInsensitiveMatch() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON("Hello"), attributeValue: JSON("hello"), insensitive: true))
+    }
+
+    func testEvalConditionValueInsensitiveMismatch() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON("Hello"), attributeValue: JSON("world"), insensitive: true))
+    }
+
+    // MARK: - isEvalConditionValue: array deep equality
+
+    func testEvalConditionValueArrayEqual() {
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: JSON([1, 2]), attributeValue: JSON([1, 2])))
+    }
+
+    func testEvalConditionValueArrayCountMismatch() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON([1, 2, 3]), attributeValue: JSON([1, 2])))
+    }
+
+    func testEvalConditionValueArrayNotArray() {
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: JSON([1, 2]), attributeValue: JSON("not-array")))
+    }
+
+    // MARK: - isEvalConditionValue: object comparison
+
+    func testEvalConditionValueNonOperatorObjectDeepEqual() {
+        let cond = JSON(["a": 1, "b": 2])
+        let attr = JSON(["a": 1, "b": 2])
+        XCTAssertTrue(eval.isEvalConditionValue(conditionValue: cond, attributeValue: attr))
+    }
+
+    func testEvalConditionValueNonOperatorObjectVsNonObject() {
+        let cond = JSON(["a": 1])
+        XCTAssertFalse(eval.isEvalConditionValue(conditionValue: cond, attributeValue: JSON("string")))
+    }
+
+    // MARK: - isElemMatch
+
+    func testElemMatchWithOperatorCondition() {
+        let items: [JSON] = [JSON(1), JSON(2), JSON(3)]
+        let condition = JSON(["$gt": 2])
+        XCTAssertTrue(eval.isElemMatch(attributeValue: items, condition: condition, savedGroups: nil))
+    }
+
+    func testElemMatchWithObjectCondition() {
+        let items: [JSON] = [JSON(["x": 1]), JSON(["x": 2])]
+        let condition = JSON(["x": 2])
+        XCTAssertTrue(eval.isElemMatch(attributeValue: items, condition: condition, savedGroups: nil))
+    }
+
+    func testElemMatchNoMatch() {
+        let items: [JSON] = [JSON(1), JSON(2)]
+        let condition = JSON(["$gt": 10])
+        XCTAssertFalse(eval.isElemMatch(attributeValue: items, condition: condition, savedGroups: nil))
+    }
+
+    func testElemMatchEmptyArray() {
+        XCTAssertFalse(eval.isElemMatch(attributeValue: [], condition: JSON(["$gt": 0]), savedGroups: nil))
+    }
+
+    // MARK: - $type operator
+
+    func testTypeOperatorString() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$type", attributeValue: JSON("hello"), conditionValue: JSON("string")))
+    }
+
+    func testTypeOperatorNumber() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$type", attributeValue: JSON(42), conditionValue: JSON("number")))
+    }
+
+    func testTypeOperatorMismatch() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$type", attributeValue: JSON(42), conditionValue: JSON("string")))
+    }
+
+    // MARK: - $not operator
+
+    func testNotOperatorTrue() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$not", attributeValue: JSON(5), conditionValue: JSON(["$gt": 10])))
+    }
+
+    func testNotOperatorFalse() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$not", attributeValue: JSON(15), conditionValue: JSON(["$gt": 10])))
+    }
+
+    // MARK: - $eq / $ne
+
+    func testEqOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$eq", attributeValue: JSON(5), conditionValue: JSON(5)))
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$eq", attributeValue: JSON(5), conditionValue: JSON(6)))
+    }
+
+    func testNeOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$ne", attributeValue: JSON(5), conditionValue: JSON(6)))
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$ne", attributeValue: JSON(5), conditionValue: JSON(5)))
+    }
+
+    // MARK: - $lt / $lte / $gt / $gte with null attribute
+
+    func testLtWithNullAttrPositiveCond() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$lt", attributeValue: JSON.null, conditionValue: JSON(1)))
+    }
+
+    func testLtWithNullAttrNegativeCond() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$lt", attributeValue: JSON.null, conditionValue: JSON(-1)))
+    }
+
+    func testLteWithNullAttrZeroCond() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$lte", attributeValue: JSON.null, conditionValue: JSON(0)))
+    }
+
+    func testGtWithNullAttrNegativeCond() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$gt", attributeValue: JSON.null, conditionValue: JSON(-1)))
+    }
+
+    func testGtWithNullAttrPositiveCond() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$gt", attributeValue: JSON.null, conditionValue: JSON(1)))
+    }
+
+    func testGteWithNullAttrZeroCond() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$gte", attributeValue: JSON.null, conditionValue: JSON(0)))
+    }
+
+    // MARK: - $lt / $gt with string attributes
+
+    func testLtWithStrings() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$lt", attributeValue: JSON("apple"), conditionValue: JSON("banana")))
+    }
+
+    func testGtWithStrings() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$gt", attributeValue: JSON("banana"), conditionValue: JSON("apple")))
+    }
+
+    func testLtWithStringNumbers() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$lt", attributeValue: JSON("3"), conditionValue: JSON("10")))
+    }
+
+    // MARK: - $ini / $nini (case-insensitive in/nin)
+
+    func testIniOperatorCaseInsensitive() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$ini", attributeValue: JSON("Hello"), conditionValue: JSON(["hello", "world"])))
+    }
+
+    func testNiniOperatorCaseInsensitive() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$nini", attributeValue: JSON("HELLO"), conditionValue: JSON(["hello"])))
+    }
+
+    // MARK: - $all / $alli
+
+    func testAllOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$all", attributeValue: JSON(["a", "b", "c"]), conditionValue: JSON(["a", "b"])))
+    }
+
+    func testAllOperatorMissing() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$all", attributeValue: JSON(["a"]), conditionValue: JSON(["a", "b"])))
+    }
+
+    func testAlliOperatorCaseInsensitive() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$alli", attributeValue: JSON(["A", "B"]), conditionValue: JSON(["a", "b"])))
+    }
+
+    // MARK: - $elemMatch / $size
+
+    func testElemMatchOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$elemMatch", attributeValue: JSON([1, 5, 10]), conditionValue: JSON(["$gt": 4])))
+    }
+
+    func testSizeOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$size", attributeValue: JSON(["a", "b", "c"]), conditionValue: JSON(3)))
+    }
+
+    func testSizeOperatorMismatch() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$size", attributeValue: JSON(["a"]), conditionValue: JSON(3)))
+    }
+
+    // MARK: - $regex / $regexi / $notRegex / $notRegexi
+
+    func testRegexOperatorMatch() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$regex", attributeValue: JSON("hello world"), conditionValue: JSON("hel+")))
+    }
+
+    func testRegexOperatorNoMatch() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$regex", attributeValue: JSON("hello"), conditionValue: JSON("^world")))
+    }
+
+    func testRegexiCaseInsensitive() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$regexi", attributeValue: JSON("Hello"), conditionValue: JSON("hello")))
+    }
+
+    func testNotRegex() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$notRegex", attributeValue: JSON("hello"), conditionValue: JSON("^world")))
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$notRegex", attributeValue: JSON("hello"), conditionValue: JSON("hello")))
+    }
+
+    func testNotRegexi() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$notRegexi", attributeValue: JSON("Hello"), conditionValue: JSON("^world")))
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$notRegexi", attributeValue: JSON("Hello"), conditionValue: JSON("hello")))
+    }
+
+    // MARK: - Version operators
+
+    func testVeqOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$veq", attributeValue: JSON("1.0.0"), conditionValue: JSON("1.0.0")))
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$veq", attributeValue: JSON("1.0.0"), conditionValue: JSON("2.0.0")))
+    }
+
+    func testVneOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$vne", attributeValue: JSON("1.0.0"), conditionValue: JSON("2.0.0")))
+    }
+
+    func testVgtOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$vgt", attributeValue: JSON("2.0.0"), conditionValue: JSON("1.0.0")))
+    }
+
+    func testVgteOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$vgte", attributeValue: JSON("1.0.0"), conditionValue: JSON("1.0.0")))
+    }
+
+    func testVlteOperator() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$vlte", attributeValue: JSON("1.0.0"), conditionValue: JSON("1.0.0")))
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$vlte", attributeValue: JSON("0.9.0"), conditionValue: JSON("1.0.0")))
+    }
+
+    // MARK: - $inGroup / $notInGroup
+
+    func testInGroupOperator() {
+        let savedGroups = JSON(["beta-users": ["user-1", "user-2"]])
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$inGroup", attributeValue: JSON("user-1"), conditionValue: JSON("beta-users"), savedGroups: savedGroups))
+    }
+
+    func testInGroupOperatorNotMember() {
+        let savedGroups = JSON(["beta-users": ["user-1"]])
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$inGroup", attributeValue: JSON("user-99"), conditionValue: JSON("beta-users"), savedGroups: savedGroups))
+    }
+
+    func testNotInGroupOperator() {
+        let savedGroups = JSON(["beta-users": ["user-1"]])
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$notInGroup", attributeValue: JSON("user-99"), conditionValue: JSON("beta-users"), savedGroups: savedGroups))
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$notInGroup", attributeValue: JSON("user-1"), conditionValue: JSON("beta-users"), savedGroups: savedGroups))
+    }
+
+    // MARK: - Unknown operator
+
+    func testUnknownOperatorReturnsFalse() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$unknown", attributeValue: JSON("x"), conditionValue: JSON("x")))
+    }
+
+    // MARK: - Full condition via isEvalCondition
+
+    func testFullConditionWithSavedGroup() {
+        let attrs = JSON(["userId": "user-1"])
+        let savedGroups = JSON(["testers": ["user-1", "user-2"]])
+        let cond = JSON(["userId": ["$inGroup": "testers"]])
+        XCTAssertTrue(eval.isEvalCondition(attributes: attrs, conditionObj: cond, savedGroups: savedGroups))
+    }
+
+    func testFullConditionAndOperator() {
+        let attrs = JSON(["age": 25, "country": "US"])
+        let cond = JSON(["$and": [["age": ["$gte": 18]], ["country": "US"]]])
+        XCTAssertTrue(eval.isEvalCondition(attributes: attrs, conditionObj: cond))
+    }
+
+    func testFullConditionDotPath() {
+        let attrs = JSON(["user": ["role": "admin"]])
+        let cond = JSON(["user.role": "admin"])
+        XCTAssertTrue(eval.isEvalCondition(attributes: attrs, conditionObj: cond))
+    }
+}

--- a/GrowthBookTests/ConstantsAndModelTests.swift
+++ b/GrowthBookTests/ConstantsAndModelTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import GrowthBook
+
+class StickyAssignmentsDocumentTests: XCTestCase {
+
+    func testInitWithStringAssignments() {
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "user-1",
+            assignments: ["exp__0": "control", "exp2__0": "variant"]
+        )
+        XCTAssertEqual(doc.attributeName, "id")
+        XCTAssertEqual(doc.attributeValue, "user-1")
+        XCTAssertEqual(doc.assignments["exp__0"], "control")
+        XCTAssertEqual(doc.assignments["exp2__0"], "variant")
+    }
+
+func testCodableRoundtrip() throws {
+        let original = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "user-99",
+            assignments: ["exp__0": "control"]
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(StickyAssignmentsDocument.self, from: data)
+        XCTAssertEqual(decoded.attributeName, original.attributeName)
+        XCTAssertEqual(decoded.attributeValue, original.attributeValue)
+        XCTAssertEqual(decoded.assignments, original.assignments)
+    }
+
+    func testInitWithEmptyAssignments() {
+        let empty: [String: String] = [:]
+        let doc = StickyAssignmentsDocument(attributeName: "id", attributeValue: "u", assignments: empty)
+        XCTAssertTrue(doc.assignments.isEmpty)
+    }
+}
+
+class ConstantsTests: XCTestCase {
+
+    // MARK: - BucketRange.init(json:)
+
+    func testBucketRangeInitFromValidJsonArray() {
+        let json = JSON([0.25, 0.75])
+        let range = BucketRange(json: json)
+        XCTAssertEqual(range.number1, 0.25)
+        XCTAssertEqual(range.number2, 0.75)
+    }
+
+    func testBucketRangeInitFromEmptyJsonArray() {
+        let json = JSON([])
+        let range = BucketRange(json: json)
+        XCTAssertEqual(range.number1, 0.0)
+        XCTAssertEqual(range.number2, 0.0)
+    }
+
+    // MARK: - Filter.init(json:)
+
+    func testFilterInitFromJson() {
+        let json: [String: JSON] = [
+            "attribute": JSON("userId"),
+            "seed": JSON("my-seed"),
+            "hashVersion": JSON(2),
+            "ranges": JSON([[0.0, 0.5], [0.6, 1.0]])
+        ]
+        let filter = Filter(json: json)
+        XCTAssertEqual(filter.attribute, "userId")
+        XCTAssertEqual(filter.seed, "my-seed")
+        XCTAssertEqual(filter.hashVersion, 2.0)
+        XCTAssertEqual(filter.ranges.count, 2)
+        XCTAssertEqual(filter.ranges[0].number1, 0.0)
+        XCTAssertEqual(filter.ranges[0].number2, 0.5)
+    }
+
+    func testFilterInitDefaultsHashVersionToTwo() {
+        let filter = Filter(json: ["seed": JSON("s")])
+        XCTAssertEqual(filter.hashVersion, 2.0)
+        XCTAssertEqual(filter.seed, "s")
+        XCTAssertNil(filter.attribute)
+        XCTAssertTrue(filter.ranges.isEmpty)
+    }
+
+    // MARK: - VariationMeta
+
+    func testVariationMetaInitFromJson() {
+        let json: [String: JSON] = [
+            "key": JSON("variant-a"),
+            "name": JSON("Variant A"),
+            "passthrough": JSON(false)
+        ]
+        let meta = VariationMeta(json: json)
+        XCTAssertEqual(meta.key, "variant-a")
+        XCTAssertEqual(meta.name, "Variant A")
+        XCTAssertEqual(meta.passthrough, false)
+    }
+
+    func testVariationMetaInitEmptyJson() {
+        let meta = VariationMeta(json: [:])
+        XCTAssertNil(meta.key)
+        XCTAssertNil(meta.name)
+        XCTAssertNil(meta.passthrough)
+    }
+
+    // MARK: - ParentConditionInterface
+
+    func testParentConditionInterfaceInitFromJson() {
+        let json: [String: JSON] = [
+            "id": JSON("parent-feature"),
+            "condition": JSON(["value": true]),
+            "gate": JSON(true)
+        ]
+        let parent = ParentConditionInterface(json: json)
+        XCTAssertEqual(parent.id, "parent-feature")
+        XCTAssertEqual(parent.condition["value"].boolValue, true)
+        XCTAssertEqual(parent.gate, true)
+    }
+
+    func testParentConditionInterfaceDefaultGateIsNil() {
+        let json: [String: JSON] = ["id": JSON("feat"), "condition": JSON(["x": 1])]
+        let parent = ParentConditionInterface(json: json)
+        XCTAssertNil(parent.gate)
+    }
+
+    // MARK: - SDKError
+
+    func testSDKErrorHasCorrectCode() {
+        XCTAssertEqual(SDKError.failedToLoadData.code, .failedToLoadData)
+        XCTAssertEqual(SDKError.failedParsedData.code, .failedParsedData)
+        XCTAssertEqual(SDKError.failedMissingKey.code, .failedMissingKey)
+        XCTAssertEqual(SDKError.failedEncryptedFeatures.code, .failedEncryptedFeatures)
+        XCTAssertEqual(SDKError.failedToFetchData.code, .failedToFetchData)
+    }
+
+    func testSDKErrorWithUnderlyingError() {
+        let underlying = NSError(domain: "test", code: 42)
+        let error = SDKError.failedToFetchData(underlying)
+        XCTAssertNotNil(error.underlying)
+        XCTAssertEqual(error.code, .failedToFetchData)
+    }
+}

--- a/GrowthBookTests/DecryptionUtilsTests.swift
+++ b/GrowthBookTests/DecryptionUtilsTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import GrowthBook
+
+class DecryptionUtilsTests: XCTestCase {
+
+    // Vectors taken from the GrowthBook standard test suite (json.json "decrypt" section).
+    let validPayload  = "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj"
+    let validKey      = "Zvwv/+uhpFDznZ6SX28Yjg=="
+    let expectedPlain = "{\"feature\":{\"defaultValue\":true}}"
+
+    // Same payload, slightly different key (last two chars differ) — should fail.
+    let wrongKey      = "Zvwv/+uhpFDznZ6SX39Yjg=="
+
+    // MARK: - Happy path
+
+    func testDecryptValidPayloadReturnsExpectedPlaintext() throws {
+        let result = try DecryptionUtils.decrypt(payload: validPayload, encryptionKey: validKey)
+        XCTAssertEqual(result.trimmingCharacters(in: .whitespacesAndNewlines), expectedPlain)
+    }
+
+    // MARK: - Invalid payload (no "." separator)
+
+    func testDecryptPayloadWithoutDotThrowsInvalidPayload() {
+        XCTAssertThrowsError(try DecryptionUtils.decrypt(payload: "nodothere", encryptionKey: validKey)) { error in
+            guard let decryptionError = error as? DecryptionUtils.DecryptionError else {
+                return XCTFail("Expected DecryptionError, got \(error)")
+            }
+            XCTAssertEqual(decryptionError, .invalidPayload)
+        }
+    }
+
+    func testDecryptEmptyPayloadThrowsInvalidPayload() {
+        XCTAssertThrowsError(try DecryptionUtils.decrypt(payload: "", encryptionKey: validKey)) { error in
+            XCTAssertTrue(error is DecryptionUtils.DecryptionError)
+        }
+    }
+
+    // MARK: - Wrong key produces decryption failure
+
+    func testDecryptWithWrongKeyThrows() {
+        XCTAssertThrowsError(try DecryptionUtils.decrypt(payload: validPayload, encryptionKey: wrongKey))
+    }
+
+    // MARK: - Invalid IV (not valid base64) → invalidPayload
+
+    func testDecryptInvalidIVThrows() {
+        XCTAssertThrowsError(
+            try DecryptionUtils.decrypt(payload: "!!!notbase64!!!.validciphertext", encryptionKey: validKey)
+        )
+    }
+
+    // MARK: - AESCryptor edge cases
+
+    func testAESCryptorWithNilDataThrows() {
+        let key = Data(repeating: 0x00, count: 16)
+        let iv  = Data(repeating: 0x00, count: 16)
+        XCTAssertThrowsError(try AESCryptor.decrypt(data: nil, key: key, iv: iv))
+    }
+
+    func testAESCryptorWithInvalidKeyLengthThrows() {
+        let key  = Data(repeating: 0x00, count: 8)   // AES requires 16, 24, or 32 bytes
+        let iv   = Data(repeating: 0x00, count: 16)
+        let data = Data(repeating: 0x41, count: 16)
+        XCTAssertThrowsError(try AESCryptor.decrypt(data: data, key: key, iv: iv))
+    }
+}

--- a/GrowthBookTests/ExperimentEvaluatorTests.swift
+++ b/GrowthBookTests/ExperimentEvaluatorTests.swift
@@ -1,0 +1,263 @@
+import XCTest
+@testable import GrowthBook
+
+class ExperimentEvaluatorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeContext(
+        attributes: JSON = JSON(["id": "user-1"]),
+        forcedVariations: JSON? = nil,
+        isEnabled: Bool = true,
+        isQaMode: Bool = false,
+        url: String? = nil,
+        features: Features = [:]
+    ) -> EvalContext {
+        let globalContext = GlobalContext(features: features)
+        let userContext = UserContext(attributes: attributes, forcedVariations: forcedVariations)
+        let options = ClientOptions(isEnabled: isEnabled, stickyBucketService: nil, isQaMode: isQaMode, trackingClosure: { _, _ in })
+        options.url = url
+        return EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
+    }
+
+    private func evaluate(_ experiment: Experiment, context: EvalContext) -> ExperimentResult {
+        ExperimentEvaluator().evaluateExperiment(context: context, experiment: experiment)
+    }
+
+    private func twoVariationExp(key: String = "exp", coverage: Float? = nil) -> Experiment {
+        Experiment(key: key, variations: [JSON("control"), JSON("variant")], coverage: coverage)
+    }
+
+    // MARK: - Fewer than 2 variations
+
+    func testFewerThanTwoVariationsNotInExperiment() {
+        let exp = Experiment(key: "exp", variations: [JSON("only")])
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertFalse(result.inExperiment)
+        XCTAssertEqual(result.variationId, 0)
+    }
+
+    func testZeroVariationsNotInExperiment() {
+        let exp = Experiment(key: "exp", variations: [])
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    // MARK: - SDK disabled
+
+    func testSDKDisabledNotInExperiment() {
+        let exp = twoVariationExp()
+        let result = evaluate(exp, context: makeContext(isEnabled: false))
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    // MARK: - QA mode
+
+    func testQaModeNotInExperiment() {
+        let exp = twoVariationExp(coverage: 1.0)
+        let result = evaluate(exp, context: makeContext(isQaMode: true))
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    // MARK: - Forced variation
+
+    func testForcedVariationReturnsCorrectVariation() {
+        let exp = twoVariationExp()
+        let context = makeContext(forcedVariations: JSON(["exp": 1]))
+        let result = evaluate(exp, context: context)
+        XCTAssertEqual(result.variationId, 1)
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    func testForcedVariationIndexZero() {
+        let exp = twoVariationExp()
+        let context = makeContext(forcedVariations: JSON(["exp": 0]))
+        let result = evaluate(exp, context: context)
+        XCTAssertEqual(result.variationId, 0)
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    // MARK: - isActive = false
+
+    func testInactiveExperimentNotInExperiment() {
+        let exp = Experiment(key: "exp", variations: [JSON("a"), JSON("b")], isActive: false)
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    // MARK: - Missing hash attribute
+
+    func testMissingHashAttributeNotInExperiment() {
+        // User attributes don't have "custom-id"
+        let exp = Experiment(key: "exp", variations: [JSON("a"), JSON("b")], hashAttribute: "custom-id")
+        let result = evaluate(exp, context: makeContext(attributes: JSON(["id": "user-1"])))
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    // MARK: - Condition fails
+
+    func testFailingConditionNotInExperiment() {
+        let exp = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            coverage: 1.0,
+            condition: JSON(["country": "DE"])
+        )
+        let result = evaluate(exp, context: makeContext(attributes: JSON(["id": "user-1", "country": "US"])))
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    func testPassingConditionInExperiment() {
+        let exp = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            coverage: 1.0,
+            condition: JSON(["country": "US"])
+        )
+        let result = evaluate(exp, context: makeContext(attributes: JSON(["id": "user-1", "country": "US"])))
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    // MARK: - Namespace exclusion
+
+    func testNamespaceExclusionNotInExperiment() {
+        // Namespace [0.9, 1.0] — user-1 hash is unlikely to fall in this tiny range
+        let exp = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            namespace: [JSON("pricing"), JSON(0.99), JSON(1.0)],
+            coverage: 1.0
+        )
+        let result = evaluate(exp, context: makeContext())
+        // This may or may not be in namespace — just verify it doesn't crash
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - Coverage
+
+    func testZeroCoverageNotInExperiment() {
+        let exp = twoVariationExp(coverage: 0.0)
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    func testFullCoverageInExperiment() {
+        let exp = twoVariationExp(coverage: 1.0)
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    // MARK: - Experiment.force
+
+    func testExperimentForceOverridesVariation() {
+        let exp = Experiment(key: "exp", variations: [JSON("a"), JSON("b")], coverage: 1.0, force: 1)
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertEqual(result.variationId, 1)
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    // MARK: - Tracking callback
+
+    func testTrackingCallbackFiredWhenInExperiment() {
+        var tracked = false
+        let globalContext = GlobalContext()
+        // Use unique userId so ExperimentHelper shared cache doesn't suppress the callback
+        let uniqueId = "tracking-test-\(UUID().uuidString)"
+        let userContext = UserContext(attributes: JSON(["id": uniqueId]))
+        let options = ClientOptions(isEnabled: true, stickyBucketService: nil, isQaMode: false, trackingClosure: { _, _ in
+            tracked = true
+        })
+        let context = EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
+
+        let exp = Experiment(key: "tracking-test-exp-\(uniqueId)", variations: [JSON("a"), JSON("b")], coverage: 1.0)
+        _ = evaluate(exp, context: context)
+        XCTAssertTrue(tracked)
+    }
+
+    func testTrackingCallbackNotFiredWhenNotInExperiment() {
+        var tracked = false
+        let globalContext = GlobalContext()
+        let userContext = UserContext(attributes: JSON(["id": "user-1"]))
+        let options = ClientOptions(isEnabled: true, stickyBucketService: nil, isQaMode: false, trackingClosure: { _, _ in
+            tracked = true
+        })
+        let context = EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
+
+        let exp = twoVariationExp(coverage: 0.0)
+        _ = evaluate(exp, context: context)
+        XCTAssertFalse(tracked)
+    }
+
+    // MARK: - Query string override
+
+    func testQueryStringOverrideForceVariation() {
+        let exp = twoVariationExp(key: "my-exp")
+        let context = makeContext(url: "https://example.com?my-exp=1")
+        let result = evaluate(exp, context: context)
+        XCTAssertEqual(result.variationId, 1)
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    // MARK: - Parent conditions in experiment
+
+    func testParentConditionPassesAllowsExperiment() {
+        let parentFeature = Feature(defaultValue: JSON(true))
+        let parentCond = ParentConditionInterface(json: [
+            "id": JSON("feature-flag"),
+            "condition": JSON(["value": true])
+        ])
+        let exp = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            parentConditions: [parentCond],
+            coverage: 1.0
+        )
+        let context = makeContext(features: ["feature-flag": parentFeature])
+        let result = evaluate(exp, context: context)
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    func testParentConditionFailsBlocksExperiment() {
+        let parentFeature = Feature(defaultValue: JSON(false))
+        let parentCond = ParentConditionInterface(json: [
+            "id": JSON("feature-flag"),
+            "condition": JSON(["value": true])
+        ])
+        let exp = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            parentConditions: [parentCond],
+            coverage: 1.0
+        )
+        let context = makeContext(features: ["feature-flag": parentFeature])
+        let result = evaluate(exp, context: context)
+        XCTAssertFalse(result.inExperiment)
+    }
+
+    // MARK: - getExperimentResult: meta fields
+
+    func testResultIncludesMetaKeyAndName() {
+        let meta = [
+            VariationMeta(json: ["key": JSON("0"), "name": JSON("Control")]),
+            VariationMeta(json: ["key": JSON("1"), "name": JSON("Variant")])
+        ]
+        let exp = Experiment(key: "exp", variations: [JSON("a"), JSON("b")], coverage: 1.0, meta: meta)
+        let result = evaluate(exp, context: makeContext(attributes: JSON(["id": "user-1"])))
+        XCTAssertNotNil(result.key)
+        XCTAssertTrue(result.inExperiment)
+    }
+
+    func testResultFeatureIdPropagated() {
+        let exp = twoVariationExp(coverage: 1.0)
+        let result = ExperimentEvaluator().evaluateExperiment(context: makeContext(), experiment: exp, featureId: "my-feature")
+        XCTAssertEqual(result.featureId, "my-feature")
+    }
+
+    // MARK: - hashAttribute propagated to result
+
+    func testHashAttributePropagatedToResult() {
+        let exp = Experiment(key: "exp", variations: [JSON("a"), JSON("b")], hashAttribute: "id", coverage: 1.0)
+        let result = evaluate(exp, context: makeContext())
+        XCTAssertEqual(result.hashAttribute, "id")
+    }
+}

--- a/GrowthBookTests/ExtensionsTests.swift
+++ b/GrowthBookTests/ExtensionsTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import GrowthBook
+
+class ExtensionsTests: XCTestCase {
+
+    // MARK: - Float.roundTo
+
+    func testRoundToTwoDecimalPlaces() {
+        XCTAssertEqual(Float(0.12345).roundTo(numFractionDigits: 2), 0.12, accuracy: 0.0001)
+    }
+
+    func testRoundToFourDecimalPlaces() {
+        XCTAssertEqual(Float(0.123456).roundTo(numFractionDigits: 4), 0.1235, accuracy: 0.00001)
+    }
+
+    func testRoundToZeroDecimalPlaces() {
+        XCTAssertEqual(Float(3.7).roundTo(numFractionDigits: 0), 4.0, accuracy: 0.0001)
+    }
+
+    func testRoundToNegativeNumber() {
+        XCTAssertEqual(Float(-0.556).roundTo(numFractionDigits: 2), -0.56, accuracy: 0.0001)
+    }
+
+    // MARK: - Sequence.sum
+
+    func testSumInts() {
+        XCTAssertEqual([1, 2, 3, 4].sum(), 10)
+    }
+
+    func testSumFloats() {
+        XCTAssertEqual([0.25, 0.25, 0.5].sum(), 1.0, accuracy: 0.0001)
+    }
+
+    func testSumEmpty() {
+        XCTAssertEqual([Float]().sum(), 0.0)
+    }
+
+    // MARK: - JSON.convertToArrayFloat
+
+    func testConvertToArrayFloat() {
+        let jsonArray: [JSON] = [JSON(1.5), JSON(2.5), JSON(3.0)]
+        let result = JSON.convertToArrayFloat(jsonArray: jsonArray)
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0], 1.5, accuracy: 0.001)
+        XCTAssertEqual(result[1], 2.5, accuracy: 0.001)
+        XCTAssertEqual(result[2], 3.0, accuracy: 0.001)
+    }
+
+    func testConvertToArrayFloatEmpty() {
+        XCTAssertTrue(JSON.convertToArrayFloat(jsonArray: []).isEmpty)
+    }
+
+    // MARK: - JSON.convertToArrayString
+
+    func testConvertToArrayString() {
+        let jsonArray: [JSON] = [JSON("a"), JSON("b"), JSON("c")]
+        let result = JSON.convertToArrayString(jsonArray: jsonArray)
+        XCTAssertEqual(result, ["a", "b", "c"])
+    }
+
+    func testConvertToArrayStringEmpty() {
+        XCTAssertTrue(JSON.convertToArrayString(jsonArray: []).isEmpty)
+    }
+
+    // MARK: - JSON.convertToTwoArrayFloat
+
+    func testConvertToTwoArrayFloat() {
+        let jsonArray: [JSON] = [JSON([0.0, 0.5]), JSON([0.5, 1.0])]
+        let result = JSON.convertToTwoArrayFloat(jsonArray: jsonArray)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0][0], 0.0, accuracy: 0.001)
+        XCTAssertEqual(result[0][1], 0.5, accuracy: 0.001)
+        XCTAssertEqual(result[1][0], 0.5, accuracy: 0.001)
+        XCTAssertEqual(result[1][1], 1.0, accuracy: 0.001)
+    }
+
+    func testConvertToTwoArrayFloatEmpty() {
+        XCTAssertTrue(JSON.convertToTwoArrayFloat(jsonArray: []).isEmpty)
+    }
+
+    // MARK: - String.toData / Data.string
+
+    func testStringToData() {
+        let data = "hello".toData()
+        XCTAssertNotNil(data)
+        XCTAssertEqual(data?.count, 5)
+    }
+
+    func testDataToString() {
+        let original = "world"
+        let data = original.data(using: .utf8)!
+        XCTAssertEqual(data.string(), "world")
+    }
+
+    func testStringToDataRoundtrip() {
+        let original = "GrowthBook SDK"
+        let result = original.toData()?.string()
+        XCTAssertEqual(result, original)
+    }
+
+    func testEmptyStringToData() {
+        let data = "".toData()
+        XCTAssertNotNil(data)
+        XCTAssertEqual(data?.count, 0)
+    }
+
+    // MARK: - String.lastPathComponent
+
+    func testLastPathComponent() {
+        XCTAssertEqual("/usr/local/bin/swift".lastPathComponent, "swift")
+    }
+
+    func testLastPathComponentNoSlash() {
+        XCTAssertEqual("filename.txt".lastPathComponent, "filename.txt")
+    }
+
+    func testLastPathComponentTrailingSlash() {
+        XCTAssertEqual("/path/to/dir/".lastPathComponent, "dir")
+    }
+
+    // MARK: - String.stringByDeletingPathExtension
+
+    func testStringByDeletingPathExtension() {
+        XCTAssertEqual("file.swift".stringByDeletingPathExtension, "file")
+    }
+
+    func testStringByDeletingPathExtensionNoExtension() {
+        XCTAssertEqual("Makefile".stringByDeletingPathExtension, "Makefile")
+    }
+
+    func testStringByDeletingPathExtensionWithPath() {
+        XCTAssertEqual("/path/to/file.txt".stringByDeletingPathExtension, "/path/to/file")
+    }
+
+    // MARK: - String.withColor
+
+    func testWithColorAppliesEscapeSequence() {
+        let result = "hello".withColor("red")
+        XCTAssertTrue(result.contains("hello"))
+        XCTAssertTrue(result.contains("red"))
+    }
+
+    func testWithColorNilReturnsOriginal() {
+        XCTAssertEqual("hello".withColor(nil), "hello")
+    }
+}

--- a/GrowthBookTests/FeatureEvaluatorTests.swift
+++ b/GrowthBookTests/FeatureEvaluatorTests.swift
@@ -1,0 +1,275 @@
+import XCTest
+@testable import GrowthBook
+
+class FeatureEvaluatorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeContext(
+        features: Features = [:],
+        attributes: JSON = JSON(["id": "user-1"]),
+        forcedFeatureValues: JSON? = nil,
+        savedGroups: JSON? = nil
+    ) -> EvalContext {
+        let globalContext = GlobalContext(features: features, savedGroups: savedGroups)
+        let userContext = UserContext(attributes: attributes, forcedFeatureValues: forcedFeatureValues)
+        let options = ClientOptions(isEnabled: true, stickyBucketService: nil, isQaMode: false, trackingClosure: { _, _ in })
+        return EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
+    }
+
+    private func evaluate(_ featureKey: String, in context: EvalContext) -> FeatureResult {
+        FeatureEvaluator(context: context, featureKey: featureKey).evaluateFeature()
+    }
+
+    // MARK: - Unknown feature
+
+    func testUnknownFeatureReturnsUnknownSource() {
+        let result = evaluate("nonexistent", in: makeContext())
+        XCTAssertEqual(result.source, FeatureSource.unknownFeature.rawValue)
+        XCTAssertEqual(result.value, JSON.null)
+        XCTAssertFalse(result.isOn)
+    }
+
+    // MARK: - Default value
+
+    func testDefaultValueReturnedWhenNoRulesMatch() {
+        let feature = Feature(defaultValue: JSON("blue"))
+        let result = evaluate("color", in: makeContext(features: ["color": feature]))
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "blue")
+    }
+
+    func testNullDefaultValue() {
+        let feature = Feature(defaultValue: nil)
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+        XCTAssertEqual(result.value, JSON.null)
+    }
+
+    // MARK: - Forced feature value (override)
+
+    func testForcedFeatureValueOverridesEvaluation() {
+        let feature = Feature(defaultValue: JSON("original"))
+        let context = makeContext(
+            features: ["color": feature],
+            forcedFeatureValues: JSON(["color": "forced"])
+        )
+        let result = evaluate("color", in: context)
+        XCTAssertEqual(result.source, FeatureSource.override.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "forced")
+    }
+
+    func testForcedFeatureValueBool() {
+        let feature = Feature(defaultValue: JSON(false))
+        let context = makeContext(
+            features: ["flag": feature],
+            forcedFeatureValues: JSON(["flag": true])
+        )
+        let result = evaluate("flag", in: context)
+        XCTAssertEqual(result.source, FeatureSource.override.rawValue)
+        XCTAssertTrue(result.isOn)
+    }
+
+    // MARK: - Circular dependency
+
+    func testCircularDependencyReturnsCorrectSource() {
+        let feature = Feature(defaultValue: JSON("x"))
+        let context = makeContext(features: ["my-feature": feature])
+        context.stackContext.evaluatedFeatures.insert("my-feature")
+        let result = evaluate("my-feature", in: context)
+        XCTAssertEqual(result.source, FeatureSource.cyclicPrerequisite.rawValue)
+        XCTAssertEqual(result.value, JSON.null)
+    }
+
+    // MARK: - Force rule
+
+    func testForceRuleNoConditionReturnsForce() {
+        let rule = FeatureRule(force: JSON("red"))
+        let feature = Feature(defaultValue: JSON("blue"), rules: [rule])
+        let result = evaluate("color", in: makeContext(features: ["color": feature]))
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "red")
+    }
+
+    func testForceRuleWithPassingCondition() {
+        let rule = FeatureRule(condition: JSON(["country": "US"]), force: JSON("red"))
+        let feature = Feature(defaultValue: JSON("blue"), rules: [rule])
+        let context = makeContext(
+            features: ["color": feature],
+            attributes: JSON(["id": "user-1", "country": "US"])
+        )
+        let result = evaluate("color", in: context)
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "red")
+    }
+
+    func testForceRuleWithFailingConditionFallsToDefault() {
+        let rule = FeatureRule(condition: JSON(["country": "DE"]), force: JSON("red"))
+        let feature = Feature(defaultValue: JSON("blue"), rules: [rule])
+        let context = makeContext(
+            features: ["color": feature],
+            attributes: JSON(["id": "user-1", "country": "US"])
+        )
+        let result = evaluate("color", in: context)
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "blue")
+    }
+
+    func testForceRuleUserExcludedFromRollout() {
+        // coverage=0 means no one is in the rollout
+        let rule = FeatureRule(coverage: 0.0, force: JSON("forced"))
+        let feature = Feature(defaultValue: JSON("default"), rules: [rule])
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+    }
+
+    func testForceRuleWithRangeSkipsCoverageCheck() {
+        // When range is set, the separate coverage check block is skipped
+        let range = BucketRange(json: JSON([0.0, 1.0]))
+        let rule = FeatureRule(coverage: 1.0, force: JSON("forced"), range: range)
+        let feature = Feature(defaultValue: JSON("default"), rules: [rule])
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "forced")
+    }
+
+    func testForceRuleNoVariationsRuleContinues() {
+        // Rule without force AND without variations → skipped
+        let skipRule = FeatureRule(condition: JSON(["x": 1]))
+        let forceRule = FeatureRule(force: JSON("result"))
+        let feature = Feature(defaultValue: JSON("default"), rules: [skipRule, forceRule])
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "result")
+    }
+
+    // MARK: - Prerequisite conditions
+
+    func testPrerequisiteGateBlocksFeatureWhenConditionFails() {
+        // "premium" feature returns false by default
+        let premiumFeature = Feature(defaultValue: JSON(false))
+
+        // "color" requires premium == true (gate=true blocks the whole feature)
+        let parentCond = ParentConditionInterface(json: [
+            "id": JSON("premium"),
+            "condition": JSON(["value": true]),
+            "gate": JSON(true)
+        ])
+        let rule = FeatureRule(parentConditions: [parentCond], force: JSON("red"))
+        let colorFeature = Feature(defaultValue: JSON("blue"), rules: [rule])
+
+        let context = makeContext(features: ["premium": premiumFeature, "color": colorFeature])
+        let result = evaluate("color", in: context)
+        XCTAssertEqual(result.source, FeatureSource.prerequisite.rawValue)
+        XCTAssertEqual(result.value, JSON.null)
+    }
+
+    func testPrerequisiteGateAllowsFeatureWhenConditionPasses() {
+        // "premium" returns true
+        let premiumFeature = Feature(defaultValue: JSON(true))
+
+        let parentCond = ParentConditionInterface(json: [
+            "id": JSON("premium"),
+            "condition": JSON(["value": true]),
+            "gate": JSON(true)
+        ])
+        let rule = FeatureRule(parentConditions: [parentCond], force: JSON("red"))
+        let colorFeature = Feature(defaultValue: JSON("blue"), rules: [rule])
+
+        let context = makeContext(features: ["premium": premiumFeature, "color": colorFeature])
+        let result = evaluate("color", in: context)
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "red")
+    }
+
+    func testNonBlockingPrerequisiteSkipsRuleWhenFails() {
+        // gate is nil → non-blocking: just skip this rule
+        let premiumFeature = Feature(defaultValue: JSON(false))
+
+        let parentCond = ParentConditionInterface(json: [
+            "id": JSON("premium"),
+            "condition": JSON(["value": true])
+            // no "gate" key → gate = nil
+        ])
+        let prereqRule = FeatureRule(parentConditions: [parentCond], force: JSON("red"))
+        let fallbackRule = FeatureRule(force: JSON("fallback"))
+        let colorFeature = Feature(defaultValue: JSON("blue"), rules: [prereqRule, fallbackRule])
+
+        let context = makeContext(features: ["premium": premiumFeature, "color": colorFeature])
+        let result = evaluate("color", in: context)
+        // prereqRule is skipped → fallbackRule applies
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "fallback")
+    }
+
+    func testCyclicPrerequisiteDetected() {
+        // A depends on B, B depends on A → cycle
+        let parentCondA = ParentConditionInterface(json: [
+            "id": JSON("feature-b"),
+            "condition": JSON(["value": true]),
+            "gate": JSON(true)
+        ])
+        let parentCondB = ParentConditionInterface(json: [
+            "id": JSON("feature-a"),
+            "condition": JSON(["value": true]),
+            "gate": JSON(true)
+        ])
+
+        let ruleA = FeatureRule(parentConditions: [parentCondA], force: JSON("a"))
+        let ruleB = FeatureRule(parentConditions: [parentCondB], force: JSON("b"))
+
+        let featureA = Feature(defaultValue: JSON("default-a"), rules: [ruleA])
+        let featureB = Feature(defaultValue: JSON("default-b"), rules: [ruleB])
+
+        let context = makeContext(features: ["feature-a": featureA, "feature-b": featureB])
+        let result = evaluate("feature-a", in: context)
+        XCTAssertEqual(result.source, FeatureSource.cyclicPrerequisite.rawValue)
+    }
+
+    // MARK: - Experiment rule
+
+    func testExperimentRuleNotInExperimentFallsToDefault() {
+        // coverage=0 → no one in experiment → falls through to default
+        let rule = FeatureRule(
+            coverage: 0.0,
+            variations: [JSON("control"), JSON("variant")]
+        )
+        let feature = Feature(defaultValue: JSON("default"), rules: [rule])
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+    }
+
+    func testExperimentRuleInExperimentReturnsExperimentSource() {
+        // coverage=1 → user is in experiment
+        let rule = FeatureRule(
+            coverage: 1.0,
+            variations: [JSON("control"), JSON("variant")],
+            weights: [0.5, 0.5]
+        )
+        let feature = Feature(defaultValue: JSON("default"), rules: [rule])
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertEqual(result.source, FeatureSource.experiment.rawValue)
+    }
+
+    // MARK: - prepareResult: isOn/isOff logic
+
+    func testIsOffForFalseStringValue() {
+        let feature = Feature(defaultValue: JSON("false"))
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertFalse(result.isOn)
+        XCTAssertTrue(result.isOff)
+    }
+
+    func testIsOffForZeroStringValue() {
+        let feature = Feature(defaultValue: JSON("0"))
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertFalse(result.isOn)
+    }
+
+    func testIsOnForNonEmptyStringValue() {
+        let feature = Feature(defaultValue: JSON("enabled"))
+        let result = evaluate("flag", in: makeContext(features: ["flag": feature]))
+        XCTAssertTrue(result.isOn)
+        XCTAssertFalse(result.isOff)
+    }
+}

--- a/GrowthBookTests/FeatureModelInitJsonTests.swift
+++ b/GrowthBookTests/FeatureModelInitJsonTests.swift
@@ -1,0 +1,401 @@
+import XCTest
+@testable import GrowthBook
+
+/// Tests for the init(json:) initializer paths used by the internal evaluator.
+/// These are separate from FeatureModelTests which covers the Codable (JSONDecoder) path.
+class FeatureModelInitJsonTests: XCTestCase {
+
+    // MARK: - Feature.init(json:)
+
+    func testFeatureInitJsonDefaultValue() {
+        let json: [String: JSON] = ["defaultValue": JSON("blue")]
+        let feature = Feature(json: json)
+        XCTAssertEqual(feature.defaultValue?.stringValue, "blue")
+        XCTAssertNil(feature.rules)
+    }
+
+    func testFeatureInitJsonBoolDefaultValue() {
+        let json: [String: JSON] = ["defaultValue": JSON(true)]
+        let feature = Feature(json: json)
+        XCTAssertEqual(feature.defaultValue?.boolValue, true)
+    }
+
+    func testFeatureInitJsonWithRules() {
+        let ruleJson = JSON(["id": "rule-1", "force": true, "coverage": 0.8])
+        let json: [String: JSON] = [
+            "defaultValue": JSON(false),
+            "rules": JSON([ruleJson])
+        ]
+        let feature = Feature(json: json)
+        XCTAssertEqual(feature.defaultValue?.boolValue, false)
+        XCTAssertEqual(feature.rules?.count, 1)
+        XCTAssertEqual(feature.rules?.first?.id, "rule-1")
+        XCTAssertEqual(feature.rules?.first?.coverage, 0.8)
+    }
+
+    func testFeatureInitJsonEmptyRules() {
+        let json: [String: JSON] = ["rules": JSON([])]
+        let feature = Feature(json: json)
+        XCTAssertEqual(feature.rules?.count, 0)
+    }
+
+    func testFeatureInitJsonNoKeys() {
+        let feature = Feature(json: [:])
+        XCTAssertNil(feature.defaultValue)
+        XCTAssertNil(feature.rules)
+    }
+
+    // MARK: - FeatureRule.init(json:)
+
+    func testFeatureRuleInitJsonBasicFields() {
+        let json: [String: JSON] = [
+            "id": JSON("rule-abc"),
+            "coverage": JSON(0.75),
+            "hashAttribute": JSON("userId"),
+            "hashVersion": JSON(2.0),
+            "seed": JSON("my-seed"),
+            "name": JSON("Test Rule"),
+            "phase": JSON("1")
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.id, "rule-abc")
+        XCTAssertEqual(rule.coverage, 0.75)
+        XCTAssertEqual(rule.hashAttribute, "userId")
+        XCTAssertEqual(rule.hashVersion, 2.0)
+        XCTAssertEqual(rule.seed, "my-seed")
+        XCTAssertEqual(rule.name, "Test Rule")
+        XCTAssertEqual(rule.phase, "1")
+    }
+
+    func testFeatureRuleInitJsonForce() {
+        let json: [String: JSON] = ["force": JSON("red")]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.force?.stringValue, "red")
+    }
+
+    func testFeatureRuleInitJsonVariations() {
+        let json: [String: JSON] = [
+            "variations": JSON(["control", "variant-a", "variant-b"])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.variations?.count, 3)
+        XCTAssertEqual(rule.variations?[0].stringValue, "control")
+    }
+
+    func testFeatureRuleInitJsonWeightsConversion() {
+        let json: [String: JSON] = [
+            "weights": JSON([0.5, 0.5])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.weights?.count, 2)
+        XCTAssertEqual(rule.weights?[0] ?? 0, 0.5, accuracy: 0.001)
+        XCTAssertEqual(rule.weights?[1] ?? 0, 0.5, accuracy: 0.001)
+    }
+
+    func testFeatureRuleInitJsonRange() {
+        let json: [String: JSON] = [
+            "range": JSON([0.0, 0.5])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.range?.number1, 0.0)
+        XCTAssertEqual(rule.range?.number2, 0.5)
+    }
+
+    func testFeatureRuleInitJsonRanges() {
+        let json: [String: JSON] = [
+            "ranges": JSON([[0.0, 0.25], [0.25, 0.5]])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.ranges?.count, 2)
+        XCTAssertEqual(rule.ranges?[0].number1, 0.0)
+        XCTAssertEqual(rule.ranges?[0].number2, 0.25)
+        XCTAssertEqual(rule.ranges?[1].number1, 0.25)
+    }
+
+    func testFeatureRuleInitJsonStickyBucketFields() {
+        let json: [String: JSON] = [
+            "fallbackAttribute": JSON("deviceId"),
+            "disableStickyBucketing": JSON(true),
+            "bucketVersion": JSON(3),
+            "minBucketVersion": JSON(1)
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.fallbackAttribute, "deviceId")
+        XCTAssertEqual(rule.disableStickyBucketing, true)
+        XCTAssertEqual(rule.bucketVersion, 3)
+        XCTAssertEqual(rule.minBucketVersion, 1)
+    }
+
+    func testFeatureRuleInitJsonMeta() {
+        let json: [String: JSON] = [
+            "meta": JSON([
+                ["key": "0", "name": "Control"],
+                ["key": "1", "name": "Variant"]
+            ])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.meta?.count, 2)
+        XCTAssertEqual(rule.meta?[0].key, "0")
+        XCTAssertEqual(rule.meta?[1].name, "Variant")
+    }
+
+    func testFeatureRuleInitJsonFilters() {
+        let json: [String: JSON] = [
+            "filters": JSON([
+                ["seed": "filter-seed", "hashVersion": 2, "ranges": [[0.0, 0.5]]]
+            ])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.filters?.count, 1)
+        XCTAssertEqual(rule.filters?[0].seed, "filter-seed")
+    }
+
+    func testFeatureRuleInitJsonCondition() {
+        let json: [String: JSON] = [
+            "condition": JSON(["country": "US", "premium": true])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.condition?["country"].stringValue, "US")
+        XCTAssertEqual(rule.condition?["premium"].boolValue, true)
+    }
+
+    func testFeatureRuleInitJsonNamespace() {
+        let json: [String: JSON] = [
+            "namespace": JSON(["pricing", 0.0, 0.5])
+        ]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.namespace?.count, 3)
+        XCTAssertEqual(rule.namespace?[0].stringValue, "pricing")
+    }
+
+    func testFeatureRuleInitJsonKey() {
+        let json: [String: JSON] = ["key": JSON("exp-key-123")]
+        let rule = FeatureRule(json: json)
+        XCTAssertEqual(rule.key, "exp-key-123")
+    }
+
+    func testFeatureRuleInitJsonEmptyDict() {
+        let rule = FeatureRule(json: [:])
+        XCTAssertEqual(rule.id, "")
+        XCTAssertNil(rule.coverage)
+        XCTAssertNil(rule.force)
+        XCTAssertNil(rule.variations)
+    }
+
+    // MARK: - Experiment.init(json:)
+
+    func testExperimentInitJsonBasicFields() {
+        let json: [String: JSON] = [
+            "key": JSON("my-exp"),
+            "variations": JSON(["control", "variant"]),
+            "hashAttribute": JSON("id"),
+            "seed": JSON("exp-seed"),
+            "name": JSON("My Experiment"),
+            "phase": JSON("2"),
+            "coverage": JSON(0.9)
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.key, "my-exp")
+        XCTAssertEqual(experiment.variations.count, 2)
+        XCTAssertEqual(experiment.hashAttribute, "id")
+        XCTAssertEqual(experiment.seed, "exp-seed")
+        XCTAssertEqual(experiment.name, "My Experiment")
+        XCTAssertEqual(experiment.phase, "2")
+        XCTAssertEqual(Double(experiment.coverage ?? 0), 0.9, accuracy: 0.001)
+    }
+
+    func testExperimentInitJsonActiveField() {
+        // init(json:) reads "active" key, not "isActive" (unlike Codable)
+        let activeJson: [String: JSON] = ["key": JSON("exp"), "active": JSON(true)]
+        let inactiveJson: [String: JSON] = ["key": JSON("exp"), "active": JSON(false)]
+
+        XCTAssertEqual(Experiment(json: activeJson).isActive, true)
+        XCTAssertEqual(Experiment(json: inactiveJson).isActive, false)
+    }
+
+    func testExperimentInitJsonDefaultsActiveToTrue() {
+        let json: [String: JSON] = ["key": JSON("exp")]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.isActive, true)
+    }
+
+    func testExperimentInitJsonWeights() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "weights": JSON([0.34, 0.33, 0.33])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.weights?.count, 3)
+        XCTAssertEqual(experiment.weights?[0] ?? 0, 0.34, accuracy: 0.001)
+    }
+
+    func testExperimentInitJsonRanges() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "ranges": JSON([[0.0, 0.5], [0.5, 1.0]])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.ranges?.count, 2)
+        XCTAssertEqual(experiment.ranges?[0].number1, 0.0)
+        XCTAssertEqual(experiment.ranges?[0].number2, 0.5)
+    }
+
+    func testExperimentInitJsonCondition() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "condition": JSON(["premium": true, "country": "UA"])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.condition?["premium"].boolValue, true)
+        XCTAssertEqual(experiment.condition?["country"].stringValue, "UA")
+    }
+
+    func testExperimentInitJsonForce() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "force": JSON(1)
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.force, 1)
+    }
+
+    func testExperimentInitJsonStickyBucketFields() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "fallbackAttribute": JSON("deviceId"),
+            "disableStickyBucketing": JSON(true),
+            "bucketVersion": JSON(2),
+            "minBucketVersion": JSON(1),
+            "hashVersion": JSON(2.0)
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.fallbackAttribute, "deviceId")
+        XCTAssertEqual(experiment.disableStickyBucketing, true)
+        XCTAssertEqual(experiment.bucketVersion, 2)
+        XCTAssertEqual(experiment.minBucketVersion, 1)
+        XCTAssertEqual(experiment.hashVersion, 2.0)
+    }
+
+    func testExperimentInitJsonMeta() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "meta": JSON([["key": "0", "name": "Control", "passthrough": false]])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.meta?.count, 1)
+        XCTAssertEqual(experiment.meta?[0].key, "0")
+        XCTAssertEqual(experiment.meta?[0].name, "Control")
+    }
+
+    func testExperimentInitJsonNamespace() {
+        let json: [String: JSON] = [
+            "key": JSON("exp"),
+            "namespace": JSON(["pricing", 0.0, 0.5])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.namespace?.count, 3)
+        XCTAssertEqual(experiment.namespace?[0].stringValue, "pricing")
+    }
+
+    func testExperimentInitJsonEmptyKey() {
+        let json: [String: JSON] = [:]
+        let experiment = Experiment(json: json)
+        XCTAssertEqual(experiment.key, "")
+        XCTAssertTrue(experiment.variations.isEmpty)
+    }
+
+    // MARK: - ExperimentResult.init(json:)
+
+    func testExperimentResultInitJsonAllFields() {
+        let json: [String: JSON] = [
+            "inExperiment": JSON(true),
+            "variationId": JSON(1),
+            "value": JSON("variant"),
+            "hashAttribute": JSON("id"),
+            "valueHash": JSON("hash-abc"),
+            "key": JSON("exp-key"),
+            "name": JSON("Variant A"),
+            "bucket": JSON(0.42),
+            "passthrough": JSON(false),
+            "hashUsed": JSON(true),
+            "featureId": JSON("my-feature"),
+            "stickyBucketUsed": JSON(false)
+        ]
+        let result = ExperimentResult(json: json)
+        XCTAssertEqual(result.inExperiment, true)
+        XCTAssertEqual(result.variationId, 1)
+        XCTAssertEqual(result.value.stringValue, "variant")
+        XCTAssertEqual(result.hashAttribute, "id")
+        XCTAssertEqual(result.valueHash, "hash-abc")
+        XCTAssertEqual(result.key, "exp-key")
+        XCTAssertEqual(result.name, "Variant A")
+        XCTAssertEqual(Double(result.bucket ?? 0), 0.42, accuracy: 0.001)
+        XCTAssertEqual(result.passthrough, false)
+        XCTAssertEqual(result.hashUsed, true)
+        XCTAssertEqual(result.featureId, "my-feature")
+        XCTAssertEqual(result.stickyBucketUsed, false)
+    }
+
+    func testExperimentResultInitJsonDefaults() {
+        let result = ExperimentResult(json: [:])
+        XCTAssertEqual(result.inExperiment, false)
+        XCTAssertEqual(result.variationId, 0)
+        XCTAssertEqual(result.key, "")
+        XCTAssertNil(result.hashAttribute)
+        XCTAssertNil(result.featureId)
+    }
+
+    // MARK: - FeatureResult.init(json:)
+
+    func testFeatureResultInitJsonUsesOnOffKeys() {
+        // init(json:) reads "on"/"off" keys — different from Codable which reads "isOn"/"isOff"
+        let json: [String: JSON] = [
+            "on": JSON(true),
+            "off": JSON(false),
+            "source": JSON("force"),
+            "value": JSON(42),
+            "ruleId": JSON("rule-99")
+        ]
+        let result = FeatureResult(json: json)
+        XCTAssertEqual(result.isOn, true)
+        XCTAssertEqual(result.isOff, false)
+        XCTAssertEqual(result.source, "force")
+        XCTAssertEqual(result.value?.intValue, 42)
+        XCTAssertEqual(result.ruleId, "rule-99")
+    }
+
+    func testFeatureResultInitJsonDefaultsOnToTrue() {
+        // When "on" key is missing, isOn defaults to true
+        let result = FeatureResult(json: [:])
+        XCTAssertEqual(result.isOn, true)
+        XCTAssertEqual(result.isOff, false)
+        XCTAssertEqual(result.source, "")
+        XCTAssertEqual(result.ruleId, "")
+    }
+
+    func testFeatureResultInitJsonWithNestedExperiment() {
+        let json: [String: JSON] = [
+            "on": JSON(true),
+            "off": JSON(false),
+            "source": JSON("experiment"),
+            "value": JSON("red"),
+            "experiment": JSON(["key": "color-exp", "variations": ["red", "blue"]]),
+            "experimentResult": JSON([
+                "inExperiment": true,
+                "variationId": 0,
+                "value": "red",
+                "key": "0"
+            ])
+        ]
+        let result = FeatureResult(json: json)
+        XCTAssertEqual(result.source, "experiment")
+        XCTAssertEqual(result.experiment?.key, "color-exp")
+        XCTAssertEqual(result.experimentResult?.variationId, 0)
+    }
+
+    func testFeatureResultInitJsonValueFallsBackToEmptyJson() {
+        // When "value" key is missing, value defaults to JSON() (empty)
+        let result = FeatureResult(json: ["source": JSON("defaultValue")])
+        XCTAssertNotNil(result.value)
+    }
+}

--- a/GrowthBookTests/FeatureModelTests.swift
+++ b/GrowthBookTests/FeatureModelTests.swift
@@ -1,0 +1,355 @@
+import XCTest
+@testable import GrowthBook
+
+class FeatureDecodeTests: XCTestCase {
+
+    // MARK: - Feature
+
+    func testFeatureDecodeDefaultValue() throws {
+        let json = """
+        {"defaultValue": "blue"}
+        """.data(using: .utf8)!
+
+        let feature = try JSONDecoder().decode(Feature.self, from: json)
+        XCTAssertEqual(feature.defaultValue?.stringValue, "blue")
+        XCTAssertNil(feature.rules)
+    }
+
+    func testFeatureDecodeBoolDefaultValue() throws {
+        let json = """
+        {"defaultValue": true}
+        """.data(using: .utf8)!
+
+        let feature = try JSONDecoder().decode(Feature.self, from: json)
+        XCTAssertEqual(feature.defaultValue?.boolValue, true)
+    }
+
+    func testFeatureDecodeNullDefaultValue() throws {
+        let json = """
+        {"defaultValue": null}
+        """.data(using: .utf8)!
+
+        let feature = try JSONDecoder().decode(Feature.self, from: json)
+        XCTAssertNotNil(feature)
+    }
+
+    func testFeatureDecodeWithRules() throws {
+        let json = """
+        {
+            "defaultValue": false,
+            "rules": [
+                {
+                    "id": "rule-1",
+                    "condition": {"country": "US"},
+                    "force": true,
+                    "coverage": 0.5,
+                    "hashAttribute": "id",
+                    "hashVersion": 2.0,
+                    "seed": "test-seed",
+                    "name": "US Rule"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let feature = try JSONDecoder().decode(Feature.self, from: json)
+        XCTAssertEqual(feature.defaultValue?.boolValue, false)
+        XCTAssertEqual(feature.rules?.count, 1)
+
+        let rule = try XCTUnwrap(feature.rules?.first)
+        XCTAssertEqual(rule.id, "rule-1")
+        XCTAssertEqual(rule.coverage, 0.5)
+        XCTAssertEqual(rule.hashAttribute, "id")
+        XCTAssertEqual(rule.hashVersion, 2.0)
+        XCTAssertEqual(rule.seed, "test-seed")
+        XCTAssertEqual(rule.name, "US Rule")
+        XCTAssertEqual(rule.force?.boolValue, true)
+    }
+
+    func testFeatureRuleDecodeVariations() throws {
+        let json = """
+        {
+            "id": "exp-rule",
+            "variations": ["control", "variant-a", "variant-b"],
+            "weights": [0.34, 0.33, 0.33],
+            "key": "my-exp-key",
+            "hashAttribute": "userId"
+        }
+        """.data(using: .utf8)!
+
+        let rule = try JSONDecoder().decode(FeatureRule.self, from: json)
+        XCTAssertEqual(rule.variations?.count, 3)
+        XCTAssertEqual(rule.variations?[0].stringValue, "control")
+        XCTAssertEqual(rule.weights?.count, 3)
+        XCTAssertEqual(rule.key, "my-exp-key")
+        XCTAssertEqual(rule.hashAttribute, "userId")
+    }
+
+    func testFeatureRuleDecodeBucketRanges() throws {
+        let json = """
+        {
+            "id": "range-rule",
+            "range": [0.0, 0.5],
+            "ranges": [[0.0, 0.25], [0.25, 0.5]]
+        }
+        """.data(using: .utf8)!
+
+        let rule = try JSONDecoder().decode(FeatureRule.self, from: json)
+        XCTAssertEqual(rule.range?.number1, 0.0)
+        XCTAssertEqual(rule.range?.number2, 0.5)
+        XCTAssertEqual(rule.ranges?.count, 2)
+        XCTAssertEqual(rule.ranges?[0].number1, 0.0)
+        XCTAssertEqual(rule.ranges?[0].number2, 0.25)
+    }
+
+    func testFeatureRuleDecodeStickyBucketFields() throws {
+        let json = """
+        {
+            "id": "sticky-rule",
+            "fallbackAttribute": "deviceId",
+            "disableStickyBucketing": true,
+            "bucketVersion": 3,
+            "minBucketVersion": 1
+        }
+        """.data(using: .utf8)!
+
+        let rule = try JSONDecoder().decode(FeatureRule.self, from: json)
+        XCTAssertEqual(rule.fallbackAttribute, "deviceId")
+        XCTAssertEqual(rule.disableStickyBucketing, true)
+        XCTAssertEqual(rule.bucketVersion, 3)
+        XCTAssertEqual(rule.minBucketVersion, 1)
+    }
+
+    func testFeatureRuleDecodeFilters() throws {
+        let json = """
+        {
+            "id": "filter-rule",
+            "filters": [
+                {"seed": "filter-seed", "hashVersion": 2, "ranges": [[0.0, 0.5]]}
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let rule = try JSONDecoder().decode(FeatureRule.self, from: json)
+        XCTAssertEqual(rule.filters?.count, 1)
+        XCTAssertEqual(rule.filters?[0].seed, "filter-seed")
+        XCTAssertEqual(rule.filters?[0].ranges.count, 1)
+    }
+
+    // MARK: - Experiment
+
+    func testExperimentDecodeBasic() throws {
+        // Note: the synthesised Codable uses "isActive" as the JSON key (not "active").
+        // "active" is only consumed by the manual init(json:) path used in the evaluator.
+        let json = """
+        {
+            "key": "my-experiment",
+            "variations": ["control", "variant"],
+            "weights": [0.5, 0.5],
+            "isActive": true,
+            "coverage": 1.0,
+            "hashAttribute": "id",
+            "seed": "exp-seed",
+            "name": "My Experiment",
+            "phase": "2"
+        }
+        """.data(using: .utf8)!
+
+        let experiment = try JSONDecoder().decode(Experiment.self, from: json)
+        XCTAssertEqual(experiment.key, "my-experiment")
+        XCTAssertEqual(experiment.variations.count, 2)
+        XCTAssertEqual(experiment.weights?.count, 2)
+        XCTAssertEqual(experiment.isActive, true)
+        XCTAssertEqual(experiment.coverage, 1.0)
+        XCTAssertEqual(experiment.hashAttribute, "id")
+        XCTAssertEqual(experiment.seed, "exp-seed")
+        XCTAssertEqual(experiment.name, "My Experiment")
+        XCTAssertEqual(experiment.phase, "2")
+    }
+
+    func testExperimentDecodeRanges() throws {
+        let json = """
+        {
+            "key": "range-exp",
+            "variations": [0, 1],
+            "ranges": [[0.0, 0.5], [0.5, 1.0]]
+        }
+        """.data(using: .utf8)!
+
+        let experiment = try JSONDecoder().decode(Experiment.self, from: json)
+        XCTAssertEqual(experiment.ranges?.count, 2)
+        XCTAssertEqual(experiment.ranges?[0].number1, 0.0)
+        XCTAssertEqual(experiment.ranges?[0].number2, 0.5)
+        XCTAssertEqual(experiment.ranges?[1].number1, 0.5)
+        XCTAssertEqual(experiment.ranges?[1].number2, 1.0)
+    }
+
+    func testExperimentDecodeStickyBucketFields() throws {
+        let json = """
+        {
+            "key": "sticky-exp",
+            "variations": [0, 1],
+            "fallbackAttribute": "deviceId",
+            "disableStickyBucketing": false,
+            "bucketVersion": 2,
+            "minBucketVersion": 0,
+            "hashVersion": 2.0
+        }
+        """.data(using: .utf8)!
+
+        let experiment = try JSONDecoder().decode(Experiment.self, from: json)
+        XCTAssertEqual(experiment.fallbackAttribute, "deviceId")
+        XCTAssertEqual(experiment.disableStickyBucketing, false)
+        XCTAssertEqual(experiment.bucketVersion, 2)
+        XCTAssertEqual(experiment.minBucketVersion, 0)
+        XCTAssertEqual(experiment.hashVersion, 2.0)
+    }
+
+    func testExperimentDecodeCondition() throws {
+        let json = """
+        {
+            "key": "cond-exp",
+            "variations": [0, 1],
+            "condition": {"country": "US", "premium": true}
+        }
+        """.data(using: .utf8)!
+
+        let experiment = try JSONDecoder().decode(Experiment.self, from: json)
+        XCTAssertEqual(experiment.condition?["country"].stringValue, "US")
+        XCTAssertEqual(experiment.condition?["premium"].boolValue, true)
+    }
+
+    func testExperimentDecodeMeta() throws {
+        let json = """
+        {
+            "key": "meta-exp",
+            "variations": [0, 1],
+            "meta": [
+                {"key": "control", "name": "Control", "passthrough": false},
+                {"key": "variant", "name": "Variant A", "passthrough": false}
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let experiment = try JSONDecoder().decode(Experiment.self, from: json)
+        XCTAssertEqual(experiment.meta?.count, 2)
+        XCTAssertEqual(experiment.meta?[0].key, "control")
+        XCTAssertEqual(experiment.meta?[1].name, "Variant A")
+    }
+
+    func testExperimentDecodeInactive() throws {
+        let json = """
+        {"key": "exp", "variations": [0, 1], "isActive": false}
+        """.data(using: .utf8)!
+
+        let experiment = try JSONDecoder().decode(Experiment.self, from: json)
+        XCTAssertEqual(experiment.isActive, false)
+    }
+
+    // MARK: - ExperimentResult
+
+    func testExperimentResultDecode() throws {
+        let json = """
+        {
+            "inExperiment": true,
+            "variationId": 1,
+            "value": "variant-value",
+            "hashAttribute": "id",
+            "valueHash": "abc123",
+            "key": "my-exp",
+            "name": "Variant A",
+            "bucket": 0.42,
+            "hashUsed": true,
+            "featureId": "my-feature",
+            "stickyBucketUsed": false
+        }
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(ExperimentResult.self, from: json)
+        XCTAssertEqual(result.inExperiment, true)
+        XCTAssertEqual(result.variationId, 1)
+        XCTAssertEqual(result.value.stringValue, "variant-value")
+        XCTAssertEqual(result.hashAttribute, "id")
+        XCTAssertEqual(result.valueHash, "abc123")
+        XCTAssertEqual(result.key, "my-exp")
+        XCTAssertEqual(result.name, "Variant A")
+        XCTAssertEqual(result.bucket, 0.42)
+        XCTAssertEqual(result.hashUsed, true)
+        XCTAssertEqual(result.featureId, "my-feature")
+        XCTAssertEqual(result.stickyBucketUsed, false)
+    }
+
+    func testExperimentResultDecodeDefaults() throws {
+        let json = """
+        {"key": "exp", "value": 0, "variationId": 0, "inExperiment": false}
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(ExperimentResult.self, from: json)
+        XCTAssertEqual(result.inExperiment, false)
+        XCTAssertNil(result.hashAttribute)
+        XCTAssertNil(result.featureId)
+        XCTAssertNil(result.stickyBucketUsed)
+    }
+
+    // MARK: - FeatureResult
+
+    func testFeatureResultDecodeViaJSON() throws {
+        let json = """
+        {
+            "on": true,
+            "off": false,
+            "source": "experiment",
+            "value": "red",
+            "ruleId": "rule-42"
+        }
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(FeatureResult.self, from: json)
+        XCTAssertEqual(result.isOn, true)
+        XCTAssertEqual(result.isOff, false)
+        XCTAssertEqual(result.source, "experiment")
+        XCTAssertEqual(result.value?.stringValue, "red")
+        XCTAssertEqual(result.ruleId, "rule-42")
+    }
+
+    func testFeatureResultInit() {
+        let result = FeatureResult(value: JSON("green"), isOn: true, source: FeatureSource.force.rawValue, ruleId: "r1")
+        XCTAssertEqual(result.isOn, true)
+        XCTAssertEqual(result.isOff, false)
+        XCTAssertEqual(result.source, "force")
+        XCTAssertEqual(result.value?.stringValue, "green")
+        XCTAssertEqual(result.ruleId, "r1")
+    }
+
+    func testFeatureResultIsOffInvertsIsOn() {
+        let onResult  = FeatureResult(value: JSON(true), isOn: true,  source: FeatureSource.defaultValue.rawValue)
+        let offResult = FeatureResult(value: JSON(false), isOn: false, source: FeatureSource.defaultValue.rawValue)
+        XCTAssertFalse(onResult.isOff)
+        XCTAssertTrue(offResult.isOff)
+    }
+
+    // MARK: - BucketRange
+
+    func testBucketRangeDecodeFromArray() throws {
+        let json = "[0.25, 0.75]".data(using: .utf8)!
+        let range = try JSONDecoder().decode(BucketRange.self, from: json)
+        XCTAssertEqual(range.number1, 0.25)
+        XCTAssertEqual(range.number2, 0.75)
+    }
+
+    func testBucketRangeEncodeToArray() throws {
+        let range = BucketRange(number1: 0.1, number2: 0.9)
+        let encoded = try JSONEncoder().encode(range)
+        let decoded = try JSONDecoder().decode([Float].self, from: encoded)
+        XCTAssertEqual(decoded[0], 0.1, accuracy: 0.0001)
+        XCTAssertEqual(decoded[1], 0.9, accuracy: 0.0001)
+    }
+
+    func testBucketRangeRoundtrip() throws {
+        let original = BucketRange(number1: 0.3333, number2: 0.6667)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(BucketRange.self, from: data)
+        XCTAssertEqual(decoded.number1, original.number1, accuracy: 0.0001)
+        XCTAssertEqual(decoded.number2, original.number2, accuracy: 0.0001)
+    }
+}

--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import GrowthBook
+
+class FeaturesViewModelExtendedTests: XCTestCase {
+
+    // MARK: - Delegate capture
+
+    private class Capture: FeaturesFlowDelegate {
+        var successCount = 0
+        var failCount = 0
+        var savedGroupsCount = 0
+        var lastError: SDKError?
+        var lastFeatures: Features?
+        var lastSavedGroups: JSON?
+
+        func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {
+            successCount += 1
+            lastFeatures = features
+        }
+        func featuresFetchFailed(error: SDKError, isRemote: Bool) {
+            failCount += 1
+            lastError = error
+        }
+        func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
+            savedGroupsCount += 1
+            lastSavedGroups = savedGroups
+        }
+        func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) { failCount += 1 }
+        func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+    }
+
+    private func makeVM(
+        response: String? = nil,
+        error: Error? = nil,
+        delegate: FeaturesFlowDelegate,
+        ttlSeconds: Int = 60,
+        apiKey: String = UUID().uuidString,
+        preloadedFeatures: Features? = nil
+    ) -> FeaturesViewModel {
+        let manager = CachingManager(apiKey: apiKey)
+        manager.clearCache()
+        let dataSource = FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: response, error: error))
+        return FeaturesViewModel(
+            delegate: delegate,
+            dataSource: dataSource,
+            cachingManager: manager,
+            ttlSeconds: ttlSeconds,
+            preloadedFeatures: preloadedFeatures
+        )
+    }
+
+    // MARK: - preloadedFeatures skips cache read
+
+    func testPreloadedFeaturesSkipsCacheRead() {
+        let capture = Capture()
+        // preloadedFeatures is provided → fetchCachedFeatures is NOT called
+        // so no featuresFetchFailed from empty cache
+        let preloaded: Features = ["flag": Feature(defaultValue: JSON(true))]
+        _ = makeVM(delegate: capture, preloadedFeatures: preloaded)
+        // With preloadedFeatures, the VM skips the cache → no success or fail from cache
+        XCTAssertEqual(capture.successCount, 0)
+        XCTAssertEqual(capture.failCount, 0)
+    }
+
+    func testNoPreloadedFeaturesReadsCache() {
+        let capture = Capture()
+        // No preloadedFeatures and empty cache → featuresFetchFailed
+        _ = makeVM(delegate: capture)
+        XCTAssertEqual(capture.failCount, 1)
+        XCTAssertEqual(capture.lastError, .failedToLoadData)
+    }
+
+    // MARK: - fetchFeatures with nil apiUrl skips network
+
+    func testFetchFeaturesNilApiUrlSkipsNetwork() {
+        let capture = Capture()
+        let vm = makeVM(response: MockResponse().successResponse, delegate: capture, ttlSeconds: 0)
+        let beforeFail = capture.failCount
+        vm.fetchFeatures(apiUrl: nil)
+        // No network call → no additional success
+        XCTAssertEqual(capture.successCount, 0)
+        XCTAssertEqual(capture.failCount, beforeFail + 1) // one more fail from cache read in fetchFeatures
+    }
+
+    // MARK: - remoteEval path
+
+    func testFetchFeaturesRemoteEvalSuccess() {
+        let capture = Capture()
+        let vm = makeVM(response: MockResponse().successResponse, delegate: capture, ttlSeconds: 0)
+        vm.fetchFeatures(apiUrl: "https://example.com", remoteEval: true)
+        // Remote eval success should trigger featuresFetchedSuccessfully
+        XCTAssertGreaterThan(capture.successCount, 0)
+    }
+
+    func testFetchFeaturesRemoteEvalFailure() {
+        let capture = Capture()
+        let vm = makeVM(error: SDKError.failedToFetchData, delegate: capture, ttlSeconds: 0)
+        vm.fetchFeatures(apiUrl: "https://example.com", remoteEval: true)
+        XCTAssertGreaterThan(capture.failCount, 0)
+    }
+
+    // MARK: - prepareFeaturesData: encryptedFeatures without key
+
+    func testPrepareFeaturesDataEncryptedFeaturesWithoutKeyFails() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        // encryptedFeatures present but no encryptionKey set
+        let payload = """
+        {"status":200,"encryptedFeatures":"someencryptedstring==.abc"}
+        """.data(using: .utf8)!
+        vm.prepareFeaturesData(data: payload)
+        XCTAssertGreaterThan(capture.failCount, 0)
+        XCTAssertEqual(capture.lastError, .failedMissingKey)
+    }
+
+    func testPrepareFeaturesDataEncryptedFeaturesWithWrongKeyFails() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        vm.encryptionKey = "wrong-key-that-is-short"
+        let payload = """
+        {"status":200,"encryptedFeatures":"someencryptedstring==.abc"}
+        """.data(using: .utf8)!
+        vm.prepareFeaturesData(data: payload)
+        XCTAssertGreaterThan(capture.failCount, 0)
+        XCTAssertEqual(capture.lastError, .failedEncryptedFeatures)
+    }
+
+    // MARK: - prepareFeaturesData: no features and no encryptedFeatures
+
+    func testPrepareFeaturesDataNoFeaturesFails() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        let payload = """
+        {"status":200}
+        """.data(using: .utf8)!
+        vm.prepareFeaturesData(data: payload)
+        XCTAssertGreaterThan(capture.failCount, 0)
+        XCTAssertEqual(capture.lastError, .failedMissingKey)
+    }
+
+    // MARK: - prepareFeaturesData: plain features success
+
+    func testPrepareFeaturesDataPlainFeaturesSuccess() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        let payload = """
+        {"status":200,"features":{"my-flag":{"defaultValue":true}}}
+        """.data(using: .utf8)!
+        vm.prepareFeaturesData(data: payload)
+        XCTAssertEqual(capture.successCount, 1)
+        XCTAssertNotNil(capture.lastFeatures?["my-flag"])
+    }
+
+    // MARK: - prepareFeaturesData: invalid JSON fails
+
+    func testPrepareFeaturesDataInvalidJsonFails() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        vm.prepareFeaturesData(data: "not json".data(using: .utf8)!)
+        XCTAssertGreaterThan(capture.failCount, 0)
+        XCTAssertEqual(capture.lastError, .failedParsedData)
+    }
+
+    // MARK: - prepareFeaturesData: savedGroups in response
+
+    func testPrepareFeaturesDataWithSavedGroups() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        let payload = """
+        {"status":200,"features":{"f":{"defaultValue":1}},"savedGroups":{"team":["a","b"]}}
+        """.data(using: .utf8)!
+        vm.prepareFeaturesData(data: payload)
+        XCTAssertEqual(capture.savedGroupsCount, 1)
+        XCTAssertNotNil(capture.lastSavedGroups)
+    }
+
+    // MARK: - fetchFeatures network failure falls back to cache
+
+    func testFetchFeaturesNetworkFailureFallsBackToCache() {
+        let capture = Capture()
+        // First populate cache
+        let apiKey = UUID().uuidString
+        let manager = CachingManager(apiKey: apiKey)
+        manager.clearCache()
+
+        // Populate cache via a successful VM
+        let populateCapture = Capture()
+        let populateVM = FeaturesViewModel(
+            delegate: populateCapture,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(
+                successResponse: MockResponse().successResponse, error: nil
+            )),
+            cachingManager: manager,
+            ttlSeconds: 0
+        )
+        populateVM.fetchFeatures(apiUrl: "https://example.com")
+
+        // Now fail the network → should fall back to cache
+        let failVM = FeaturesViewModel(
+            delegate: capture,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(
+                successResponse: nil, error: SDKError.failedToFetchData
+            )),
+            cachingManager: manager,
+            ttlSeconds: 0
+        )
+        failVM.fetchFeatures(apiUrl: "https://example.com")
+        // After network fail, falls back to cache → at least one success
+        XCTAssertGreaterThan(capture.successCount, 0)
+    }
+}

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -1,0 +1,344 @@
+import XCTest
+@testable import GrowthBook
+
+class GrowthBookSDKTests: XCTestCase {
+
+    let apiHost    = "https://host.com"
+    let clientKey  = "sdk-test-key"
+    let attributes: JSON = JSON(["id": "user-1", "country": "US"])
+
+    // MARK: - Helpers
+
+    private func makeSDK(
+        features: Data? = nil,
+        networkResponse: String? = nil,
+        networkError: Error? = nil,
+        ttlSeconds: Int = 60
+    ) -> GrowthBookSDK {
+        GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "US"],
+            features: features,
+            trackingCallback: { _, _ in },
+            backgroundSync: false,
+            ttlSeconds: ttlSeconds
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(
+            successResponse: networkResponse ?? MockResponse().successResponse,
+            error: networkError
+        ))
+        .initializer()
+    }
+
+    private func makeSDKWithFeatures() -> GrowthBookSDK {
+        let payload = """
+        {"features":{"flag-a":{"defaultValue":true},"flag-b":{"defaultValue":false}}}
+        """.data(using: .utf8)!
+        return makeSDK(features: payload)
+    }
+
+    // MARK: - isOn
+
+    func testIsOnReturnsTrueForKnownFeature() {
+        let sdk = makeSDKWithFeatures()
+        XCTAssertTrue(sdk.isOn(feature: "flag-a"))
+    }
+
+    func testIsOnReturnsFalseForFeatureWithDefaultFalse() {
+        let sdk = makeSDKWithFeatures()
+        XCTAssertFalse(sdk.isOn(feature: "flag-b"))
+    }
+
+    func testIsOnReturnsFalseForUnknownFeature() {
+        let sdk = makeSDKWithFeatures()
+        XCTAssertFalse(sdk.isOn(feature: "nonexistent"))
+    }
+
+    // MARK: - getFeatureValue
+
+    func testGetFeatureValueReturnsDefaultValue() {
+        let sdk = makeSDKWithFeatures()
+        let value = sdk.getFeatureValue(feature: "flag-a", default: JSON(false))
+        XCTAssertEqual(value.boolValue, true)
+    }
+
+    func testGetFeatureValueReturnsNullForUnknownFeature() {
+        let sdk = makeSDKWithFeatures()
+        // Unknown features have no value (nil stored as JSON.null), so ?? fallback doesn't apply
+        let value = sdk.getFeatureValue(feature: "nonexistent", default: JSON("fallback"))
+        XCTAssertEqual(value, JSON.null)
+    }
+
+    func testGetFeatureValueReturnsStringFeatureValue() {
+        let payload = """
+        {"features":{"theme":{"defaultValue":"dark"}}}
+        """.data(using: .utf8)!
+        let sdk = makeSDK(features: payload)
+        let value = sdk.getFeatureValue(feature: "theme", default: JSON("light"))
+        XCTAssertEqual(value.stringValue, "dark")
+    }
+
+    // MARK: - getGBAttributes
+
+    func testGetGBAttributesReturnsCurrentAttributes() {
+        let sdk = makeSDKWithFeatures()
+        let attrs = sdk.getGBAttributes()
+        XCTAssertEqual(attrs["id"].stringValue, "user-1")
+        XCTAssertEqual(attrs["country"].stringValue, "US")
+    }
+
+    // MARK: - setAttributes
+
+    func testSetAttributesReplacesAttributes() {
+        let sdk = makeSDKWithFeatures()
+        sdk.setAttributes(attributes: ["id": "user-99", "plan": "premium"])
+        let attrs = sdk.getGBAttributes()
+        XCTAssertEqual(attrs["id"].stringValue, "user-99")
+        XCTAssertEqual(attrs["plan"].stringValue, "premium")
+        XCTAssertEqual(attrs["country"].stringValue, "")
+    }
+
+    func testSetAttributesEmptyDict() {
+        let sdk = makeSDKWithFeatures()
+        sdk.setAttributes(attributes: [:])
+        XCTAssertTrue(sdk.getGBAttributes().dictionaryValue.isEmpty)
+    }
+
+    // MARK: - setForcedFeatures
+
+    func testSetForcedFeaturesOverridesEvaluation() {
+        let payload = """
+        {"features":{"promo":{"defaultValue":false}}}
+        """.data(using: .utf8)!
+        let sdk = makeSDK(features: payload)
+
+        XCTAssertFalse(sdk.isOn(feature: "promo"))
+
+        sdk.setForcedFeatures(forcedFeatures: ["promo": true])
+
+        XCTAssertTrue(sdk.isOn(feature: "promo"))
+    }
+
+    func testSetForcedFeaturesCanBeCleared() {
+        let payload = """
+        {"features":{"flag":{"defaultValue":false}}}
+        """.data(using: .utf8)!
+        let sdk = makeSDK(features: payload)
+
+        sdk.setForcedFeatures(forcedFeatures: ["flag": true])
+        XCTAssertTrue(sdk.isOn(feature: "flag"))
+
+        sdk.setForcedFeatures(forcedFeatures: [:])
+        XCTAssertFalse(sdk.isOn(feature: "flag"))
+    }
+
+    // MARK: - setForcedVariations (SDK method)
+
+    func testSetForcedVariationsUpdatesContext() {
+        let sdk = makeSDKWithFeatures()
+        sdk.setForcedVariations(forcedVariations: ["my-exp": 1])
+        let context = sdk.getGBContext()
+        XCTAssertEqual(context.forcedVariations?["my-exp"].intValue, 1)
+    }
+
+    // MARK: - setAttributeOverrides
+
+    func testSetAttributeOverridesDoesNotCrash() {
+        let sdk = makeSDKWithFeatures()
+        sdk.setAttributeOverrides(overrides: ["plan": "enterprise"])
+        // No assertion needed — verifies it doesn't crash and updates state
+        XCTAssertNotNil(sdk)
+    }
+
+    // MARK: - subscribe / clearSubscriptions
+
+    func testSubscribeReceivesExperimentCallback() {
+        let sdk = makeSDKWithFeatures()
+
+        var receivedExperiment: Experiment?
+        sdk.subscribe { experiment, _ in
+            receivedExperiment = experiment
+        }
+
+        let exp = Experiment(key: "test-exp", variations: ["a", "b"])
+        _ = sdk.run(experiment: exp)
+
+        XCTAssertEqual(receivedExperiment?.key, "test-exp")
+    }
+
+    func testMultipleSubscribersAllReceiveCallback() {
+        let sdk = makeSDKWithFeatures()
+        var count = 0
+        sdk.subscribe { _, _ in count += 1 }
+        sdk.subscribe { _, _ in count += 1 }
+        sdk.subscribe { _, _ in count += 1 }
+
+        _ = sdk.run(experiment: Experiment(key: "exp", variations: ["a", "b"]))
+
+        XCTAssertEqual(count, 3)
+    }
+
+    func testClearSubscriptionsStopsCallbacks() {
+        let sdk = makeSDKWithFeatures()
+        var called = false
+        sdk.subscribe { _, _ in called = true }
+        sdk.clearSubscriptions()
+
+        _ = sdk.run(experiment: Experiment(key: "exp", variations: ["a", "b"]))
+
+        XCTAssertFalse(called)
+    }
+
+    // MARK: - updateApiRequestHeaders / updateStreamingHostRequestHeaders
+
+    func testUpdateApiRequestHeadersDoesNotCrash() {
+        let sdk = makeSDKWithFeatures()
+        sdk.updateApiRequestHeaders(["X-Custom": "value"])
+        XCTAssertNotNil(sdk)
+    }
+
+    func testUpdateStreamingHostRequestHeadersDoesNotCrash() {
+        let sdk = makeSDKWithFeatures()
+        sdk.updateStreamingHostRequestHeaders(["Authorization": "Bearer token"])
+        XCTAssertNotNil(sdk)
+    }
+
+    // MARK: - Builder: setForcedFeatures
+
+    func testBuilderSetForcedFeaturesApplied() {
+        let payload = """
+        {"features":{"premium":{"defaultValue":false}}}
+        """.data(using: .utf8)!
+        let sdk = GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            attributes: [:],
+            features: payload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setForcedFeatures(forcedFeatures: ["premium": true])
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        XCTAssertTrue(sdk.isOn(feature: "premium"))
+    }
+
+    // MARK: - Builder: setStreamingHost
+
+    func testBuilderSetStreamingHostApplied() {
+        let sdk = GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            attributes: [:],
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setStreamingHost(streamingHost: "https://custom-streaming.com")
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        let context = sdk.getGBContext()
+        XCTAssertEqual(context.streamingHost, "https://custom-streaming.com")
+    }
+
+    // MARK: - Builder: setLogLevel
+
+    func testBuilderSetLogLevelDoesNotCrash() {
+        let sdk = GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            attributes: [:],
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setLogLevel(.warning)
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        XCTAssertNotNil(sdk)
+    }
+
+    // MARK: - Builder: setStickyBucketService
+
+    func testBuilderSetStickyBucketService() {
+        let service = StickyBucketService(prefix: "test__")
+        let sdk = GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            attributes: [:],
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setStickyBucketService(stickyBucketService: service)
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketService)
+    }
+
+    // MARK: - featuresFetchFailed propagates to refreshHandler
+
+    func testFeaturesFetchFailedCallsRefreshHandlerWithError() {
+        let exp = expectation(description: "refreshHandler called with error")
+        exp.assertForOverFulfill = false
+        var receivedError: SDKError?
+
+        let cachingManager = CachingManager(apiKey: "isolated-error-test")
+        cachingManager.clearCache()
+
+        let sdk = GrowthBookBuilder(
+            growthBookBuilderModel: GrowthBookModel(
+                apiHost: apiHost, clientKey: "isolated-error-test",
+                attributes: JSON([:]), trackingClosure: { _, _ in },
+                backgroundSync: false
+            ),
+            networkDispatcher: MockNetworkClient(successResponse: nil, error: SDKError.failedToFetchData),
+            ttlSeconds: 0,
+            cachingManager: cachingManager,
+            refreshHandler: { error in
+                if let error = error {
+                    receivedError = error
+                    exp.fulfill()
+                }
+            }
+        ).initializer()
+
+        _ = sdk
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertNotNil(receivedError)
+    }
+
+    // MARK: - savedGroupsFetchedSuccessfully updates context
+
+    func testSavedGroupsAreAppliedToContext() {
+        let exp = expectation(description: "savedGroups applied")
+        exp.assertForOverFulfill = false
+        var savedGroupsApplied = false
+
+        let cachingManager = CachingManager(apiKey: "isolated-savedgroups-test")
+        cachingManager.clearCache()
+
+        let sdk = GrowthBookBuilder(
+            growthBookBuilderModel: GrowthBookModel(
+                apiHost: apiHost, clientKey: "isolated-savedgroups-test",
+                attributes: JSON([:]), trackingClosure: { _, _ in },
+                backgroundSync: false
+            ),
+            networkDispatcher: MockNetworkClient(
+                successResponse: MockResponse().successResponse,
+                error: nil
+            ),
+            ttlSeconds: 0,
+            cachingManager: cachingManager,
+            refreshHandler: { _ in
+                exp.fulfill()
+            }
+        ).initializer()
+
+        wait(for: [exp], timeout: 2.0)
+        savedGroupsApplied = sdk.getGBContext().savedGroups != nil
+        XCTAssertTrue(savedGroupsApplied)
+    }
+}

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -283,7 +283,6 @@ class GrowthBookSDKTests: XCTestCase {
     func testFeaturesFetchFailedCallsRefreshHandlerWithError() {
         let exp = expectation(description: "refreshHandler called with error")
         exp.assertForOverFulfill = false
-        var receivedError: SDKError?
 
         let cachingManager = CachingManager(apiKey: "isolated-error-test")
         cachingManager.clearCache()
@@ -298,16 +297,12 @@ class GrowthBookSDKTests: XCTestCase {
             ttlSeconds: 0,
             cachingManager: cachingManager,
             refreshHandler: { error in
-                if let error = error {
-                    receivedError = error
-                    exp.fulfill()
-                }
+                if error != nil { exp.fulfill() }
             }
         ).initializer()
 
         _ = sdk
         wait(for: [exp], timeout: 2.0)
-        XCTAssertNotNil(receivedError)
     }
 
     // MARK: - savedGroupsFetchedSuccessfully updates context

--- a/GrowthBookTests/MiscCoverageTests.swift
+++ b/GrowthBookTests/MiscCoverageTests.swift
@@ -1,0 +1,375 @@
+import XCTest
+@testable import GrowthBook
+
+// MARK: - FeaturesDataModel
+
+class FeaturesDataModelTests: XCTestCase {
+
+    func testInitWithAllFields() {
+        let model = FeaturesDataModel(
+            features: ["flag": Feature(defaultValue: JSON(true))],
+            encryptedFeatures: "enc-features",
+            dateUpdated: "2024-01-01",
+            savedGroups: JSON(["group": ["a", "b"]]),
+            encryptedSavedGroups: "enc-groups",
+            experiments: [],
+            encryptedExperiments: "enc-exp"
+        )
+        XCTAssertNotNil(model.features)
+        XCTAssertEqual(model.encryptedFeatures, "enc-features")
+        XCTAssertEqual(model.dateUpdated, "2024-01-01")
+        XCTAssertNotNil(model.savedGroups)
+        XCTAssertEqual(model.encryptedSavedGroups, "enc-groups")
+        XCTAssertNotNil(model.experiments)
+        XCTAssertEqual(model.encryptedExperiments, "enc-exp")
+    }
+
+    func testDefaultInit() {
+        let model = FeaturesDataModel()
+        XCTAssertNil(model.features)
+        XCTAssertNil(model.encryptedFeatures)
+        XCTAssertNil(model.savedGroups)
+    }
+
+    func testCodableDecode() throws {
+        let json = """
+        {"features":{"flag":{"defaultValue":true}},"dateUpdated":"2024-01-01","savedGroups":{"g":["1","2"]}}
+        """.data(using: .utf8)!
+        let model = try JSONDecoder().decode(FeaturesDataModel.self, from: json)
+        XCTAssertNotNil(model.features?["flag"])
+        XCTAssertEqual(model.dateUpdated, "2024-01-01")
+        XCTAssertNotNil(model.savedGroups)
+    }
+}
+
+// MARK: - StickyAssignmentsDocument JSON init
+
+class StickyAssignmentsDocumentJsonInitTests: XCTestCase {
+
+    func testInitWithJsonAssignments() {
+        let jsonAssignments: [String: JSON] = [
+            "exp__0": JSON("control"),
+            "exp2__0": JSON("variant")
+        ]
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "user-1",
+            assignments: jsonAssignments
+        )
+        XCTAssertEqual(doc.attributeName, "id")
+        XCTAssertEqual(doc.attributeValue, "user-1")
+        XCTAssertEqual(doc.assignments["exp__0"], "control")
+        XCTAssertEqual(doc.assignments["exp2__0"], "variant")
+    }
+
+    func testInitWithJsonAssignmentsEmpty() {
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "u",
+            assignments: [String: JSON]()
+        )
+        XCTAssertTrue(doc.assignments.isEmpty)
+    }
+
+    func testInitWithJsonAssignmentsBoolValue() {
+        let jsonAssignments: [String: JSON] = ["flag__0": JSON(true)]
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "u",
+            assignments: jsonAssignments
+        )
+        XCTAssertEqual(doc.assignments["flag__0"], "true")
+    }
+}
+
+// MARK: - Context URL methods
+
+class ContextURLTests: XCTestCase {
+
+    private func makeContext(apiHost: String? = "https://cdn.growthbook.io", clientKey: String? = "sdk-key", streamingHost: String? = nil) -> Context {
+        Context(
+            apiHost: apiHost,
+            streamingHost: streamingHost,
+            clientKey: clientKey,
+            encryptionKey: nil,
+            isEnabled: true,
+            attributes: JSON([:]),
+            forcedVariations: nil,
+            isQaMode: false,
+            trackingClosure: { _, _ in }
+        )
+    }
+
+    // getFeaturesURL
+
+    func testGetFeaturesURLWithValidValues() {
+        let ctx = makeContext()
+        XCTAssertEqual(ctx.getFeaturesURL(), "https://cdn.growthbook.io/api/features/sdk-key")
+    }
+
+    func testGetFeaturesURLNilApiHost() {
+        let ctx = makeContext(apiHost: nil)
+        XCTAssertNil(ctx.getFeaturesURL())
+    }
+
+    func testGetFeaturesURLNilClientKey() {
+        let ctx = makeContext(clientKey: nil)
+        XCTAssertNil(ctx.getFeaturesURL())
+    }
+
+    // getRemoteEvalUrl
+
+    func testGetRemoteEvalUrlWithValidValues() {
+        let ctx = makeContext()
+        XCTAssertEqual(ctx.getRemoteEvalUrl(), "https://cdn.growthbook.io/api/eval/sdk-key")
+    }
+
+    func testGetRemoteEvalUrlNilApiHost() {
+        XCTAssertNil(makeContext(apiHost: nil).getRemoteEvalUrl())
+    }
+
+    func testGetRemoteEvalUrlNilClientKey() {
+        XCTAssertNil(makeContext(clientKey: nil).getRemoteEvalUrl())
+    }
+
+    // getSSEUrl
+
+    func testGetSSEUrlUsesStreamingHostWhenSet() {
+        let ctx = makeContext(streamingHost: "https://streaming.growthbook.io")
+        XCTAssertEqual(ctx.getSSEUrl(), "https://streaming.growthbook.io/sub/sdk-key")
+    }
+
+    func testGetSSEUrlFallsBackToApiHost() {
+        let ctx = makeContext()
+        XCTAssertEqual(ctx.getSSEUrl(), "https://cdn.growthbook.io/sub/sdk-key")
+    }
+
+    func testGetSSEUrlNilBothHosts() {
+        let ctx = makeContext(apiHost: nil)
+        XCTAssertNil(ctx.getSSEUrl())
+    }
+
+    func testGetSSEUrlNilClientKey() {
+        XCTAssertNil(makeContext(clientKey: nil).getSSEUrl())
+    }
+}
+
+// MARK: - Formatter
+
+class FormatterTests: XCTestCase {
+
+    private let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func callFormat(components: [Component], format: String = "%@") -> String {
+        let formatter = Formatter(format, components)
+        return formatter.format(
+            level: .info,
+            items: ["hello"],
+            separator: " ",
+            terminator: "",
+            file: "/path/to/MyFile.swift",
+            line: 42,
+            column: 5,
+            function: "testFunc()",
+            date: date
+        )
+    }
+
+    // MARK: Components in log format
+
+    func testMessageComponent() {
+        let result = callFormat(components: [.message])
+        XCTAssertEqual(result, "hello")
+    }
+
+    func testLevelComponent() {
+        let result = callFormat(components: [.level])
+        XCTAssertTrue(result.lowercased().contains("info"))
+    }
+
+    func testLineComponent() {
+        let result = callFormat(components: [.line])
+        XCTAssertEqual(result, "42")
+    }
+
+    func testColumnComponent() {
+        let result = callFormat(components: [.column])
+        XCTAssertEqual(result, "5")
+    }
+
+    func testFunctionComponent() {
+        let result = callFormat(components: [.function])
+        XCTAssertEqual(result, "testFunc()")
+    }
+
+    func testDateComponent() {
+        let result = callFormat(components: [.date("yyyy")])
+        XCTAssertFalse(result.isEmpty)
+    }
+
+    func testLocationComponent() {
+        let result = callFormat(components: [.location])
+        XCTAssertTrue(result.contains("MyFile.swift"))
+        XCTAssertTrue(result.contains("42"))
+    }
+
+    func testFileFullPathWithExtension() {
+        let result = callFormat(components: [.file(fullPath: true, fileExtension: true)])
+        XCTAssertTrue(result.contains("/path/to/MyFile.swift"))
+    }
+
+    func testFileShortNameNoExtension() {
+        let result = callFormat(components: [.file(fullPath: false, fileExtension: false)])
+        XCTAssertEqual(result, "MyFile")
+    }
+
+    func testFileShortNameWithExtension() {
+        let result = callFormat(components: [.file(fullPath: false, fileExtension: true)])
+        XCTAssertEqual(result, "MyFile.swift")
+    }
+
+    func testBlockComponentReturnsValue() {
+        let result = callFormat(components: [.block({ "block-value" })])
+        XCTAssertEqual(result, "block-value")
+    }
+
+    func testBlockComponentReturnsNilFallback() {
+        let result = callFormat(components: [.block({ nil })])
+        XCTAssertEqual(result, "")
+    }
+
+    func testMultipleItemsSeparator() {
+        let formatter = Formatter("%@", [.message])
+        let result = formatter.format(
+            level: .debug,
+            items: ["a", "b", "c"],
+            separator: "-",
+            terminator: "",
+            file: "f.swift",
+            line: 1,
+            column: 1,
+            function: "f()",
+            date: date
+        )
+        XCTAssertEqual(result, "a-b-c")
+    }
+
+    func testTerminatorAppended() {
+        let formatter = Formatter("%@", [.message])
+        let result = formatter.format(
+            level: .debug,
+            items: ["msg"],
+            separator: " ",
+            terminator: "\n",
+            file: "f.swift",
+            line: 1,
+            column: 1,
+            function: "f()",
+            date: date
+        )
+        XCTAssertTrue(result.hasSuffix("\n"))
+    }
+
+    // MARK: measure format overload
+
+    func testMeasureFormatAllComponents() {
+        let formatter = Formatter("%@ %@ %@ %@ %@ %@", [
+            .date("yyyy"),
+            .file(fullPath: false, fileExtension: false),
+            .function,
+            .line,
+            .level,
+            .message
+        ])
+        let result = formatter.format(
+            description: "my-measure",
+            average: 0.123,
+            relativeStandardDeviation: 5.0,
+            file: "/path/to/File.swift",
+            line: 10,
+            column: 1,
+            function: "myFunc()",
+            date: date
+        )
+        XCTAssertTrue(result.contains("0.123"))
+        XCTAssertTrue(result.contains("STDEV"))
+        XCTAssertTrue(result.contains("MEASURE"))
+    }
+
+    func testMeasureFormatLocationAndBlockComponents() {
+        let formatter = Formatter("%@ %@", [
+            .location,
+            .block({ "extra" })
+        ])
+        let result = formatter.format(
+            description: nil,
+            average: 1.0,
+            relativeStandardDeviation: 0.5,
+            file: "/path/to/File.swift",
+            line: 5,
+            column: 1,
+            function: "f()",
+            date: date
+        )
+        XCTAssertTrue(result.contains("File.swift:5"))
+        XCTAssertTrue(result.contains("extra"))
+    }
+
+    // MARK: description property
+
+    func testDescriptionProperty() {
+        let formatter = Formatter("[%@] %@", [.level, .message])
+        let desc = formatter.description
+        XCTAssertTrue(desc.contains("LEVEL"))
+        XCTAssertTrue(desc.contains("MESSAGE"))
+    }
+
+    // MARK: Predefined formatters
+
+    func testDefaultFormatterProducesOutput() {
+        let result = Formatters.default.format(
+            level: .warning,
+            items: ["test"],
+            separator: " ",
+            terminator: "",
+            file: "F.swift",
+            line: 1,
+            column: 1,
+            function: "f()",
+            date: date
+        )
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertTrue(result.lowercased().contains("warning") || result.contains("WARNING"))
+    }
+
+    func testMinimalFormatterProducesOutput() {
+        let result = Formatters.minimal.format(
+            level: .error,
+            items: ["err"],
+            separator: " ",
+            terminator: "",
+            file: "F.swift",
+            line: 1,
+            column: 1,
+            function: "f()",
+            date: date
+        )
+        XCTAssertTrue(result.contains("err"))
+    }
+
+    func testDetailedFormatterProducesOutput() {
+        let result = Formatters.detailed.format(
+            level: .debug,
+            items: ["detail"],
+            separator: " ",
+            terminator: "",
+            file: "/path/F.swift",
+            line: 99,
+            column: 1,
+            function: "myFunc()",
+            date: date
+        )
+        XCTAssertTrue(result.contains("detail"))
+        XCTAssertTrue(result.contains("99"))
+    }
+}

--- a/GrowthBookTests/StickyBucketServiceTests.swift
+++ b/GrowthBookTests/StickyBucketServiceTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import GrowthBook
+
+class StickyBucketServiceTests: XCTestCase {
+
+    var service: StickyBucketService!
+    let testPrefix = "test_sticky_\(Int.random(in: 100_000...999_999))__"
+
+    override func setUp() {
+        super.setUp()
+        service = StickyBucketService(prefix: testPrefix)
+    }
+
+    // MARK: - getAssignments returns nil when nothing is saved
+
+    func testGetAssignmentsReturnsNilForUnknownKey() {
+        let expectation = expectation(description: "completion called")
+        service.getAssignments(attributeName: "id", attributeValue: "nonexistent-user") { doc, error in
+            XCTAssertNil(doc)
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - saveAssignments → getAssignments round-trip
+
+    func testSaveAndGetAssignments() {
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "user-abc",
+            assignments: ["exp-1__0": "control", "exp-2__0": "variant"]
+        )
+
+        let saveExpectation = expectation(description: "save completed")
+        service.saveAssignments(doc: doc) { _ in saveExpectation.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let getExpectation = expectation(description: "get completed")
+        service.getAssignments(attributeName: "id", attributeValue: "user-abc") { retrieved, error in
+            XCTAssertNotNil(retrieved)
+            XCTAssertNil(error)
+            XCTAssertEqual(retrieved?.attributeName, "id")
+            XCTAssertEqual(retrieved?.attributeValue, "user-abc")
+            XCTAssertEqual(retrieved?.assignments["exp-1__0"], "control")
+            XCTAssertEqual(retrieved?.assignments["exp-2__0"], "variant")
+            getExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - saveAssignments overwrites existing doc
+
+    func testSaveAssignmentsOverwritesPreviousDoc() {
+        let original = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-xyz",
+            assignments: ["exp-1__0": "control"]
+        )
+        let updated = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-xyz",
+            assignments: ["exp-1__0": "variant"]
+        )
+
+        let save1 = expectation(description: "first save")
+        service.saveAssignments(doc: original) { _ in save1.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let save2 = expectation(description: "second save")
+        service.saveAssignments(doc: updated) { _ in save2.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let get = expectation(description: "get")
+        service.getAssignments(attributeName: "id", attributeValue: "user-xyz") { retrieved, _ in
+            XCTAssertEqual(retrieved?.assignments["exp-1__0"], "variant")
+            get.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - getAllAssignments
+
+    func testGetAllAssignmentsReturnsOnlyMatchingDocs() {
+        let docA = StickyAssignmentsDocument(attributeName: "id",       attributeValue: "user-1",   assignments: ["exp__0": "a"])
+        let docB = StickyAssignmentsDocument(attributeName: "deviceId", attributeValue: "device-1", assignments: ["exp__0": "b"])
+
+        let s1 = expectation(description: "save A"); service.saveAssignments(doc: docA) { _ in s1.fulfill() }
+        let s2 = expectation(description: "save B"); service.saveAssignments(doc: docB) { _ in s2.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let getAllExp = expectation(description: "getAll")
+        service.getAllAssignments(attributes: ["id": "user-1", "deviceId": "device-1"]) { docs, error in
+            XCTAssertNil(error)
+            XCTAssertEqual(docs?.count, 2)
+            XCTAssertNotNil(docs?["id||user-1"])
+            XCTAssertNotNil(docs?["deviceId||device-1"])
+            getAllExp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testGetAllAssignmentsReturnsEmptyWhenNothingSaved() {
+        let exp = expectation(description: "getAll empty")
+        service.getAllAssignments(attributes: ["id": "unknown-user"]) { docs, error in
+            XCTAssertNil(error)
+            XCTAssertTrue(docs?.isEmpty ?? true)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - Different prefixes are isolated
+
+    func testDifferentPrefixesDoNotShareData() {
+        let serviceA = StickyBucketService(prefix: "prefix_a__")
+        let serviceB = StickyBucketService(prefix: "prefix_b__")
+
+        let doc = StickyAssignmentsDocument(attributeName: "id", attributeValue: "shared-user", assignments: ["exp__0": "variant"])
+
+        let saveExp = expectation(description: "save in A")
+        serviceA.saveAssignments(doc: doc) { _ in saveExp.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let getExp = expectation(description: "get from B")
+        serviceB.getAssignments(attributeName: "id", attributeValue: "shared-user") { retrieved, _ in
+            XCTAssertNil(retrieved, "prefix_b should not see data saved under prefix_a")
+            getExp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/GrowthBookTests/UtilsExtendedTests.swift
+++ b/GrowthBookTests/UtilsExtendedTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import GrowthBook
+
+class UtilsExtendedTests: XCTestCase {
+
+    // MARK: - hash edge cases
+
+    func testHashVersionOneReturnsBetweenZeroAndOne() {
+        let result = Utils.hash(seed: "test", value: "user-123", version: 1)
+        XCTAssertNotNil(result)
+        XCTAssertGreaterThanOrEqual(result!, 0.0)
+        XCTAssertLessThanOrEqual(result!, 1.0)
+    }
+
+    func testHashVersionTwoReturnsBetweenZeroAndOne() {
+        let result = Utils.hash(seed: "test", value: "user-123", version: 2)
+        XCTAssertNotNil(result)
+        XCTAssertGreaterThanOrEqual(result!, 0.0)
+        XCTAssertLessThanOrEqual(result!, 1.0)
+    }
+
+    func testHashVersionTwoDifferentFromVersionOne() {
+        let v1 = Utils.hash(seed: "seed", value: "abc", version: 1)
+        let v2 = Utils.hash(seed: "seed", value: "abc", version: 2)
+        XCTAssertNotNil(v1)
+        XCTAssertNotNil(v2)
+        XCTAssertNotEqual(v1, v2)
+    }
+
+    func testHashUnknownVersionReturnsNil() {
+        XCTAssertNil(Utils.hash(seed: "seed", value: "value", version: 99))
+        XCTAssertNil(Utils.hash(seed: "seed", value: "value", version: 0))
+    }
+
+    func testHashIsDeterministic() {
+        let a = Utils.hash(seed: "s", value: "v", version: 2)
+        let b = Utils.hash(seed: "s", value: "v", version: 2)
+        XCTAssertEqual(a, b)
+    }
+
+    // MARK: - isFilteredOut
+
+    func testIsFilteredOutReturnsFalseWhenHashInRange() {
+        let attributes = JSON(["id": "user-1"])
+        let filter = Filter(
+            attribute: "id",
+            seed: "my-seed",
+            hashVersion: 2,
+            ranges: [BucketRange(number1: 0.0, number2: 1.0)],
+            fallbackAttribute: nil
+        )
+        XCTAssertFalse(Utils.isFilteredOut(filters: [filter], attributes: attributes))
+    }
+
+    func testIsFilteredOutReturnsTrueWhenHashOutsideAllRanges() {
+        let attributes = JSON(["id": "user-1"])
+        let filter = Filter(
+            attribute: "id",
+            seed: "my-seed",
+            hashVersion: 2,
+            ranges: [BucketRange(number1: 0.0, number2: 0.0)],
+            fallbackAttribute: nil
+        )
+        XCTAssertTrue(Utils.isFilteredOut(filters: [filter], attributes: attributes))
+    }
+
+    func testIsFilteredOutReturnsFalseForEmptyFilters() {
+        let attributes = JSON(["id": "anything"])
+        XCTAssertFalse(Utils.isFilteredOut(filters: [], attributes: attributes))
+    }
+
+    // MARK: - isIncludedInRollout
+
+    func testIsIncludedInRolloutBothNilReturnsTrue() {
+        XCTAssertTrue(Utils.isIncludedInRollout(
+            attributes: JSON(["id": "user"]),
+            seed: "seed",
+            hashAttribute: "id",
+            fallbackAttribute: nil,
+            range: nil,
+            coverage: nil,
+            hashVersion: 1
+        ))
+    }
+
+    func testIsIncludedInRolloutCoverageZeroReturnsFalse() {
+        XCTAssertFalse(Utils.isIncludedInRollout(
+            attributes: JSON(["id": "user"]),
+            seed: "seed",
+            hashAttribute: "id",
+            fallbackAttribute: nil,
+            range: nil,
+            coverage: 0,
+            hashVersion: 1
+        ))
+    }
+
+    func testIsIncludedInRolloutFullCoverageIncludesAll() {
+        for i in 0..<20 {
+            let included = Utils.isIncludedInRollout(
+                attributes: JSON(["id": "user-\(i)"]),
+                seed: "seed",
+                hashAttribute: "id",
+                fallbackAttribute: nil,
+                range: nil,
+                coverage: 1.0,
+                hashVersion: 1
+            )
+            XCTAssertTrue(included, "user-\(i) should be included at coverage 1.0")
+        }
+    }
+
+    func testIsIncludedInRolloutRangeIncludesHashInRange() {
+        XCTAssertTrue(Utils.isIncludedInRollout(
+            attributes: JSON(["id": "user"]),
+            seed: "seed",
+            hashAttribute: "id",
+            fallbackAttribute: nil,
+            range: BucketRange(number1: 0.0, number2: 1.0),
+            coverage: nil,
+            hashVersion: 1
+        ))
+    }
+
+    func testIsIncludedInRolloutRangeExcludesHashOutOfRange() {
+        XCTAssertFalse(Utils.isIncludedInRollout(
+            attributes: JSON(["id": "user"]),
+            seed: "seed",
+            hashAttribute: "id",
+            fallbackAttribute: nil,
+            range: BucketRange(number1: 0.0, number2: 0.0),
+            coverage: nil,
+            hashVersion: 1
+        ))
+    }
+
+    func testIsIncludedInRolloutUsesFallbackWhenAttributeMissing() {
+        let attrs = JSON(["deviceId": "device-42"])
+        let withFallback = Utils.isIncludedInRollout(
+            attributes: attrs,
+            seed: "seed",
+            hashAttribute: "id",
+            fallbackAttribute: "deviceId",
+            range: nil,
+            coverage: 1.0,
+            hashVersion: 1
+        )
+        XCTAssertTrue(withFallback)
+    }
+
+    // MARK: - getHashAttribute
+
+    func testGetHashAttributePrimaryHit() {
+        let attrs = JSON(["id": "user-99"])
+        let result = Utils.getHashAttribute(attr: "id", attributes: attrs)
+        XCTAssertEqual(result.hashAttribute, "id")
+        XCTAssertEqual(result.hashValue, "user-99")
+    }
+
+    func testGetHashAttributeFallsBackWhenPrimaryMissing() {
+        let attrs = JSON(["deviceId": "device-77"])
+        let result = Utils.getHashAttribute(attr: "id", fallback: "deviceId", attributes: attrs)
+        XCTAssertEqual(result.hashAttribute, "deviceId")
+        XCTAssertEqual(result.hashValue, "device-77")
+    }
+
+    func testGetHashAttributeDefaultsToIdKey() {
+        let attrs = JSON(["id": "default-user"])
+        let result = Utils.getHashAttribute(attr: nil, attributes: attrs)
+        XCTAssertEqual(result.hashAttribute, "id")
+        XCTAssertEqual(result.hashValue, "default-user")
+    }
+
+    func testGetHashAttributeReturnsEmptyWhenBothMissing() {
+        let attrs = JSON(["email": "user@example.com"])
+        let result = Utils.getHashAttribute(attr: "id", fallback: "deviceId", attributes: attrs)
+        XCTAssertEqual(result.hashValue, "")
+    }
+
+    // MARK: - parseQueryString
+
+    func testParseQueryStringBasic() {
+        let result = Utils.parseQueryString("foo=bar&baz=qux")
+        XCTAssertEqual(result["foo"], "bar")
+        XCTAssertEqual(result["baz"], "qux")
+    }
+
+    func testParseQueryStringEmpty() {
+        XCTAssertTrue(Utils.parseQueryString(nil).isEmpty)
+        XCTAssertTrue(Utils.parseQueryString("").isEmpty)
+    }
+
+    func testParseQueryStringWithPercentEncoding() {
+        let result = Utils.parseQueryString("name=hello%20world")
+        XCTAssertEqual(result["name"], "hello world")
+    }
+
+    func testParseQueryStringKeyWithoutValue() {
+        let result = Utils.parseQueryString("flag=")
+        XCTAssertEqual(result["flag"], "")
+    }
+
+    // MARK: - getQueryStringOverride
+
+    func testGetQueryStringOverrideReturnsVariationIndex() {
+        let result = Utils.getQueryStringOverride(id: "my-exp", urlString: "https://example.com?my-exp=1", numberOfVariations: 3)
+        XCTAssertEqual(result, 1)
+    }
+
+    func testGetQueryStringOverrideReturnsNilWhenKeyAbsent() {
+        let result = Utils.getQueryStringOverride(id: "other-exp", urlString: "https://example.com?my-exp=1", numberOfVariations: 3)
+        XCTAssertNil(result)
+    }
+
+    func testGetQueryStringOverrideReturnsNilWhenIndexOutOfBounds() {
+        let result = Utils.getQueryStringOverride(id: "my-exp", urlString: "https://example.com?my-exp=5", numberOfVariations: 3)
+        XCTAssertNil(result)
+    }
+
+    func testGetQueryStringOverrideReturnsNilForInvalidURL() {
+        let result = Utils.getQueryStringOverride(id: "exp", urlString: nil, numberOfVariations: 2)
+        XCTAssertNil(result)
+    }
+
+    func testGetQueryStringOverrideZeroIndexAllowed() {
+        let result = Utils.getQueryStringOverride(id: "exp", urlString: "https://example.com?exp=0", numberOfVariations: 2)
+        XCTAssertEqual(result, 0)
+    }
+
+    // MARK: - inRange
+
+    func testInRangeReturnsTrueForValueAtStart() {
+        XCTAssertTrue(Utils.inRange(n: 0.0, range: BucketRange(number1: 0.0, number2: 0.5)))
+    }
+
+    func testInRangeReturnsFalseForValueAtEnd() {
+        XCTAssertFalse(Utils.inRange(n: 0.5, range: BucketRange(number1: 0.0, number2: 0.5)))
+    }
+
+    func testInRangeReturnsFalseForValueBeforeRange() {
+        XCTAssertFalse(Utils.inRange(n: -0.1, range: BucketRange(number1: 0.0, number2: 0.5)))
+    }
+
+    func testInRangeReturnsFalseForValueAfterRange() {
+        XCTAssertFalse(Utils.inRange(n: 0.9, range: BucketRange(number1: 0.0, number2: 0.5)))
+    }
+
+    // MARK: - convertJsonToDouble
+
+    func testConvertJsonToDoubleFromNumber() {
+        let value = JSON(3.14)
+        let result = try? XCTUnwrap(Utils.convertJsonToDouble(from: value))
+        XCTAssertEqual(result ?? 0, 3.14, accuracy: 0.0001)
+    }
+
+    func testConvertJsonToDoubleFromString() {
+        let value = JSON("2.718")
+        let result = try? XCTUnwrap(Utils.convertJsonToDouble(from: value))
+        XCTAssertEqual(result ?? 0, 2.718, accuracy: 0.0001)
+    }
+
+    func testConvertJsonToDoubleFromNil() {
+        XCTAssertNil(Utils.convertJsonToDouble(from: nil))
+    }
+
+    func testConvertJsonToDoubleFromNonNumericString() {
+        let value = JSON("not-a-number")
+        XCTAssertNil(Utils.convertJsonToDouble(from: value))
+    }
+}

--- a/GrowthBookTests/UtilsStickyBucketTests.swift
+++ b/GrowthBookTests/UtilsStickyBucketTests.swift
@@ -1,0 +1,286 @@
+import XCTest
+@testable import GrowthBook
+
+class UtilsStickyBucketTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeEvalContext(
+        attributes: JSON = JSON(["id": "user-1"]),
+        features: Features = [:],
+        experiments: [Experiment]? = nil,
+        stickyDocs: [String: StickyAssignmentsDocument]? = nil,
+        stickyService: StickyBucketServiceProtocol? = nil
+    ) -> EvalContext {
+        let globalContext = GlobalContext(features: features, experiments: experiments)
+        let userContext = UserContext(attributes: attributes, stickyBucketAssignmentDocs: stickyDocs)
+        let options = ClientOptions(
+            isEnabled: true,
+            stickyBucketService: stickyService,
+            isQaMode: false,
+            trackingClosure: { _, _ in }
+        )
+        return EvalContext(
+            globalContext: globalContext,
+            userContext: userContext,
+            stackContext: StackContext(),
+            options: options
+        )
+    }
+
+    // MARK: - getStickyBucketExperimentKey
+
+    func testGetStickyBucketExperimentKeyDefaultVersion() {
+        XCTAssertEqual(Utils.getStickyBucketExperimentKey("my-exp"), "my-exp__0")
+    }
+
+    func testGetStickyBucketExperimentKeyWithVersion() {
+        XCTAssertEqual(Utils.getStickyBucketExperimentKey("my-exp", 3), "my-exp__3")
+    }
+
+    func testGetStickyBucketExperimentKeyVersionZero() {
+        XCTAssertEqual(Utils.getStickyBucketExperimentKey("exp", 0), "exp__0")
+    }
+
+    // MARK: - getStickyBucketAssignments
+
+    func testGetStickyBucketAssignmentsNoDocsReturnsEmpty() {
+        let context = makeEvalContext(stickyDocs: nil)
+        let result = Utils.getStickyBucketAssignments(context: context, expHashAttribute: "id")
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testGetStickyBucketAssignmentsReturnsMatchingDoc() {
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "user-1",
+            assignments: ["exp__0": "control"]
+        )
+        let context = makeEvalContext(stickyDocs: ["id||user-1": doc])
+        let result = Utils.getStickyBucketAssignments(context: context, expHashAttribute: "id")
+        XCTAssertEqual(result["exp__0"], "control")
+    }
+
+    func testGetStickyBucketAssignmentsMergesFallback() {
+        let primaryDoc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp-a__0": "variant"]
+        )
+        let fallbackDoc = StickyAssignmentsDocument(
+            attributeName: "deviceId", attributeValue: "device-99",
+            assignments: ["exp-b__0": "control"]
+        )
+        let context = makeEvalContext(
+            attributes: JSON(["id": "user-1", "deviceId": "device-99"]),
+            stickyDocs: ["id||user-1": primaryDoc, "deviceId||device-99": fallbackDoc]
+        )
+        let result = Utils.getStickyBucketAssignments(
+            context: context,
+            expHashAttribute: "id",
+            expFallbackAttribute: "deviceId"
+        )
+        XCTAssertEqual(result["exp-a__0"], "variant")
+        XCTAssertEqual(result["exp-b__0"], "control")
+    }
+
+    // MARK: - generateStickyBucketAssignmentDoc
+
+    func testGenerateStickyBucketAssignmentDocNewKey() {
+        let context = makeEvalContext()
+        let result = Utils.generateStickyBucketAssignmentDoc(
+            context: context,
+            attributeName: "id",
+            attributeValue: "user-1",
+            assignments: ["exp__0": "variant"]
+        )
+        XCTAssertEqual(result.key, "id||user-1")
+        XCTAssertEqual(result.doc.assignments["exp__0"], "variant")
+        XCTAssertTrue(result.changed)
+    }
+
+    func testGenerateStickyBucketAssignmentDocMergesExisting() {
+        let existingDoc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp-a__0": "control"]
+        )
+        let context = makeEvalContext(stickyDocs: ["id||user-1": existingDoc])
+        let result = Utils.generateStickyBucketAssignmentDoc(
+            context: context,
+            attributeName: "id",
+            attributeValue: "user-1",
+            assignments: ["exp-b__0": "variant"]
+        )
+        XCTAssertEqual(result.doc.assignments["exp-a__0"], "control")
+        XCTAssertEqual(result.doc.assignments["exp-b__0"], "variant")
+        XCTAssertTrue(result.changed)
+    }
+
+    func testGenerateStickyBucketAssignmentDocUnchangedWhenSame() {
+        let existingDoc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp__0": "control"]
+        )
+        let context = makeEvalContext(stickyDocs: ["id||user-1": existingDoc])
+        let result = Utils.generateStickyBucketAssignmentDoc(
+            context: context,
+            attributeName: "id",
+            attributeValue: "user-1",
+            assignments: ["exp__0": "control"]
+        )
+        XCTAssertFalse(result.changed)
+    }
+
+    // MARK: - getStickyBucketVariation
+
+    func testGetStickyBucketVariationNoAssignmentsReturnsMinusOne() {
+        let context = makeEvalContext()
+        let result = Utils.getStickyBucketVariation(
+            context: context,
+            experimentKey: "my-exp",
+            meta: [VariationMeta(json: ["key": "control"]), VariationMeta(json: ["key": "variant"])]
+        )
+        XCTAssertEqual(result.variation, -1)
+        XCTAssertNil(result.versionIsBlocked)
+    }
+
+    func testGetStickyBucketVariationReturnsAssignedVariation() {
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["my-exp__0": "variant"]
+        )
+        let context = makeEvalContext(stickyDocs: ["id||user-1": doc])
+        let meta = [
+            VariationMeta(json: ["key": "control"]),
+            VariationMeta(json: ["key": "variant"])
+        ]
+        let result = Utils.getStickyBucketVariation(
+            context: context,
+            experimentKey: "my-exp",
+            meta: meta
+        )
+        XCTAssertEqual(result.variation, 1)
+        XCTAssertNil(result.versionIsBlocked)
+    }
+
+    func testGetStickyBucketVariationBlockedByMinVersion() {
+        let doc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["my-exp__0": "control"]
+        )
+        let context = makeEvalContext(stickyDocs: ["id||user-1": doc])
+        let result = Utils.getStickyBucketVariation(
+            context: context,
+            experimentKey: "my-exp",
+            experimentBucketVersion: 1,
+            minExperimentBucketVersion: 1,
+            meta: [VariationMeta(json: ["key": "control"])]
+        )
+        XCTAssertEqual(result.variation, -1)
+        XCTAssertEqual(result.versionIsBlocked, true)
+    }
+
+    // MARK: - deriveStickyBucketIdentifierAttributes
+
+    func testDeriveStickyBucketAttributesFromFeatureRules() {
+        // variations must be non-nil for the rule to be processed
+        let rule = FeatureRule(
+            variations: [JSON("a"), JSON("b")],
+            hashAttribute: "userId",
+            fallBackAttribute: "deviceId"
+        )
+        let feature = Feature(defaultValue: nil, rules: [rule])
+        let context = makeEvalContext(features: ["my-feature": feature])
+        let attrs = Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil)
+        XCTAssertTrue(attrs.contains("userId"))
+        XCTAssertTrue(attrs.contains("deviceId"))
+    }
+
+    func testDeriveStickyBucketAttributesDefaultsToId() {
+        let rule = FeatureRule(variations: [JSON("a"), JSON("b")])
+        let feature = Feature(defaultValue: nil, rules: [rule])
+        let context = makeEvalContext(features: ["f": feature])
+        let attrs = Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil)
+        XCTAssertTrue(attrs.contains("id"))
+    }
+
+    func testDeriveStickyBucketAttributesFromExperiments() {
+        let experiment = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            hashAttribute: "email",
+            fallBackAttribute: "phone"
+        )
+        let context = makeEvalContext(experiments: [experiment])
+        let attrs = Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil)
+        XCTAssertTrue(attrs.contains("email"))
+        XCTAssertTrue(attrs.contains("phone"))
+    }
+
+    // MARK: - propagateStickyAssignments
+
+    func testPropagateStickyAssignmentsCopiesChildToParent() {
+        let childDoc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp__0": "variant"]
+        )
+        let childContext = makeEvalContext(stickyDocs: ["id||user-1": childDoc])
+        let parentContext = makeEvalContext(stickyDocs: nil)
+
+        Utils.propagateStickyAssignments(from: childContext, to: parentContext)
+
+        XCTAssertEqual(
+            parentContext.userContext.stickyBucketAssignmentDocs?["id||user-1"]?.assignments["exp__0"],
+            "variant"
+        )
+    }
+
+    func testPropagateStickyAssignmentsMergesWithExistingParentDoc() {
+        let childDoc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp-b__0": "variant"]
+        )
+        let parentDoc = StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp-a__0": "control"]
+        )
+        let childContext = makeEvalContext(stickyDocs: ["id||user-1": childDoc])
+        let parentContext = makeEvalContext(stickyDocs: ["id||user-1": parentDoc])
+
+        Utils.propagateStickyAssignments(from: childContext, to: parentContext)
+
+        let merged = parentContext.userContext.stickyBucketAssignmentDocs?["id||user-1"]?.assignments
+        XCTAssertEqual(merged?["exp-a__0"], "control")
+        XCTAssertEqual(merged?["exp-b__0"], "variant")
+    }
+
+    func testPropagateStickyAssignmentsSkipsEmptyChild() {
+        let childContext = makeEvalContext(stickyDocs: nil)
+        let parentContext = makeEvalContext(stickyDocs: nil)
+
+        Utils.propagateStickyAssignments(from: childContext, to: parentContext)
+
+        XCTAssertNil(parentContext.userContext.stickyBucketAssignmentDocs)
+    }
+
+    // MARK: - initializeEvalContext (deprecated)
+
+    func testInitializeEvalContextCreatesValidContext() {
+        let context = Context(
+            apiHost: "https://host.com",
+            streamingHost: nil,
+            clientKey: "key",
+            encryptionKey: nil,
+            isEnabled: true,
+            attributes: JSON(["id": "user-1"]),
+            forcedVariations: JSON([:]),
+            isQaMode: false,
+            trackingClosure: { _, _ in },
+            features: [:],
+            backgroundSync: false
+        )
+        let evalContext = Utils.initializeEvalContext(context: context)
+        XCTAssertEqual(evalContext.userContext.attributes["id"].stringValue, "user-1")
+        XCTAssertTrue(evalContext.options.isEnabled)
+        XCTAssertFalse(evalContext.options.isQaMode)
+    }
+}


### PR DESCRIPTION
  Summary
                                                                                                                      
  - Added comprehensive unit test coverage across the GrowthBook iOS SDK
  - New test files cover: models (FeatureModelTests, ConstantsAndModelTests, FeatureModelInitJsonTests), utilities    
  (ExtensionsTests, UtilsExtendedTests, UtilsStickyBucketTests), evaluators (ConditionEvaluatorTests,                 
  FeatureEvaluatorTests, ExperimentEvaluatorTests), services (DecryptionUtilsTests, StickyBucketServiceTests), view   
  model (FeaturesViewModelExtendedTests), and public API (GrowthBookSDKTests)                                         
  - Fixed a Swift concurrency mutation error in SDK tests
  - Total: ~3900 lines of new tests across 17 test files   