### PR TITLE
feat: add Sendable conformances for Swift 6 / strict concurrency compatibility

### DIFF
--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -18,3 +18,18 @@ jobs:
       run: ./Scripts/runTest.sh
     - name: Build Framework
       run: ./Scripts/build.sh
+
+  swift6_language_mode:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        clean: 'true'
+    # A separate job on its own toolchain: the build above is pinned to Xcode 15.2, whose Swift 5.9
+    # compiler does not accept -swift-version 6 at all. Tracking latest-stable is deliberate — the
+    # point of this job is to catch new concurrency diagnostics as they ship.
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Build in Swift 6 language mode
+      run: swift build -Xswiftc -swift-version -Xswiftc 6 -Xswiftc -strict-concurrency=complete

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */; };
 		843316142FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */; };
 		843316162FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */; };
+		843317012FA3FAEF00D1C388 /* GBLoggerConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843317002FA3FAEF00D1C388 /* GBLoggerConcurrencyTests.swift */; };
 		843316182FA3FD1800D1C388 /* MiscCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
@@ -123,6 +124,7 @@
 		843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesViewModelExtendedTests.swift; sourceTree = "<group>"; };
+		843317002FA3FAEF00D1C388 /* GBLoggerConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GBLoggerConcurrencyTests.swift; sourceTree = "<group>"; };
 		843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscCoverageTests.swift; sourceTree = "<group>"; };
 		843363F627F845EB0072BFDC /* GrowthBookSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDK.swift; sourceTree = "<group>"; };
 		843363F827F845EB0072BFDC /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 			children = (
 				843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */,
 				843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */,
+				843317002FA3FAEF00D1C388 /* GBLoggerConcurrencyTests.swift */,
 				843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */,
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
@@ -511,6 +514,7 @@
 				849114C7280DA73000C0B9A5 /* FeaturesViewModelTests.swift in Sources */,
 				5D5EAD1F2EF1DED60049F432 /* LruETagCacheTests.swift in Sources */,
 				843316162FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift in Sources */,
+				843317012FA3FAEF00D1C388 /* GBLoggerConcurrencyTests.swift in Sources */,
 				843316062FA252B300D1C388 /* GrowthBookSDKTests.swift in Sources */,
 				849114C8280DA73000C0B9A5 /* ConditionTests.swift in Sources */,
 				849114C9280DA73000C0B9A5 /* ExperimentRunTests.swift in Sources */,

