### PR TITLE
chore: call refreshHandler once and even if features are up to date

### DIFF
--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -6,6 +6,7 @@ class FeaturesViewModelExtendedTests: XCTestCase {
     // MARK: - Delegate capture
 
     private class Capture: FeaturesFlowDelegate {
+
         var successCount = 0
         var failCount = 0
         var savedGroupsCount = 0
@@ -27,6 +28,16 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         }
         func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) { failCount += 1 }
         func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
+
+        // featuresUpdateIsComplete
+        
+        var featuresUpdateIsCompleteCallCount = 0
+        var featuresUpdateIsCompleteArguments: [(error: GrowthBook.SDKError?, isRemote: Bool)] = []
+
+        func featuresUpdateIsComplete(error: GrowthBook.SDKError?, isRemote: Bool) {
+            featuresUpdateIsCompleteArguments += [(error, isRemote)]
+            featuresUpdateIsCompleteCallCount += 1
+        }
     }
 
     private func makeVM(
@@ -60,6 +71,7 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         // With preloadedFeatures, the VM skips the cache → no success or fail from cache
         XCTAssertEqual(capture.successCount, 0)
         XCTAssertEqual(capture.failCount, 0)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 0)
     }
 
     func testNoPreloadedFeaturesReadsCache() {
@@ -68,6 +80,7 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         _ = makeVM(delegate: capture)
         XCTAssertEqual(capture.failCount, 1)
         XCTAssertEqual(capture.lastError, .failedToLoadData)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 0)
     }
 
     // MARK: - fetchFeatures with nil apiUrl skips network
@@ -80,6 +93,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         // No network call → no additional success
         XCTAssertEqual(capture.successCount, 0)
         XCTAssertEqual(capture.failCount, beforeFail + 1) // one more fail from cache read in fetchFeatures
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1) // fetchFeatures
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error, .invalidAPIURL)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].isRemote, false)
     }
 
     // MARK: - remoteEval path
@@ -90,6 +106,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.fetchFeatures(apiUrl: "https://example.com", remoteEval: true)
         // Remote eval success should trigger featuresFetchedSuccessfully
         XCTAssertGreaterThan(capture.successCount, 0)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(capture.featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     func testFetchFeaturesRemoteEvalFailure() {
@@ -97,6 +116,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         let vm = makeVM(error: SDKError.failedToFetchData, delegate: capture, ttlSeconds: 0)
         vm.fetchFeatures(apiUrl: "https://example.com", remoteEval: true)
         XCTAssertGreaterThan(capture.failCount, 0)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error?.code, .failedToLoadData)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     // MARK: - prepareFeaturesData: encryptedFeatures without key
@@ -111,6 +133,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.prepareFeaturesData(data: payload)
         XCTAssertGreaterThan(capture.failCount, 0)
         XCTAssertEqual(capture.lastError, .failedMissingKey)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error?.code, .failedMissingKey)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     func testPrepareFeaturesDataEncryptedFeaturesWithWrongKeyFails() {
@@ -123,6 +148,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.prepareFeaturesData(data: payload)
         XCTAssertGreaterThan(capture.failCount, 0)
         XCTAssertEqual(capture.lastError, .failedEncryptedFeatures)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error?.code, .failedEncryptedFeatures)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     // MARK: - prepareFeaturesData: no features and no encryptedFeatures
@@ -136,6 +164,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.prepareFeaturesData(data: payload)
         XCTAssertGreaterThan(capture.failCount, 0)
         XCTAssertEqual(capture.lastError, .failedMissingKey)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error?.code, .failedMissingKey)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     // MARK: - prepareFeaturesData: plain features success
@@ -149,6 +180,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.prepareFeaturesData(data: payload)
         XCTAssertEqual(capture.successCount, 1)
         XCTAssertNotNil(capture.lastFeatures?["my-flag"])
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(capture.featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     // MARK: - prepareFeaturesData: invalid JSON fails
@@ -159,6 +193,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.prepareFeaturesData(data: "not json".data(using: .utf8)!)
         XCTAssertGreaterThan(capture.failCount, 0)
         XCTAssertEqual(capture.lastError, .failedParsedData)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error?.code, .failedParsedData)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     // MARK: - prepareFeaturesData: savedGroups in response
