### PR TITLE
fix: restore raw-map preloaded features fallback

### DIFF
--- a/GrowthBookTests/GrowthBookSDKBuilderTests.swift
+++ b/GrowthBookTests/GrowthBookSDKBuilderTests.swift
@@ -302,6 +302,40 @@ class GrowthBookSDKBuilderTests: XCTestCase {
         XCTAssertEqual(2, countTrackingCallback)
     }
     
+    // MARK: - Raw-map preloaded payload
+
+    /// Regression test for the v1.1.0 fallback-unreachable bug.
+    /// A raw { "featureId": { ... } } blob (no "features" envelope) must be decoded via the
+    /// fallback path and produce the correct evalFeature result — not unknownFeature.
+    func testRawMapFeaturesPayloadIsLoaded() throws {
+        let rawMapPayload = """
+        {
+            "my-flag": {
+                "defaultValue": true,
+                "rules": [
+                    { "id": "rule_1", "condition": {"label": "my-label"}, "force": false }
+                ]
+            }
+        }
+        """.data(using: .utf8)!
+
+        let sdk = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: testClientKey,
+            attributes: [:],
+            features: rawMapPayload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        XCTAssertEqual(sdk.getFeatures().count, 1, "Raw-map payload must produce exactly one feature")
+        let result = sdk.evalFeature(id: "my-flag")
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue, "Feature source must be defaultValue, not unknownFeature")
+        XCTAssertEqual(result.value?.bool, true, "Feature default value must be true")
+    }
+
     // MARK: - Offline Mode
 
     /// When features are supplied at init and backgroundSync is false, the SDK must not

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -288,8 +288,12 @@ protocol GrowthBookProtocol: AnyObject {
 
         if let featuresData = growthBookBuilderModel.features {
             let decoder = JSONDecoder()
-            // Try to decode as FeaturesDataModel first (API format)
-            if let featuresModel = try? decoder.decode(FeaturesDataModel.self, from: featuresData) {
+            // Try to decode as FeaturesDataModel first (API format).
+            // Guard requires at least one known envelope field to be non-nil: because every field on
+            // FeaturesDataModel is Optional, the decoder accepts any JSON object and always succeeds,
+            // so without this check the else-if fallback for raw-map payloads is unreachable.
+            if let featuresModel = try? decoder.decode(FeaturesDataModel.self, from: featuresData),
+               featuresModel.features != nil || featuresModel.encryptedFeatures != nil {
                 if let features = featuresModel.features {
                     initialFeatures = features
                     hasPreloadedPayload = true


### PR DESCRIPTION
  ## Summary
  
  - `FeaturesDataModel` has all-optional fields, so `try? decoder.decode(FeaturesDataModel.self, …)`
    always succeeds for any valid JSON object — making the `else if` fallback for raw-map payloads
    unreachable since the v1.1.0 refactor
  - Fixed by guarding the outer `if let` with `featuresModel.features != nil || featuresModel.encryptedFeatures !=
  nil`
  - Added regression test `testRawMapFeaturesPayloadIsLoaded` that reproduces the exact scenario from the issue report
  
  Closes #161 