--- a/GrowthBookTests/GBLoggerConcurrencyTests.swift
+++ b/GrowthBookTests/GBLoggerConcurrencyTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import GrowthBook
+
+/// `GBLogger` claims `@unchecked Sendable`, which the compiler cannot verify — these tests cover the
+/// part it has to earn: configuration is mutable from any thread while logging happens on another.
+final class GBLoggerConcurrencyTests: XCTestCase {
+
+    func testConfigurationRoundTrips() {
+        let logger = GBLogger()
+
+        logger.minLevel = .warning
+        logger.enabled = false
+        logger.theme = nil
+
+        XCTAssertEqual(logger.minLevel, .warning)
+        XCTAssertFalse(logger.enabled)
+        XCTAssertNil(logger.theme)
+    }
+
+    /// The formatter setter used to be a stored property with a `didSet` that pointed the formatter
+    /// back at its logger. Now that it is lock-guarded, that wiring has to happen in the setter —
+    /// without it, themed output silently loses its colours.
+    func testAssigningFormatterKeepsItPointingAtTheLogger() {
+        let logger = GBLogger()
+        // A distinct instance, not the shared `Formatter.default`: that one is already wired to
+        // whichever logger was created last, so asserting on it would prove nothing.
+        let formatter = Formatter("%@ %@", [.level, .message])
+
+        logger.formatter = formatter
+
+        XCTAssertTrue(logger.formatter === formatter)
+        XCTAssertTrue(formatter.logger === logger, "The formatter must be wired back to its logger")
+    }
+
+    /// Reconfiguring while logging from other threads must neither crash nor deadlock. The lock is
+    /// deliberately not held across formatting, which is where a naive implementation deadlocks:
+    /// `Formatter` reads `logger?.theme` while it formats.
+    func testConcurrentReconfigurationWhileLogging() {
+        let logger = GBLogger(minLevel: .trace)
+        let group = DispatchGroup()
+
+        for i in 0..<50 {
+            DispatchQueue.global().async(group: group) {
+                logger.info("message \(i)")
+            }
+            DispatchQueue.global().async(group: group) {
+                logger.minLevel = (i % 2 == 0) ? .trace : .error
+                logger.enabled = (i % 3 != 0)
+                _ = logger.format
+                _ = logger.colors
+            }
+        }
+
+        let finished = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(finished, .success, "Logging and reconfiguration must not deadlock")
+        XCTAssertTrue([Level.trace, .error].contains(logger.minLevel))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -463,6 +463,26 @@ If you would like to implement Sticky Bucketing while using Remote Evaluation, y
 Sticky bucketing ensures that users see the same experiment variant, even when user session, user login status, or experiment parameters change. See the [Sticky Bucketing docs](/app/sticky-bucketing) for more information. If your organization and experiment supports sticky bucketing, you must implement an instance of the `StickyBucketService` to use Sticky Bucketing. For simple bucket persistence using the browser's LocalStorage (can be polyfilled for other environments).
 
 
+## Swift 6 and strict concurrency
+
+The SDK builds under the Swift 6 language mode, and CI keeps it that way:
+
+```bash
+swift build -Xswiftc -swift-version -Xswiftc 6 -Xswiftc -strict-concurrency=complete
+```
+
+Two things are worth knowing when you migrate an app to Swift 6 or turn on strict concurrency:
+
+- **`NetworkProtocol` closures are now `@Sendable`.** If you pass a custom network client to
+  `setNetworkDispatcher(networkDispatcher:)`, the protocol still conforms as before — but the
+  closures you hand to `consumeGETRequest` / `consumePOSTRequest` can no longer capture
+  non-`Sendable` state. Under strict concurrency such a call site becomes a compile error rather
+  than a warning, so capture values, not mutable objects.
+- **Logger configuration is safe to change from any thread.** `GBLogger`'s `enabled`, `formatter`,
+  `theme` and `minLevel` are guarded internally, so adjusting log level at runtime while the SDK
+  logs from its own queues is fine.
+
+
 ## License
 
 This project uses the MIT license. The core GrowthBook app will always remain open and free, although we may add some commercial enterprise add-ons in the future.

--- a/Sources/CommonMain/Evaluators/ExperimentHelper.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentHelper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-internal class ExperimentHelper {
+internal class ExperimentHelper: @unchecked Sendable {
     static let shared = ExperimentHelper()
     
     private var trackedExperiments: Set<String> = Set<String>()

--- a/Sources/CommonMain/Features/FeaturesDataSource.swift
+++ b/Sources/CommonMain/Features/FeaturesDataSource.swift
@@ -9,7 +9,7 @@ class FeaturesDataSource {
     }
 
     /// Executes API Call to fetch features
-    func fetchFeatures(apiUrl: String, fetchResult: @escaping (Result<Data, Error>) -> Void) {
+    func fetchFeatures(apiUrl: String, fetchResult: @escaping @Sendable (Result<Data, Error>) -> Void) {
         dispatcher.consumeGETRequest(url: apiUrl, successResult: { data in
             fetchResult(.success(data))
         }, errorResult: { error in
@@ -18,7 +18,7 @@ class FeaturesDataSource {
     }
     
     /// Executes API Call to fetch features and send data for remote eval
-    func fetchRemoteEval(apiUrl: String, params: RemoteEvalParams?, fetchResult: @escaping (Result<Data, Error>) -> Void) {
+    func fetchRemoteEval(apiUrl: String, params: RemoteEvalParams?, fetchResult: @escaping @Sendable (Result<Data, Error>) -> Void) {
         var payload: [String: Any] = [:]
         
         if let params = params {

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -11,7 +11,7 @@ protocol FeaturesFlowDelegate: AnyObject {
 }
 
 /// View Model for Features
-class FeaturesViewModel {
+class FeaturesViewModel: @unchecked Sendable {
     weak var delegate: FeaturesFlowDelegate?
     let dataSource: FeaturesDataSource
     var encryptionKey: String?

--- a/Sources/CommonMain/JsonManager/JsonManager.swift
+++ b/Sources/CommonMain/JsonManager/JsonManager.swift
@@ -50,7 +50,7 @@ public enum Type: Int {
 
 // MARK: - JSON Base
 
-public struct JSON {
+public struct JSON: @unchecked Sendable {
 
     /**
      Creates a JSON using the data.

--- a/Sources/CommonMain/LoggingManager/Formatter.swift
+++ b/Sources/CommonMain/LoggingManager/Formatter.swift
@@ -19,9 +19,9 @@ public enum Component {
     case block(() -> Any?)
 }
 
-open class Formatters {}
+open class Formatters: @unchecked Sendable {}
 
-open class Formatter: Formatters {
+open class Formatter: Formatters, @unchecked Sendable {
     /// The formatter format.
     private var format: String
 

--- a/Sources/CommonMain/LoggingManager/Formatter.swift
+++ b/Sources/CommonMain/LoggingManager/Formatter.swift
@@ -23,16 +23,27 @@ open class Formatters: @unchecked Sendable {}
 
 open class Formatter: Formatters, @unchecked Sendable {
     /// The formatter format.
-    private var format: String
+    private let format: String
 
     /// The formatter components.
-    private var components: [Component]
+    private let components: [Component]
 
     /// The date formatter.
     private let dateFormatter = DateFormatter()
 
-    /// The formatter logger.
-    weak var logger: GBLogger?
+    private let loggerLock = NSLock()
+    private weak var _logger: GBLogger?
+
+    /// The logger this formatter reads its theme from.
+    ///
+    /// `Formatter.default` is a shared instance, so this reference is reassigned whenever another
+    /// logger adopts the formatter — while formatting may be reading it from a different thread.
+    /// The storage stays `weak` to avoid a retain cycle with the logger; the accessors make the
+    /// hand-off atomic, which is what `@unchecked Sendable` on this class promises.
+    var logger: GBLogger? {
+        get { loggerLock.lock(); defer { loggerLock.unlock() }; return _logger }
+        set { loggerLock.lock(); defer { loggerLock.unlock() }; _logger = newValue }
+    }
 
     /// The formatter textual representation.
     var description: String {

--- a/Sources/CommonMain/LoggingManager/LoggingManager.swift
+++ b/Sources/CommonMain/LoggingManager/LoggingManager.swift
@@ -22,20 +22,51 @@ extension Level: Comparable {
     }
 }
 
+/// The SDK logger.
+///
+/// `@unchecked Sendable` is a claim the compiler cannot verify, so it has to be earned: every
+/// mutable property below is guarded by `stateLock`, and the only other stored state — the logging
+/// queue and the OS logger — is immutable after init. Configuration can therefore be changed from
+/// any thread while logging happens on another.
+///
+/// The lock is never held across formatting: `Formatter` reads `logger?.theme` while it formats, so
+/// holding it there would deadlock on the very first themed message.
 open class GBLogger: @unchecked Sendable {
+    private let stateLock = NSLock()
+
+    private var _enabled: Bool = true
+    private var _formatter: Formatter
+    private var _theme: Theme?
+    private var _minLevel: Level
+
     /// The logger state.
-    open var enabled: Bool = true
+    open var enabled: Bool {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _enabled }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _enabled = newValue }
+    }
 
     /// The logger formatter.
     open var formatter: Formatter {
-        didSet { formatter.logger = self }
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _formatter }
+        set {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            _formatter = newValue
+            newValue.logger = self
+        }
     }
 
     /// The logger theme.
-    open var theme: Theme?
+    open var theme: Theme? {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _theme }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _theme = newValue }
+    }
 
     /// The minimum level of severity.
-    open var minLevel: Level
+    open var minLevel: Level {
+        get { stateLock.lock(); defer { stateLock.unlock() }; return _minLevel }
+        set { stateLock.lock(); defer { stateLock.unlock() }; _minLevel = newValue }
+    }
 
     /// The logger format.
     open var format: String {
@@ -49,8 +80,8 @@ open class GBLogger: @unchecked Sendable {
 
     /// The queue used for logging.
     private let queue = DispatchQueue(label: "delba.log")
-    
-    private var osLogger: Any? = {
+
+    private let osLogger: Any? = {
         if #available(iOS 14.0, macCatalyst 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *) {
             return Logger(subsystem: "com.growthbook.sdk", category: "GrowthBook")
         } else {
@@ -67,9 +98,11 @@ open class GBLogger: @unchecked Sendable {
      - returns: A newly created logger.
      */
     public init(formatter: Formatter = .default, theme: Theme? = nil, minLevel: Level = .trace) {
-        self.formatter = formatter
-        self.theme = theme
-        self.minLevel = minLevel
+        // Assign the storage directly: the instance has not escaped yet, so there is nothing to
+        // serialise against, and going through the setters would take a lock for no reason.
+        self._formatter = formatter
+        self._theme = theme
+        self._minLevel = minLevel
 
         formatter.logger = self
     }

--- a/Sources/CommonMain/LoggingManager/LoggingManager.swift
+++ b/Sources/CommonMain/LoggingManager/LoggingManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import os
 
-public enum Level: Int {
+public enum Level: Int, Sendable {
     case trace, debug, info, warning, error
 
     var description: String {
@@ -22,7 +22,7 @@ extension Level: Comparable {
     }
 }
 
-open class GBLogger {
+open class GBLogger: @unchecked Sendable {
     /// The logger state.
     open var enabled: Bool = true
 

--- a/Sources/CommonMain/LoggingManager/Theme.swift
+++ b/Sources/CommonMain/LoggingManager/Theme.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-open class Themes {}
+open class Themes: @unchecked Sendable {}
 
-open class Theme: Themes {
+open class Theme: Themes, @unchecked Sendable {
     /// The theme colors.
     var colors: [Level: String]
 

--- a/Sources/CommonMain/LoggingManager/Theme.swift
+++ b/Sources/CommonMain/LoggingManager/Theme.swift
@@ -10,8 +10,9 @@ import Foundation
 open class Themes: @unchecked Sendable {}
 
 open class Theme: Themes, @unchecked Sendable {
-    /// The theme colors.
-    var colors: [Level: String]
+    /// The theme colors. Immutable after init, which is what makes sharing a theme across threads
+    /// safe without a lock.
+    let colors: [Level: String]
 
     /// The theme textual representation.
     var description: String {

--- a/Sources/CommonMain/Model/Experiment.swift
+++ b/Sources/CommonMain/Model/Experiment.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Defines a single experiment
-@objc public class Experiment: NSObject, Codable {
+@objc public class Experiment: NSObject, Codable, @unchecked Sendable {
     /// The globally unique tracking key for the experiment
     public let key: String
     /// The different variations to choose between
@@ -198,7 +198,7 @@ import Foundation
 }
 
 /// The result of running an Experiment given a specific Context
-@objc public class ExperimentResult: NSObject, Codable {
+@objc public class ExperimentResult: NSObject, Codable, @unchecked Sendable {
     /// Whether or not the user is part of the experiment
     public let inExperiment: Bool
     /// The array index of the assigned variation

--- a/Sources/CommonMain/Model/Feature.swift
+++ b/Sources/CommonMain/Model/Feature.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A Feature object consists of possible values plus rules for how to assign values to users.
-@objc public class Feature: NSObject, Codable, Sendable {
+@objc public class Feature: NSObject, Codable, @unchecked Sendable {
     /// The default value (should use null if not specified)
     public let defaultValue: JSON?
     /// Array of Rule objects that determine when and how the defaultValue gets overridden

--- a/Sources/CommonMain/Network/NetworkClient.swift
+++ b/Sources/CommonMain/Network/NetworkClient.swift
@@ -4,11 +4,11 @@ import Foundation
 ///
 /// Implement this protocol to define specific implementation for Network Calls - to be made by SDK
 @objc public protocol NetworkProtocol: AnyObject {
-    func consumeGETRequest(url: String, successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void)
-    func consumePOSTRequest(url: String, params: [String : Any], successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void)
+    func consumeGETRequest(url: String, successResult: @escaping @Sendable (Data) -> Void, errorResult: @escaping @Sendable (Error) -> Void)
+    func consumePOSTRequest(url: String, params: [String : Any], successResult: @escaping @Sendable (Data) -> Void, errorResult: @escaping @Sendable (Error) -> Void)
 }
 
-class CoreNetworkClient: NetworkProtocol {
+class CoreNetworkClient: NetworkProtocol, @unchecked Sendable {
     var apiRequestHeaders: [String: String]
     var streamingHostRequestHeaders: [String: String]
     
@@ -33,15 +33,15 @@ class CoreNetworkClient: NetworkProtocol {
         self.streamingHostRequestHeaders = streamingHostRequestHeaders
     }
     
-    func consumeGETRequest(url: String, successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void) {
+    func consumeGETRequest(url: String, successResult: @escaping @Sendable (Data) -> Void, errorResult: @escaping @Sendable (Error) -> Void) {
         perform(urlString: url, method: "GET", params: nil, successResult: successResult, errorResult: errorResult)
     }
-    
-    func consumePOSTRequest(url: String, params: [String : Any], successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void) {
+
+    func consumePOSTRequest(url: String, params: [String : Any], successResult: @escaping @Sendable (Data) -> Void, errorResult: @escaping @Sendable (Error) -> Void) {
         perform(urlString: url, method: "POST", params: params, successResult: successResult, errorResult: errorResult)
     }
-    
-    private func perform(urlString: String, method: String, params: [String: Any]?, successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void) {
+
+    private func perform(urlString: String, method: String, params: [String: Any]?, successResult: @escaping @Sendable (Data) -> Void, errorResult: @escaping @Sendable (Error) -> Void) {
         guard let url = URL(string: urlString) else { return }
         
         var request = URLRequest(url: url)

--- a/Sources/CommonMain/Network/NetworkRetryHandler.swift
+++ b/Sources/CommonMain/Network/NetworkRetryHandler.swift
@@ -1,7 +1,7 @@
 import Network
 import Foundation
 
-final class NetworkRetryHandler {
+final class NetworkRetryHandler: @unchecked Sendable {
     private let monitor = NWPathMonitor()
     private let monitorQueue = DispatchQueue(label: "NetworkRetryQueue")
     private var onOnlineCallbacks: [() -> Void] = []
@@ -35,7 +35,7 @@ final class NetworkRetryHandler {
         monitor.start(queue: monitorQueue)
     }
     
-    func retryWhenOnline(_ onOnline: @escaping () -> Void) {
+    func retryWhenOnline(_ onOnline: @escaping @Sendable () -> Void) {
         if isInternetAvailable {
             DispatchQueue.main.async {
                 onOnline()
@@ -45,7 +45,7 @@ final class NetworkRetryHandler {
         }
     }
     
-    private func checkInternetAccess(completion: @escaping (Bool) -> Void) {
+    private func checkInternetAccess(completion: @escaping @Sendable (Bool) -> Void) {
         var request = URLRequest(url: testUrl)
         request.timeoutInterval = 5
         URLSession.shared.dataTask(with: request) { _, response, error in

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -6,7 +6,7 @@ enum SSEConnectionStatus {
     case disconnected
 }
 
-class SSEHandler: NSObject, URLSessionDataDelegate {
+class SSEHandler: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     static let DefaultRetryTime = 1000
     public let url: URL
     public var lastEventId: String?
@@ -16,7 +16,7 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
 
     private var onConnect: (() -> Void)?
     private var onDisconnect: ((Int?, Bool?, NSError?) -> Void)?
-    private var eventListeners: [String: (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
+    private var eventListeners: [String: @Sendable (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
     private var eventHandler: EventHandler?
     private var operationQueue: OperationQueue
     private var mainQueue = DispatchQueue.main
@@ -59,7 +59,7 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
     }
 
     public func addEventListener(event: String,
-                                 handler: @escaping ((_ id: String?, _ event: String?, _ data: String?) -> ())) {
+                                 handler: @escaping @Sendable (_ id: String?, _ event: String?, _ data: String?) -> Void) {
         eventListeners[event] = handler
     }
 

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -16,7 +16,7 @@ typealias Features = [String: Feature]
 /// Type Alias for Condition Element in GrowthBook Rules
 typealias Condition = JSON
 
-public struct ParentConditionInterface: Codable {
+public struct ParentConditionInterface: Codable, Sendable {
     public let id: String
     public let condition: JSON
     public let gate: Bool?
@@ -45,7 +45,7 @@ public typealias ExperimentRunCallback = (Experiment, ExperimentResult) -> Void
 typealias NameSpace = (String, Float, Float)
 
 /// Double Struct for GrowthBook Ranges
-public struct BucketRange: Codable {
+public struct BucketRange: Codable, Sendable {
     let number1: Float
     let number2: Float
     
@@ -79,7 +79,7 @@ public struct BucketRange: Codable {
     }
 }
 
-public enum SDKErrorCode: String {
+public enum SDKErrorCode: String, Sendable {
     case failedToLoadData
     case failedParsedData
     case failedMissingKey
@@ -113,7 +113,7 @@ public enum SDKErrorCode: String {
 }
 
 /// Meta info about the variations
-public struct VariationMeta: Codable {
+public struct VariationMeta: Codable, Sendable {
     /// Used to implement holdout groups
     let passthrough: Bool?
     /// A unique key for this variation
@@ -128,7 +128,7 @@ public struct VariationMeta: Codable {
     }
 }
 
-public struct Track: Codable {
+public struct Track: Codable, Sendable {
     public let experiment: Experiment?
     public let result: ExperimentResult?
     
@@ -139,7 +139,7 @@ public struct Track: Codable {
 }
 
 ///Used for remote feature evaluation to trigger the `TrackingCallback`
-public struct TrackData: Codable {
+public struct TrackData: Codable, Sendable {
     let experiment: Experiment
     let result: ExperimentResult
     
@@ -151,7 +151,7 @@ public struct TrackData: Codable {
 }
 
 /// Object used for mutual exclusion and filtering users out of experiments based on random hashes.
-@objc public class Filter: NSObject, Codable {
+@objc public class Filter: NSObject, Codable, @unchecked Sendable {
     /// The attribute to use (default to `"id"`)
     var attribute: String?
     /// The seed used in the hash

--- a/Sources/CommonMain/Utils/DecryptionUtils.swift
+++ b/Sources/CommonMain/Utils/DecryptionUtils.swift
@@ -88,7 +88,7 @@ class AESCryptor {
     }
 }
 
-class DecryptionException: Error {
+class DecryptionException: Error, @unchecked Sendable {
     let errorMessage: String
 
     init(errorMessage: String) {

--- a/Sources/CommonMain/Utils/Logger.swift
+++ b/Sources/CommonMain/Utils/Logger.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 // GrowthBook default logger
-var logger = GBLogger()
+nonisolated(unsafe) var logger = GBLogger()
 
 @objc public enum LoggerLevel: NSInteger {
     case trace = 0

--- a/Sources/CommonMain/Utils/Logger.swift
+++ b/Sources/CommonMain/Utils/Logger.swift
@@ -1,8 +1,12 @@
  
 import Foundation
 
-// GrowthBook default logger
-var logger = GBLogger()
+// GrowthBook default logger.
+//
+// A `let`: nothing reassigns this reference, and a mutable global is rejected outright under the
+// Swift 6 language mode as unsafe shared state. Configuration still changes at runtime — through
+// GBLogger's own lock-guarded properties — so `logger.minLevel = ...` keeps working.
+let logger = GBLogger()
 
 @objc public enum LoggerLevel: NSInteger {
     case trace = 0

--- a/Sources/CommonMain/Utils/Logger.swift
+++ b/Sources/CommonMain/Utils/Logger.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 // GrowthBook default logger
-nonisolated(unsafe) var logger = GBLogger()
+var logger = GBLogger()
 
 @objc public enum LoggerLevel: NSInteger {
     case trace = 0


### PR DESCRIPTION
 ## Summary
  Adds `Sendable` conformances to all public SDK types so that projects using `SWIFT_STRICT_CONCURRENCY = complete` or
   Swift 6 language mode compile without warnings or errors.
   
  ## Changes
  - `JSON` → `@unchecked Sendable` (contains `[Any]` internally)
  - `BucketRange`, `VariationMeta`, `ParentConditionInterface`, `SDKErrorCode`, `Track`, `TrackData` → `Sendable`
  - `Feature`, `Experiment`, `ExperimentResult`, `Filter` → `@unchecked Sendable` (`@objc` non-final classes)
  - `SSEHandler`, `CoreNetworkClient`, `NetworkRetryHandler`, `FeaturesViewModel`, `ExperimentHelper`, `GBLogger`,
  `Formatter`, `Theme` → `@unchecked Sendable`
  - `Level` → `Sendable` 
  - `logger` global → `nonisolated(unsafe)`
  - `NetworkProtocol` closure params and `SSEHandler.addEventListener` handler marked `@Sendable`

  ## Potential impact
  Users with a custom `NetworkProtocol` implementation will need to add `@Sendable` to their closure parameters. In
  Swift 5 this surfaces as a warning only — existing code will continue to compile and run.
  
  ## Test plan
  - Build with `SWIFT_STRICT_CONCURRENCY = complete` — 0 warnings
  - Full test suite passes