@@ -172,6 +209,9 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         vm.prepareFeaturesData(data: payload)
         XCTAssertEqual(capture.savedGroupsCount, 1)
         XCTAssertNotNil(capture.lastSavedGroups)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(capture.featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     // MARK: - fetchFeatures network failure falls back to cache
@@ -207,5 +247,32 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         failVM.fetchFeatures(apiUrl: "https://example.com")
         // After network fail, falls back to cache → at least one success
         XCTAssertGreaterThan(capture.successCount, 0)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[0].error?.code, .failedToFetchData)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
+    }
+
+    // MARK: - fetchFeatures is not stale reports featuresAreUpToDate to the delegate
+
+    func testFetchFeaturesReportIfNotStale() {
+        // GIVEN
+        let capture = Capture()
+        let vm = makeVM(response: MockResponse().successResponse, delegate: capture, ttlSeconds: 100)
+        // first successful fetch
+        vm.fetchFeatures(apiUrl: "https://example.com", remoteEval: true)
+        XCTAssertGreaterThan(capture.successCount, 0)
+        // no featuresAreUpToDate callse
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(capture.featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
+
+        // WHEN
+        // trying to fetch while cache is not expired
+        vm.fetchFeatures(apiUrl: "https://example.com", remoteEval: true)
+
+        // THEN
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 2, "Expected to call featuresAreUpToDate delegate method")
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[1].error, nil)
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments[1].isRemote, true)
     }
 }

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -8,7 +8,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     var isError: Bool = false
     var hasFeatures: Bool = false
     var ttlSeconds = 60
