### PR TITLE
fix: surface network error and recover after cache fallback

### DIFF
--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -155,6 +155,145 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertFalse(isError)
     }
 
+    // MARK: - Large Saved Group tests (reproduces the 10k-record payload bug)
+
+    func testLargeSavedGroupPayloadParsedSuccessfully() throws {
+        let ids = (1...10_000).map { "\($0)" }
+        let idsJSON = ids.map { "\"\($0)\"" }.joined(separator: ",")
+        let payload = """
+        {
+            "status": 200,
+            "features": { "large_group_feature": { "defaultValue": false } },
+            "savedGroups": { "large_group": [\(idsJSON)] }
+        }
+        """
+
+        isSuccess = false
+        isError = true
+
+        let viewModel = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: payload, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        viewModel.fetchFeatures(apiUrl: "")
+
+        XCTAssertTrue(isSuccess, "SDK should parse a 10k-record savedGroup without error")
+        XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
+    }
+
+    func testLargeSavedGroupIsPersistedToCache() throws {
+        let ids = (1...10_000).map { "\($0)" }
+        let idsJSON = ids.map { "\"\($0)\"" }.joined(separator: ",")
+        let payload = """
+        {
+            "status": 200,
+            "features": { "large_group_feature": { "defaultValue": false } },
+            "savedGroups": { "large_group": [\(idsJSON)] }
+        }
+        """
+
+        let viewModel = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: payload, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        viewModel.fetchFeatures(apiUrl: "")
+
+        guard let cachedData = cachingManager.getContent(fileName: Constants.savedGroupsCache) else {
+            XCTFail("savedGroups should be written to cache after a large payload fetch")
+            return
+        }
+        let decoded = try? JSONDecoder().decode(JSON.self, from: cachedData)
+        XCTAssertNotNil(decoded, "Cached savedGroups should be valid JSON")
+        XCTAssertEqual(decoded?["large_group"].arrayValue.count, 10_000)
+    }
+
+    func testFallbackToCacheWhenLargePayloadNetworkFails() throws {
+        // Populate cache with a valid response first
+        let seedVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        seedVM.fetchFeatures(apiUrl: "")
+        XCTAssertTrue(isSuccess, "Seed fetch should succeed")
+
+        // Simulate the large-payload timeout that Cloudflare/Proxy triggers
+        isSuccess = false
+        isError = true
+        let timeoutError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
+                                   userInfo: [NSLocalizedDescriptionKey: "The request timed out"])
+        let failingVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: timeoutError)),
+            cachingManager: cachingManager,
+            ttlSeconds: 0 // force network attempt
+        )
+        failingVM.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
+
+        XCTAssertTrue(isSuccess, "SDK should serve cached features when network fails due to large payload")
+        XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
+    }
+
+    func testUnderlyingErrorPreservedOnNetworkFailure() throws {
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
+                                   userInfo: [NSLocalizedDescriptionKey: "The request timed out"])
+        var capturedErrors: [SDKError] = []
+        let capture = ErrorCapture { capturedErrors.append($0) }
+
+        let viewModel = FeaturesViewModel(
+            delegate: capture,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: networkError)),
+            cachingManager: CachingManager(),
+            ttlSeconds: 0
+        )
+        viewModel.manager.clearCache()
+        viewModel.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
+
+        let fetchError = capturedErrors.first(where: { $0.code == .failedToFetchData })
+        XCTAssertNotNil(fetchError, "failedToFetchData must be reported")
+        XCTAssertNotNil(fetchError?.underlying, "Underlying network error must be forwarded to the caller")
+        XCTAssertEqual((fetchError?.underlying as NSError?)?.code, NSURLErrorTimedOut)
+    }
+
+    func testFeaturesSuccessCallbackFiredWithIsRemoteAfterCacheFallback() throws {
+        // Populate cache
+        let seedVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        seedVM.fetchFeatures(apiUrl: "")
+        XCTAssertTrue(isSuccess)
+
+        // Network fails — ViewModel must call featuresFetchedSuccessfully(isRemote: true)
+        // so that GrowthBookSDK's refreshHandler receives nil (success), not an error.
+        var fetchFailedCalledRemote = false
+        var successCalledRemote = false
+        let capture = RemoteCallCapture(
+            onSuccess: { isRemote in if isRemote { successCalledRemote = true } },
+            onFailure: { isRemote in if isRemote { fetchFailedCalledRemote = true } }
+        )
+        let timeoutError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+        let vm = FeaturesViewModel(
+            delegate: capture,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: timeoutError)),
+            cachingManager: cachingManager,
+            ttlSeconds: 0
+        )
+        vm.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
+
+        XCTAssertTrue(fetchFailedCalledRemote, "featuresFetchFailed(isRemote: true) must be reported for network error")
+        XCTAssertTrue(successCalledRemote, "featuresFetchedSuccessfully(isRemote: true) must be called after cache fallback so refreshHandler receives nil")
+    }
+
     func testError() throws {
         isSuccess = false
         isError = true
@@ -247,4 +386,28 @@ private class SavedGroupsCapture: FeaturesFlowDelegate {
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
         onSavedGroups(savedGroups)
     }
+}
+
+private class RemoteCallCapture: FeaturesFlowDelegate {
+    private let onSuccess: (Bool) -> Void
+    private let onFailure: (Bool) -> Void
+    init(onSuccess: @escaping (Bool) -> Void, onFailure: @escaping (Bool) -> Void) {
+        self.onSuccess = onSuccess
+        self.onFailure = onFailure
+    }
+    func featuresFetchedSuccessfully(features: Features, isRemote: Bool) { onSuccess(isRemote) }
+    func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+    func featuresFetchFailed(error: SDKError, isRemote: Bool) { onFailure(isRemote) }
+    func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
+}
+
+private class ErrorCapture: FeaturesFlowDelegate {
+    private let onError: (SDKError) -> Void
+    init(_ onError: @escaping (SDKError) -> Void) { self.onError = onError }
+    func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {}
+    func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+    func featuresFetchFailed(error: SDKError, isRemote: Bool) { onError(error) }
+    func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
 }

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -177,6 +177,145 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertEqual(featuresUpdateIsCompleteArguments[1].isRemote, true)
     }
 
