### PR TITLE
feat: add customFields property to Experiment

### DIFF
--- a/GrowthBookTests/ModelTests.swift
+++ b/GrowthBookTests/ModelTests.swift
@@ -264,3 +264,37 @@ class EvaluationDataTests: XCTestCase {
     }
 }
 
+class ExperimentCustomFieldsTests: XCTestCase {
+
+    func testCustomFields_parsedFromJSON() {
+        let json: [String: JSON] = [
+            "key": JSON("my-experiment"),
+            "variations": JSON([JSON("control"), JSON("variant")]),
+            "customFields": JSON(["cfl_abc123": "My custom field", "cfl_def456": 42])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertNotNil(experiment.customFields)
+        XCTAssertEqual(experiment.customFields?["cfl_abc123"]?.stringValue, "My custom field")
+        XCTAssertEqual(experiment.customFields?["cfl_def456"]?.intValue, 42)
+    }
+
+    func testCustomFields_nilWhenAbsent() {
+        let json: [String: JSON] = [
+            "key": JSON("my-experiment"),
+            "variations": JSON([JSON("control"), JSON("variant")])
+        ]
+        let experiment = Experiment(json: json)
+        XCTAssertNil(experiment.customFields)
+    }
+
+    func testCustomFields_publicInit() {
+        let experiment = Experiment(
+            key: "my-experiment",
+            variations: ["control", "variant"],
+            customFields: ["cfl_xyz": "hello"]
+        )
+        XCTAssertNotNil(experiment.customFields)
+        XCTAssertEqual(experiment.customFields?["cfl_xyz"]?.stringValue, "hello")
+    }
+}
+

--- a/Sources/CommonMain/Model/Experiment.swift
+++ b/Sources/CommonMain/Model/Experiment.swift
@@ -44,7 +44,9 @@ import Foundation
     public let name: String?
     /// Id of the current experiment phase
     public let phase: String?
-    
+    /// Custom fields defined in the GrowthBook UI
+    public let customFields: [String: JSON]?
+
     public init(key: String,
                 variations: [Any] = [],
                 namespace: [Any]? = nil,
@@ -65,7 +67,8 @@ import Foundation
                 filters: [Filter]? = nil,
                 seed: String? = nil,
                 name: String? = nil,
-                phase: String? = nil) {
+                phase: String? = nil,
+                customFields: [String: Any]? = nil) {
         self.key = key
         self.variations = JSON(variations).arrayValue
         if let namespace = namespace {
@@ -93,6 +96,11 @@ import Foundation
         self.seed = seed
         self.name = name
         self.phase = phase
+        if let customFields = customFields {
+            self.customFields = JSON(customFields).dictionaryValue
+        } else {
+            self.customFields = nil
+        }
     }
 
     init(key: String,
@@ -115,7 +123,8 @@ import Foundation
          filters: [Filter]? = nil,
          seed: String? = nil,
          name: String? = nil,
-         phase: String? = nil) {
+         phase: String? = nil,
+         customFields: [String: JSON]? = nil) {
         self.key = key
         self.variations = variations
         self.namespace = namespace
@@ -137,6 +146,7 @@ import Foundation
         self.seed = seed
         self.name = name
         self.phase = phase
+        self.customFields = customFields
     }
 
     init(json: [String: JSON]) {
@@ -189,11 +199,12 @@ import Foundation
         })
         
         seed = json["seed"]?.stringValue
-        
+
         name = json["name"]?.stringValue
-        
+
         phase = json["phase"]?.stringValue
-        
+
+        customFields = json["customFields"]?.dictionaryValue
     }
 }
 


### PR DESCRIPTION
 ## Summary
  Adds support for Custom Fields in Experiments, allowing developers
  to access custom metadata defined in the GrowthBook UI through the Swift SDK.

  ## What Changed
  - Added `customFields: [String: JSON]?` property to the `Experiment` class
  - Property is deserialized from the `customFields` field in the API response
  - All three initializers (`public init`, internal `init`, `init(json:)`)
    updated to support the new property

  ## Why
  GrowthBook UI allows defining Custom Fields for experiments
  (e.g. team ownership, ticket links, metric type).
  Previously the Swift SDK silently ignored this field during JSON parsing,
  making it inaccessible to developers even when the API returned it.

  ## Test plan
  - `testCustomFields_parsedFromJSON` — parses string and numeric values from JSON
  - `testCustomFields_nilWhenAbsent` — returns nil when field is not present in payload
  - `testCustomFields_publicInit` — works correctly via public initializer