-    
+
     let cachingManager: CachingLayer = CachingManager()
     
     override func setUp() {
@@ -30,6 +30,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
         XCTAssertTrue(hasFeatures)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     func testSuccessForEncryptedFeatures() throws {
@@ -43,6 +46,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
     
     func testGetDataFromCache() throws {
@@ -80,6 +86,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
         XCTAssertTrue(hasFeatures)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
     
     func testWithEncryptGetDataFromCache() throws {
@@ -110,6 +119,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
     
     func testSavedGroupsRestoredFromCacheOnRestart() throws {
@@ -136,6 +148,11 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertNotNil(savedGroupsFromCache, "savedGroups should be restored from cache on restart")
         XCTAssertFalse(savedGroupsFromCache?.dictionaryValue.isEmpty ?? true, "savedGroups should not be empty")
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
+
+        XCTAssertEqual(captureDelegate.featuresUpdateIsCompleteCallCount, 0)
     }
 
     func test304NotModifiedTreatedAsSuccess() throws {
@@ -153,6 +170,11 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
 
         XCTAssertTrue(isSuccess)
         XCTAssertFalse(isError)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 2)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
+        XCTAssertEqual(featuresUpdateIsCompleteArguments[1].error, nil)
+        XCTAssertEqual(featuresUpdateIsCompleteArguments[1].isRemote, true)
     }
 
     func testError() throws {
@@ -167,6 +189,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertFalse(isSuccess)
         XCTAssertTrue(isError)
         XCTAssertFalse(hasFeatures)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(featuresUpdateIsCompleteArguments[0].error?.code, .failedToFetchData)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     func testInvalid() throws {
@@ -178,6 +203,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertFalse(isSuccess)
         XCTAssertTrue(isError)
         XCTAssertFalse(hasFeatures)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertEqual(featuresUpdateIsCompleteArguments[0].error?.code, .failedMissingKey)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     /// Regression test: payloads that include `filters` with array-encoded `ranges`
@@ -204,6 +232,9 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         XCTAssertTrue(isSuccess, "Expected successful feature fetch with filters payload")
         XCTAssertFalse(isError)
         XCTAssertTrue(hasFeatures)
+        XCTAssertEqual(featuresUpdateIsCompleteCallCount, 1)
+        XCTAssertNil(featuresUpdateIsCompleteArguments[0].error)
+        XCTAssertTrue(featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
     func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {
@@ -231,6 +262,16 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     func featuresAPIModelSuccessfully(model: FeaturesDataModel) {
 
     }
+
+    // featuresUpdateIsComplete
+
+    var featuresUpdateIsCompleteCallCount = 0
+    var featuresUpdateIsCompleteArguments: [(error: GrowthBook.SDKError?, isRemote: Bool)] = []
+
+    func featuresUpdateIsComplete(error: GrowthBook.SDKError?, isRemote: Bool) {
+        featuresUpdateIsCompleteArguments += [(error, isRemote)]
+        featuresUpdateIsCompleteCallCount += 1
+    }
 }
 
 private class SavedGroupsCapture: FeaturesFlowDelegate {
@@ -246,5 +287,15 @@ private class SavedGroupsCapture: FeaturesFlowDelegate {
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
         onSavedGroups(savedGroups)
+    }
+
+    // featuresUpdateIsComplete
+
+    var featuresUpdateIsCompleteCallCount = 0
+    var featuresUpdateIsCompleteArguments: [(error: GrowthBook.SDKError?, isRemote: Bool)] = []
+
+    func featuresUpdateIsComplete(error: GrowthBook.SDKError?, isRemote: Bool) {
+        featuresUpdateIsCompleteArguments += [(error, isRemote)]
+        featuresUpdateIsCompleteCallCount += 1
     }
 }

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -14,7 +14,7 @@ class GrowthBookSDKTests: XCTestCase {
         refreshHandler: CacheRefreshHandler? = nil,
         networkResponse: String? = nil,
         networkError: Error? = nil,
-        ttlSeconds: Int = 60,
+        ttlSeconds: Int = 60
     ) -> GrowthBookSDK {
         GrowthBookBuilder(
             apiHost: apiHost,

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -11,9 +11,10 @@ class GrowthBookSDKTests: XCTestCase {
 
     private func makeSDK(
         features: Data? = nil,
+        refreshHandler: CacheRefreshHandler? = nil,
         networkResponse: String? = nil,
         networkError: Error? = nil,
-        ttlSeconds: Int = 60
+        ttlSeconds: Int = 60,
     ) -> GrowthBookSDK {
         GrowthBookBuilder(
             apiHost: apiHost,
@@ -21,6 +22,7 @@ class GrowthBookSDKTests: XCTestCase {
             attributes: ["id": "user-1", "country": "US"],
             features: features,
             trackingCallback: { _, _ in },
+            refreshHandler: refreshHandler,
             backgroundSync: false,
             ttlSeconds: ttlSeconds
         )
@@ -31,11 +33,11 @@ class GrowthBookSDKTests: XCTestCase {
         .initializer()
     }
 
-    private func makeSDKWithFeatures() -> GrowthBookSDK {
+    private func makeSDKWithFeatures(refreshHandler: CacheRefreshHandler? = nil) -> GrowthBookSDK {
         let payload = """
         {"features":{"flag-a":{"defaultValue":true},"flag-b":{"defaultValue":false}}}
         """.data(using: .utf8)!
-        return makeSDK(features: payload)
+        return makeSDK(features: payload, refreshHandler: refreshHandler)
     }
 
     // MARK: - isOn
@@ -335,5 +337,40 @@ class GrowthBookSDKTests: XCTestCase {
         wait(for: [exp], timeout: 2.0)
         savedGroupsApplied = sdk.getGBContext().savedGroups != nil
         XCTAssertTrue(savedGroupsApplied)
+    }
+
+    func testRunsRefreshHandler() {
+        // GIVEN
+        let expectation = XCTestExpectation(description: "Runs refresh handler even if features are cached")
+        expectation.expectedFulfillmentCount = 2
+        // 1 call - initializer.featuresUpdateIsComplete
+        // 2 call - refreshCache.featuresUpdateIsComplete
+        let cachingManager = CachingManager(apiKey: "isolated-savedgroups-test")
+        cachingManager.clearCache()
+
+        let sdk = GrowthBookBuilder(
+            growthBookBuilderModel: GrowthBookModel(
+                apiHost: apiHost, clientKey: "isolated-savedgroups-test",
+                attributes: JSON([:]), trackingClosure: { _, _ in },
+                backgroundSync: false
+            ),
+            networkDispatcher: MockNetworkClient(
+                successResponse: MockResponse().successResponseNoGroups,
+                error: nil
+            ),
+            ttlSeconds: 60,
+            cachingManager: cachingManager,
+            refreshHandler: { _ in
+                expectation.fulfill()
+            }
+        ).initializer()
+
+        // WHEN
+        sdk.refreshCache()
+
+        // THEN
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertTrue(sdk.isOn(feature: "onboarding"))
     }
 }

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -11,7 +11,6 @@ class GrowthBookSDKTests: XCTestCase {
 
     private func makeSDK(
         features: Data? = nil,
-        refreshHandler: CacheRefreshHandler? = nil,
         networkResponse: String? = nil,
         networkError: Error? = nil,
         ttlSeconds: Int = 60
@@ -22,7 +21,6 @@ class GrowthBookSDKTests: XCTestCase {
             attributes: ["id": "user-1", "country": "US"],
             features: features,
             trackingCallback: { _, _ in },
-            refreshHandler: refreshHandler,
             backgroundSync: false,
             ttlSeconds: ttlSeconds
         )
@@ -33,11 +31,11 @@ class GrowthBookSDKTests: XCTestCase {
         .initializer()
     }
 
-    private func makeSDKWithFeatures(refreshHandler: CacheRefreshHandler? = nil) -> GrowthBookSDK {
+    private func makeSDKWithFeatures() -> GrowthBookSDK {
         let payload = """
         {"features":{"flag-a":{"defaultValue":true},"flag-b":{"defaultValue":false}}}
         """.data(using: .utf8)!
-        return makeSDK(features: payload, refreshHandler: refreshHandler)
+        return makeSDK(features: payload)
     }
 
     // MARK: - isOn

--- a/GrowthBookTests/MockNetworkClient.swift
+++ b/GrowthBookTests/MockNetworkClient.swift
@@ -216,7 +216,37 @@ class MockResponse {
         "savedGroups": {"group_id": ["4", "5", "6"]}
     }
     """.trimmingCharacters(in: .whitespaces)
-    
+
+    let successResponseNoGroups = """
+    {
+        "status": 200,
+        "features": {
+            "onboarding": {
+                "defaultValue": "top",
+                "rules": [
+                    {
+                        "condition": {
+                            "id": "2435245",
+                            "loggedIn": false
+                        },
+                        "variations": [
+                            "top",
+                            "bottom",
+                            "center"
+                        ],
+                        "weights": [
+                            0.25,
+                            0.5,
+                            0.25
+                        ],
+                        "hashAttribute": "id"
+                    }
+                ]
+            }
+        }
+    }
+    """.trimmingCharacters(in: .whitespaces)
+
     /// Reproduces the payload shape reported by users after multiRange namespace support
     /// was introduced: feature rules may now carry a `filters` array whose `ranges` items
     /// are bare JSON arrays `[start, end]` rather than keyed objects.

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -7,6 +7,7 @@ protocol FeaturesFlowDelegate: AnyObject {
     func featuresFetchFailed(error: SDKError, isRemote: Bool)
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool)
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool)
+    func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool)
 }
 
 /// View Model for Features
@@ -70,8 +71,10 @@ class FeaturesViewModel {
     deinit {
         sseHandler?.disconnect()
     }
-    
-    private func fetchCachedFeatures(logging: Bool = false, isRemote: Bool = false) {
+
+    @discardableResult
+    private func fetchCachedFeatures(logging: Bool = false, isRemote: Bool = false) -> SDKError? {
+        var occurredError: SDKError? = nil
         // Check for cache data
         if let data = manager.getContent(fileName: Constants.featureCache) {
             let decoder = JSONDecoder()
@@ -80,18 +83,24 @@ class FeaturesViewModel {
                 if let features = crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) {
                     delegate?.featuresFetchedSuccessfully(features: features, isRemote: isRemote)
                 } else {
-                    delegate?.featuresFetchFailed(error: .failedParsedEncryptedData, isRemote: isRemote)
+                    let erorr = SDKError.failedParsedEncryptedData
+                    delegate?.featuresFetchFailed(error: erorr, isRemote: isRemote)
                     if logging { logger.error("Failed get features from cached encrypted features") }
+                    return erorr
                 }
             } else if let features = try? decoder.decode(Features.self, from: data) {
                 // Call Success Delegate with mention of data available but its not remote
                 delegate?.featuresFetchedSuccessfully(features: features, isRemote: isRemote)
             } else {
-                delegate?.featuresFetchFailed(error: .failedParsedData, isRemote: isRemote)
+                let erorr = SDKError.failedParsedData
+                delegate?.featuresFetchFailed(error: erorr, isRemote: isRemote)
+                occurredError = erorr
                 if logging { logger.error("Failed parse local data") }
             }
         } else {
-            delegate?.featuresFetchFailed(error: .failedToLoadData, isRemote: isRemote)
+            let erorr = SDKError.failedToLoadData
+            delegate?.featuresFetchFailed(error: erorr, isRemote: isRemote)
+            occurredError = erorr
             if logging { logger.info("Cache directory is empty. Nothing to fetch.") }
         }
 
@@ -105,6 +114,7 @@ class FeaturesViewModel {
                 delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: isRemote)
             }
         }
+        return occurredError
     }
     
     
@@ -112,7 +122,28 @@ class FeaturesViewModel {
     func fetchFeatures(apiUrl: String?, remoteEval: Bool = false, payload: RemoteEvalParams? = nil) {
         // Check for cache data
         fetchCachedFeatures(logging: true)
-        if isCacheExpired(), let apiUrl = apiUrl {
+        guard let apiUrl else {
+            delegate?.featuresUpdateIsComplete(error: .invalidAPIURL, isRemote: false)
+            return
+        }
+        guard isCacheExpired() else {
+            delegate?.featuresUpdateIsComplete(error: nil, isRemote: true)
+            return
+        }
+
+        if remoteEval {
+            dataSource.fetchRemoteEval(apiUrl: apiUrl, params: payload) { result in
+                switch result {
+                case .success(let data):
+                    self.prepareFeaturesData(data: data)
+                case .failure(let error):
+                    logger.error("Failed get features: \(error.localizedDescription)")
+                    let error: SDKError = .failedToLoadData
+                    self.delegate?.featuresFetchFailed(error: error, isRemote: true)
+                    self.delegate?.featuresUpdateIsComplete(error: error, isRemote: true)
+                }
+            }
+        } else {
             dataSource.fetchFeatures(apiUrl: apiUrl) { result in
                 switch result {
                 case .success(let data):
@@ -120,23 +151,15 @@ class FeaturesViewModel {
                 case .failure(let error):
                     if (error as NSError).code == 304 {
                         self.refreshExpiresAt()
-                        self.fetchCachedFeatures(isRemote: true)
+                        let fetchCachedFeaturesError = self.fetchCachedFeatures(isRemote: true)
+                        self.delegate?.featuresUpdateIsComplete(error: fetchCachedFeaturesError, isRemote: true)
                         return
                     }
                     logger.info("Failed to get features from remote: \(error.localizedDescription)")
-                    self.delegate?.featuresFetchFailed(error: .failedToFetchData, isRemote: true)
+                    let error: SDKError = .failedToFetchData
+                    self.delegate?.featuresFetchFailed(error: error, isRemote: true)
                     self.fetchCachedFeatures()
-                }
-            }
-        }
-        if let apiUrl = apiUrl, remoteEval {
-            dataSource.fetchRemoteEval(apiUrl: apiUrl, params: payload) { result in
-                switch result {
-                case .success(let data):
-                    self.prepareFeaturesData(data: data)
-                case .failure(let error):
-                    self.delegate?.featuresFetchFailed(error: .failedToLoadData, isRemote: true)
-                    logger.error("Failed get features: \(error.localizedDescription)")
+                    self.delegate?.featuresUpdateIsComplete(error: error, isRemote: true)
                 }
             }
         }
@@ -145,7 +168,11 @@ class FeaturesViewModel {
     /// Cache API Response and push success event
     func prepareFeaturesData(data: Data) {
         // Call Success Delegate with mention of data available with remote
-        
+        var occurredError: SDKError? = nil
+        defer {
+            delegate?.featuresUpdateIsComplete(error: occurredError, isRemote: true)
+        }
+
         let decoder = JSONDecoder()
         if let jsonPetitions = try? decoder.decode(FeaturesDataModel.self, from: data) {
             delegate?.featuresAPIModelSuccessfully(model: jsonPetitions)
@@ -161,12 +188,16 @@ class FeaturesViewModel {
                         }
                         delegate?.featuresFetchedSuccessfully(features: features, isRemote: true)
                     } else {
-                        delegate?.featuresFetchFailed(error: .failedEncryptedFeatures, isRemote: true)
+                        let error: SDKError = .failedEncryptedFeatures
+                        delegate?.featuresFetchFailed(error: error, isRemote: true)
+                        occurredError = error
                         logger.error("Failed get features from encrypted features")
                         return
                     }
                 } else {
-                    delegate?.featuresFetchFailed(error: .failedMissingKey, isRemote: true)
+                    let error: SDKError = .failedMissingKey
+                    delegate?.featuresFetchFailed(error: error, isRemote: true)
+                    occurredError = error
                     logger.error("Failed get encryption key or it's empty")
                     return
                 }
@@ -177,7 +208,9 @@ class FeaturesViewModel {
                 }
                 delegate?.featuresFetchedSuccessfully(features: features, isRemote: true)
             } else {
-                delegate?.featuresFetchFailed(error: .failedMissingKey, isRemote: true)
+                let error: SDKError = .failedMissingKey
+                delegate?.featuresFetchFailed(error: error, isRemote: true)
+                occurredError = error
                 logger.error("Failed get encrypted features or it's empty")
                 return
             }
@@ -192,7 +225,9 @@ class FeaturesViewModel {
                     }
                     delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: true)
                 } else {
+                    let error: SDKError = .failedEncryptedSavedGroups
                     delegate?.savedGroupsFetchFailed(error: .failedEncryptedSavedGroups, isRemote: true)
+                    occurredError = error
                     logger.error("Failed get saved groups from encrypted saved groups")
                     return
                 }
@@ -203,7 +238,9 @@ class FeaturesViewModel {
                 delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: true)
             }
         } else {
+            let error: SDKError = .failedParsedData
             delegate?.featuresFetchFailed(error: .failedParsedData, isRemote: true)
+            occurredError = error
             logger.error("Failed get features data model")
             return
         }

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -83,24 +83,24 @@ class FeaturesViewModel {
                 if let features = crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) {
                     delegate?.featuresFetchedSuccessfully(features: features, isRemote: isRemote)
                 } else {
-                    let erorr = SDKError.failedParsedEncryptedData
-                    delegate?.featuresFetchFailed(error: erorr, isRemote: isRemote)
+                    let error = SDKError.failedParsedEncryptedData
+                    delegate?.featuresFetchFailed(error: error, isRemote: isRemote)
                     if logging { logger.error("Failed get features from cached encrypted features") }
-                    return erorr
+                    return error
                 }
             } else if let features = try? decoder.decode(Features.self, from: data) {
                 // Call Success Delegate with mention of data available but its not remote
                 delegate?.featuresFetchedSuccessfully(features: features, isRemote: isRemote)
             } else {
-                let erorr = SDKError.failedParsedData
-                delegate?.featuresFetchFailed(error: erorr, isRemote: isRemote)
-                occurredError = erorr
+                let error = SDKError.failedParsedData
+                delegate?.featuresFetchFailed(error: error, isRemote: isRemote)
+                occurredError = error
                 if logging { logger.error("Failed parse local data") }
             }
         } else {
-            let erorr = SDKError.failedToLoadData
-            delegate?.featuresFetchFailed(error: erorr, isRemote: isRemote)
-            occurredError = erorr
+            let error = SDKError.failedToLoadData
+            delegate?.featuresFetchFailed(error: error, isRemote: isRemote)
+            occurredError = error
             if logging { logger.info("Cache directory is empty. Nothing to fetch.") }
         }
 

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -635,10 +635,8 @@ protocol GrowthBookProtocol: AnyObject {
     func featuresFetchFailed(error: SDKError, isRemote: Bool) {}
 
     func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {
-        if isRemote {
-            withLock {
-                refreshHandler?(error)
-            }
+        withLock {
+            refreshHandler?(error)
         }
     }
 

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -593,7 +593,6 @@ protocol GrowthBookProtocol: AnyObject {
             if stableSession && sessionEstablished {
                 if isRemote {
                     logger.info("stableSession: new features received from network — cached for next session, not applied now")
-                    self.refreshHandler?(.none)
                 } else {
                     logger.debug("stableSession: ignoring cache refresh — session features already established")
                 }
@@ -608,10 +607,6 @@ protocol GrowthBookProtocol: AnyObject {
             if stableSession {
                 sessionEstablished = true
                 logger.info("stableSession: initial features established. Session is now locked — subsequent refreshes will update the cache only and apply on next SDK initialization.")
-            }
-
-            if isRemote {
-                self.refreshHandler?(.none)
             }
         }
     }
@@ -637,9 +632,13 @@ protocol GrowthBookProtocol: AnyObject {
         }
     }
 
-    @objc public func featuresFetchFailed(error: SDKError, isRemote: Bool) {
+    func featuresFetchFailed(error: SDKError, isRemote: Bool) {}
+
+    func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {
         if isRemote {
-            refreshHandler?(error)
+            withLock {
+                refreshHandler?(error)
+            }
         }
     }
 
@@ -647,16 +646,13 @@ protocol GrowthBookProtocol: AnyObject {
         contextManager.getEvalContext()
     }
 
-    @objc public func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {
-        refreshHandler?(error)
-    }
+    func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
 
-    public func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
+    func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
         withLock {
             self.contextManager.updateEvalData { data in
                 data.savedGroups = savedGroups
             }
-            self.refreshHandler?(.none)
         }
     }
 
@@ -788,7 +784,7 @@ protocol GrowthBookProtocol: AnyObject {
         }
     }
 
-    @objc func featuresAPIModelSuccessfully(model: FeaturesDataModel) {
+    func featuresAPIModelSuccessfully(model: FeaturesDataModel) {
         withLock {
             refreshStickyBucketService(model)
         }

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -87,6 +87,7 @@ public enum SDKErrorCode: String {
     case failedEncryptedSavedGroups
     case failedParsedEncryptedData
     case failedToFetchData
+    case invalidAPIURL
 }
 
 /// GrowthBook Error Class to handle any error / exception scenario
@@ -98,7 +99,8 @@ public enum SDKErrorCode: String {
     static let failedEncryptedSavedGroups = SDKError(code: .failedEncryptedSavedGroups)
     static let failedParsedEncryptedData = SDKError(code: .failedParsedEncryptedData)
     static let failedToFetchData = SDKError(code: .failedToFetchData)
-    
+    static let invalidAPIURL = SDKError(code: .invalidAPIURL)
+
     static func failedToFetchData(_ error: Error?) -> SDKError { .init(code: .failedToFetchData, underlying: error) }
     
     public let code: SDKErrorCode


### PR DESCRIPTION
## Summary

This PR makes `refreshHandler` behave as a single completion signal. It is now called once for network success/failure handling and for the case where cached features are still fresh and no network request is needed.
This allows us to determine the sate of the GrowthBookSDK and if the features are ready or not.

## Problem

`refreshCache()` delegates to `FeaturesViewModel.fetchFeatures`, but the previous callback flow only notified `refreshHandler` from specific success or failure delegate paths and could call it several times. That meant a refresh could restore cached features and finish without notifying callers, so consumers could not reliably treat `refreshHandler` as a "ready" signal.

Remote evaluation also had two issues in the previous flow:

- When `remoteEval` was enabled and the cache was expired, `fetchFeatures` started both the regular feature fetch and the remote-evaluation fetch.
- The cache-expiration check only guarded the regular feature fetch; the remote-evaluation fetch still ran even when cached data was fresh.

There was also a duplicate-notification risk because both `featuresFetchedSuccessfully` and `savedGroupsFetchedSuccessfully` could call `refreshHandler` during the same response handling path.

## Solution

The change introduces a single delegate method, `featuresUpdateIsComplete(error:isRemote:)`, and routes `refreshHandler` through that method instead of calling it from individual feature and saved-group success/failure callbacks.

`FeaturesViewModel.fetchFeatures` now:

- Reports `.invalidAPIURL` when no API URL is available.
- Reports completion with no error when cached features are up to date.
- Uses the cache-expiration check before choosing either the remote-evaluation fetch or the regular feature fetch.
- Calls the completion delegate once after remote fetch handling succeeds or fails.

`GrowthBookSDK` keeps `featuresFetchFailed` and `savedGroupsFetchFailed` as no-op delegate methods, if you want me to delete them just ask 😅.

## Tests

The patch adds regression coverage for:

- `refreshHandler` firing when `refreshCache()` is called while features are already cached.
- `featuresUpdateIsComplete` being called once for remote-evaluation success and failure.
- `featuresUpdateIsComplete` being called when cached features are fresh.