+    // MARK: - Large Saved Group tests (reproduces the 10k-record payload bug)
+
+    func testLargeSavedGroupPayloadParsedSuccessfully() throws {
+        let ids = (1...10_000).map { "\($0)" }
+        let idsJSON = ids.map { "\"\($0)\"" }.joined(separator: ",")
+        let payload = """
+        {
+            "status": 200,
+            "features": { "large_group_feature": { "defaultValue": false } },
+            "savedGroups": { "large_group": [\(idsJSON)] }
+        }
+        """
+
+        isSuccess = false
+        isError = true
+
+        let viewModel = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: payload, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        viewModel.fetchFeatures(apiUrl: "")
+
+        XCTAssertTrue(isSuccess, "SDK should parse a 10k-record savedGroup without error")
+        XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
+    }
+
+    func testLargeSavedGroupIsPersistedToCache() throws {
+        let ids = (1...10_000).map { "\($0)" }
+        let idsJSON = ids.map { "\"\($0)\"" }.joined(separator: ",")
+        let payload = """
+        {
+            "status": 200,
+            "features": { "large_group_feature": { "defaultValue": false } },
+            "savedGroups": { "large_group": [\(idsJSON)] }
+        }
+        """
+
+        let viewModel = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: payload, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        viewModel.fetchFeatures(apiUrl: "")
+
+        guard let cachedData = cachingManager.getContent(fileName: Constants.savedGroupsCache) else {
+            XCTFail("savedGroups should be written to cache after a large payload fetch")
+            return
+        }
+        let decoded = try? JSONDecoder().decode(JSON.self, from: cachedData)
+        XCTAssertNotNil(decoded, "Cached savedGroups should be valid JSON")
+        XCTAssertEqual(decoded?["large_group"].arrayValue.count, 10_000)
+    }
+
+    func testFallbackToCacheWhenLargePayloadNetworkFails() throws {
+        // Populate cache with a valid response first
+        let seedVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        seedVM.fetchFeatures(apiUrl: "")
+        XCTAssertTrue(isSuccess, "Seed fetch should succeed")
+
+        // Simulate the large-payload timeout that Cloudflare/Proxy triggers
+        isSuccess = false
+        isError = true
+        let timeoutError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
+                                   userInfo: [NSLocalizedDescriptionKey: "The request timed out"])
+        let failingVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: timeoutError)),
+            cachingManager: cachingManager,
+            ttlSeconds: 0 // force network attempt
+        )
+        failingVM.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
+
+        XCTAssertTrue(isSuccess, "SDK should serve cached features when network fails due to large payload")
+        XCTAssertFalse(isError)
+        XCTAssertTrue(hasFeatures)
+    }
+
+    func testUnderlyingErrorPreservedOnNetworkFailure() throws {
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
+                                   userInfo: [NSLocalizedDescriptionKey: "The request timed out"])
+        var capturedErrors: [SDKError] = []
+        let capture = ErrorCapture { capturedErrors.append($0) }
+
+        let viewModel = FeaturesViewModel(
+            delegate: capture,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: networkError)),
+            cachingManager: CachingManager(),
+            ttlSeconds: 0
+        )
+        viewModel.manager.clearCache()
+        viewModel.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
+
+        let fetchError = capturedErrors.first(where: { $0.code == .failedToFetchData })
+        XCTAssertNotNil(fetchError, "failedToFetchData must be reported")
+        XCTAssertNotNil(fetchError?.underlying, "Underlying network error must be forwarded to the caller")
+        XCTAssertEqual((fetchError?.underlying as NSError?)?.code, NSURLErrorTimedOut)
+    }
+
+    func testFeaturesSuccessCallbackFiredWithIsRemoteAfterCacheFallback() throws {
+        // Populate cache
+        let seedVM = FeaturesViewModel(
+            delegate: self,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)),
+            cachingManager: cachingManager,
+            ttlSeconds: ttlSeconds
+        )
+        seedVM.fetchFeatures(apiUrl: "")
+        XCTAssertTrue(isSuccess)
+
+        // Network fails — ViewModel must call featuresFetchedSuccessfully(isRemote: true)
+        // so that GrowthBookSDK's refreshHandler receives nil (success), not an error.
+        var fetchFailedCalledRemote = false
+        var successCalledRemote = false
+        let capture = RemoteCallCapture(
+            onSuccess: { isRemote in if isRemote { successCalledRemote = true } },
+            onFailure: { isRemote in if isRemote { fetchFailedCalledRemote = true } }
+        )
+        let timeoutError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+        let vm = FeaturesViewModel(
+            delegate: capture,
+            dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: timeoutError)),
+            cachingManager: cachingManager,
+            ttlSeconds: 0
+        )
+        vm.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
+
+        XCTAssertTrue(fetchFailedCalledRemote, "featuresFetchFailed(isRemote: true) must be reported for network error")
+        XCTAssertTrue(successCalledRemote, "featuresFetchedSuccessfully(isRemote: true) must be called after cache fallback so refreshHandler receives nil")
+    }
+
     func testError() throws {
         isSuccess = false
         isError = true
@@ -298,4 +437,28 @@ private class SavedGroupsCapture: FeaturesFlowDelegate {
         featuresUpdateIsCompleteArguments += [(error, isRemote)]
         featuresUpdateIsCompleteCallCount += 1
     }
+}
+
+private class RemoteCallCapture: FeaturesFlowDelegate {
+    private let onSuccess: (Bool) -> Void
+    private let onFailure: (Bool) -> Void
+    init(onSuccess: @escaping (Bool) -> Void, onFailure: @escaping (Bool) -> Void) {
+        self.onSuccess = onSuccess
+        self.onFailure = onFailure
+    }
+    func featuresFetchedSuccessfully(features: Features, isRemote: Bool) { onSuccess(isRemote) }
+    func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+    func featuresFetchFailed(error: SDKError, isRemote: Bool) { onFailure(isRemote) }
+    func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
+}
+
+private class ErrorCapture: FeaturesFlowDelegate {
+    private let onError: (SDKError) -> Void
+    init(_ onError: @escaping (SDKError) -> Void) { self.onError = onError }
+    func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {}
+    func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+    func featuresFetchFailed(error: SDKError, isRemote: Bool) { onError(error) }
+    func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
 }

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -451,6 +451,7 @@ private class RemoteCallCapture: FeaturesFlowDelegate {
     func featuresFetchFailed(error: SDKError, isRemote: Bool) { onFailure(isRemote) }
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
+    func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {}
 }
 
 private class ErrorCapture: FeaturesFlowDelegate {
@@ -461,4 +462,5 @@ private class ErrorCapture: FeaturesFlowDelegate {
     func featuresFetchFailed(error: SDKError, isRemote: Bool) { onError(error) }
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
+    func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {}
 }

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -124,8 +124,8 @@ class FeaturesViewModel {
                         return
                     }
                     logger.info("Failed to get features from remote: \(error.localizedDescription)")
-                    self.delegate?.featuresFetchFailed(error: .failedToFetchData, isRemote: true)
-                    self.fetchCachedFeatures()
+                    self.delegate?.featuresFetchFailed(error: .failedToFetchData(error), isRemote: true)
+                    self.fetchCachedFeatures(isRemote: true)
                 }
             }
         }

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -156,10 +156,10 @@ class FeaturesViewModel {
                         return
                     }
                     logger.info("Failed to get features from remote: \(error.localizedDescription)")
-                    let error: SDKError = .failedToFetchData
-                    self.delegate?.featuresFetchFailed(error: error, isRemote: true)
-                    self.fetchCachedFeatures()
-                    self.delegate?.featuresUpdateIsComplete(error: error, isRemote: true)
+                    let sdkError: SDKError = .failedToFetchData(error)
+                    self.delegate?.featuresFetchFailed(error: sdkError, isRemote: true)
+                    self.fetchCachedFeatures(isRemote: true)
+                    self.delegate?.featuresUpdateIsComplete(error: sdkError, isRemote: true)
                 }
             }
         }


### PR DESCRIPTION
Summary

Two bugs triggered by large saved-group payloads causing network failures:

Underlying error was swallowed — featuresFetchFailed always reported the generic .failedToFetchData static error,
discarding the original network error. Changed to .failedToFetchData(error) so callers can inspect error.underlying
to distinguish timeout, HTTP 5xx, connection failure, etc.
refreshHandler stayed in error state after cache fallback — when a network request failed and the SDK successfully
loaded features from cache, fetchCachedFeatures() was called with isRemote: false. Since
featuresFetchedSuccessfully only invokes refreshHandler when isRemote == true, the handler never received nil and
the app continued showing an error even though features were available. Fixed by passing isRemote: true in the
fallback call.

Test plan

testUnderlyingErrorPreservedOnNetworkFailure — error.underlying is non-nil and matches the original network error
code
testFeaturesSuccessCallbackFiredWithIsRemoteAfterCacheFallback — featuresFetchedSuccessfully(isRemote: true) is
called after cache fallback so refreshHandler receives nil
testFallbackToCacheWhenLargePayloadNetworkFails — app remains functional (features served from cache) when network
fails due to large payload
testLargeSavedGroupPayloadParsedSuccessfully — SDK correctly parses a 10k-record saved group
testLargeSavedGroupIsPersistedToCache — 10k-record saved group is written to and read back from disk cache
correctly