### PR TITLE
fix: correct sticky bucketing for user switches, overrides, and payload race

### DIFF
--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -2,6 +2,95 @@ import XCTest
 
 @testable import GrowthBook
 
+// Captures the getAllAssignments completion without calling it, so tests can
+// control exactly when the async refresh resolves.
+private class ManualStickyBucketService: NSObject, StickyBucketServiceProtocol {
+    private var pendingCompletion: (([String: StickyAssignmentsDocument]?, Error?) -> Void)?
+
+    func getAssignments(attributeName: String, attributeValue: String,
+                        completion: @escaping (StickyAssignmentsDocument?, Error?) -> Void) {
+        completion(nil, nil)
+    }
+
+    func saveAssignments(doc: StickyAssignmentsDocument, completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+
+    func getAllAssignments(attributes: [String: String],
+                           completion: @escaping ([String: StickyAssignmentsDocument]?, Error?) -> Void) {
+        pendingCompletion = completion
+    }
+
+    func flush(docs: [String: StickyAssignmentsDocument] = [:]) {
+        pendingCompletion?(docs, nil)
+        pendingCompletion = nil
+    }
+}
+
+private func makeSdk(attributes: [String: Any],
+                     service: StickyBucketServiceProtocol) -> GrowthBookSDK {
+    let emptyFeatures = try! JSONEncoder().encode([String: Feature]())
+    return GrowthBookBuilder(
+        features: emptyFeatures,
+        attributes: attributes,
+        trackingCallback: { _, _ in },
+        backgroundSync: false
+    )
+    .setStickyBucketService(stickyBucketService: service)
+    .initializer()
+}
+
+class StickyBucketUserSwitchTests: XCTestCase {
+
+    func testSetAttributesClearsStickyDocsBeforeRefreshCompletes() {
+        let service = ManualStickyBucketService()
+        let sdk = makeSdk(attributes: ["id": "userA"], service: service)
+
+        let userADocs = ["id||userA": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "userA",
+            assignments: ["exp-1__0": "control"]
+        )]
+        service.flush(docs: userADocs)
+        XCTAssertEqual(sdk.getGBContext().stickyBucketAssignmentDocs?["id||userA"]?.assignments["exp-1__0"], "control",
+                       "Precondition: userA docs must be loaded after init flush")
+
+        sdk.setAttributes(attributes: ["id": "userB"])
+
+        // Before the refresh completion fires, stale userA docs must already be gone.
+        XCTAssertNil(sdk.getGBContext().stickyBucketAssignmentDocs,
+                     "Stale docs from previous user must be cleared synchronously on setAttributes")
+
+        let userBDocs = ["id||userB": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "userB",
+            assignments: ["exp-1__0": "variant"]
+        )]
+        service.flush(docs: userBDocs)
+        XCTAssertEqual(sdk.getGBContext().stickyBucketAssignmentDocs?["id||userB"]?.assignments["exp-1__0"], "variant",
+                       "userB docs must be loaded after refresh completes")
+    }
+
+    func testAppendAttributesClearsStickyDocsBeforeRefreshCompletes() {
+        let service = ManualStickyBucketService()
+        let sdk = makeSdk(attributes: ["deviceId": "device-1"], service: service)
+
+        let anonymousDocs = ["deviceId||device-1": StickyAssignmentsDocument(
+            attributeName: "deviceId", attributeValue: "device-1",
+            assignments: ["exp-1__0": "control"]
+        )]
+        service.flush(docs: anonymousDocs)
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs,
+                        "Precondition: anonymous docs must be loaded after init flush")
+
+        try? sdk.appendAttributes(attributes: ["id": "user-logged-in"])
+
+        XCTAssertNil(sdk.getGBContext().stickyBucketAssignmentDocs,
+                     "Stale docs must be cleared synchronously on appendAttributes")
+
+        service.flush(docs: [:])
+        XCTAssertTrue(sdk.getGBContext().stickyBucketAssignmentDocs?.isEmpty ?? true)
+    }
+}
+
 class StickyBucketingFeatureTests: XCTestCase {
     var service: StickyBucketService!
     var evalConditions: [JSON]?

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -2,10 +2,13 @@ import XCTest
 
 @testable import GrowthBook
 
-// Captures the getAllAssignments completion without calling it, so tests can
-// control exactly when the async refresh resolves.
+// Captures getAllAssignments completions without calling them, so tests control exactly when — and
+// in which order — each async refresh resolves. Completions are queued rather than replaced, which
+// is what lets a test resolve a newer request before an older one that is still in flight.
 private class ManualStickyBucketService: NSObject, StickyBucketServiceProtocol {
-    private var pendingCompletion: (([String: StickyAssignmentsDocument]?, Error?) -> Void)?
+    private var pendingCompletions: [([String: StickyAssignmentsDocument]?, Error?) -> Void] = []
+
+    var pendingCount: Int { pendingCompletions.count }
 
     func getAssignments(attributeName: String, attributeValue: String,
                         completion: @escaping (StickyAssignmentsDocument?, Error?) -> Void) {
@@ -18,12 +21,21 @@ private class ManualStickyBucketService: NSObject, StickyBucketServiceProtocol {
 
     func getAllAssignments(attributes: [String: String],
                            completion: @escaping ([String: StickyAssignmentsDocument]?, Error?) -> Void) {
-        pendingCompletion = completion
+        pendingCompletions.append(completion)
     }
 
+    /// Resolves the oldest pending request — the single-request behaviour most tests rely on.
     func flush(docs: [String: StickyAssignmentsDocument] = [:]) {
-        pendingCompletion?(docs, nil)
-        pendingCompletion = nil
+        guard !pendingCompletions.isEmpty else { return }
+        let completion = pendingCompletions.removeFirst()
+        completion(docs, nil)
+    }
+
+    /// Resolves one specific pending request, so a test can complete them out of order.
+    func complete(_ index: Int, with docs: [String: StickyAssignmentsDocument]) {
+        guard pendingCompletions.indices.contains(index) else { return }
+        let completion = pendingCompletions.remove(at: index)
+        completion(docs, nil)
     }
 }
 
@@ -67,6 +79,62 @@ class StickyBucketUserSwitchTests: XCTestCase {
         service.flush(docs: userBDocs)
         XCTAssertEqual(sdk.getGBContext().stickyBucketAssignmentDocs?["id||userB"]?.assignments["exp-1__0"], "variant",
                        "userB docs must be loaded after refresh completes")
+    }
+
+    /// A custom service is free to resolve out of order, so the request started for userA can
+    /// complete after the one started for userB. The late userA documents belong to a user the SDK
+    /// has already left and must not win by completion order.
+    func testStaleRefreshCompletionDoesNotOverwriteNewerUser() {
+        let service = ManualStickyBucketService()
+        let sdk = makeSdk(attributes: ["id": "userA"], service: service)
+
+        XCTAssertEqual(service.pendingCount, 1, "Precondition: init started a refresh for userA")
+
+        sdk.setAttributes(attributes: ["id": "userB"])
+        XCTAssertEqual(service.pendingCount, 2, "setAttributes must start a second refresh")
+
+        let userADocs = ["id||userA": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "userA",
+            assignments: ["exp-1__0": "control"]
+        )]
+        let userBDocs = ["id||userB": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "userB",
+            assignments: ["exp-1__0": "variant"]
+        )]
+
+        service.complete(1, with: userBDocs)   // newer request wins the race
+        service.complete(0, with: userADocs)   // superseded request lands afterwards
+
+        let docs = sdk.getGBContext().stickyBucketAssignmentDocs
+        XCTAssertEqual(docs?["id||userB"]?.assignments["exp-1__0"], "variant",
+                       "Documents of the current user must survive a late completion for the previous one")
+        XCTAssertNil(docs?["id||userA"],
+                     "Documents from the superseded request must be discarded, not merged in")
+    }
+
+    /// Control for the test above: in the natural order the newest completion is the one applied.
+    func testLatestRefreshCompletionIsAppliedWhenItResolvesLast() {
+        let service = ManualStickyBucketService()
+        let sdk = makeSdk(attributes: ["id": "userA"], service: service)
+
+        sdk.setAttributes(attributes: ["id": "userB"])
+        XCTAssertEqual(service.pendingCount, 2)
+
+        let userADocs = ["id||userA": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "userA",
+            assignments: ["exp-1__0": "control"]
+        )]
+        let userBDocs = ["id||userB": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "userB",
+            assignments: ["exp-1__0": "variant"]
+        )]
+
+        service.complete(0, with: userADocs)   // stale request resolves first
+        service.complete(0, with: userBDocs)   // then the current one
+
+        let docs = sdk.getGBContext().stickyBucketAssignmentDocs
+        XCTAssertEqual(docs?["id||userB"]?.assignments["exp-1__0"], "variant")
+        XCTAssertNil(docs?["id||userA"], "The stale documents must not linger once the current request lands")
     }
 
     func testAppendAttributesClearsStickyDocsBeforeRefreshCompletes() {
@@ -272,5 +340,70 @@ class StickyBucketingFeatureTests: XCTestCase {
         print("Failed TESTS - \(failedScenarios.count)")
 
         XCTAssertTrue(failedScenarios.count == 0)
+    }
+}
+
+// MARK: - Remote eval payload
+
+/// Records the POST body of every remote-eval request so tests can assert on what the server
+/// would actually be asked to evaluate.
+private class CapturingNetworkClient: NetworkProtocol {
+    private(set) var capturedParams: [[String: Any]] = []
+
+    func consumeGETRequest(url: String, successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void) {
+        successResult(Data("{\"features\":{}}".utf8))
+    }
+
+    func consumePOSTRequest(url: String, params: [String: Any], successResult: @escaping (Data) -> Void, errorResult: @escaping (Error) -> Void) {
+        capturedParams.append(params)
+        successResult(Data("{\"features\":{}}".utf8))
+    }
+
+    var lastAttributes: [String: Any]? { capturedParams.last?["attributes"] as? [String: Any] }
+}
+
+class RemoteEvalPayloadTests: XCTestCase {
+
+    private func makeRemoteEvalSdk(network: NetworkProtocol) -> GrowthBookSDK {
+        GrowthBookBuilder(apiHost: "https://host.com",
+                          clientKey: "key",
+                          attributes: ["id": "user-1", "country": "PL"],
+                          trackingCallback: { _, _ in },
+                          refreshHandler: nil,
+                          backgroundSync: false,
+                          remoteEval: true,
+                          // ttlSeconds: 0 keeps this test about payload content: the TTL gate on
+                          // remote-eval refreshes is a separate concern, fixed on its own branch.
+                          ttlSeconds: 0)
+            .setNetworkDispatcher(networkDispatcher: network)
+            .initializer()
+    }
+
+    /// Local evaluation runs on attributes with the overrides merged in, so the remote payload has
+    /// to carry the same effective attributes — otherwise the server evaluates a user the SDK has
+    /// already stopped seeing.
+    func testOverridesAreIncludedInRemoteEvalPayload() {
+        let network = CapturingNetworkClient()
+        let sdk = makeRemoteEvalSdk(network: network)
+
+        sdk.setAttributeOverrides(overrides: ["country": "UA"])
+
+        let attributes = network.lastAttributes
+        XCTAssertEqual(attributes?["country"] as? String, "UA",
+                       "The overridden attribute must be sent to the remote-eval endpoint")
+        XCTAssertEqual(attributes?["id"] as? String, "user-1",
+                       "Base attributes that are not overridden must still be sent")
+    }
+
+    /// Clearing the overrides has to be visible to the server too.
+    func testClearedOverridesRevertRemoteEvalPayloadToBaseAttributes() {
+        let network = CapturingNetworkClient()
+        let sdk = makeRemoteEvalSdk(network: network)
+
+        sdk.setAttributeOverrides(overrides: ["country": "UA"])
+        sdk.setAttributeOverrides(overrides: [String: Any]())
+
+        XCTAssertEqual(network.lastAttributes?["country"] as? String, "PL",
+                       "With the overrides lifted the payload must fall back to the base attributes")
     }
 }

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -24,10 +24,12 @@ private class ManualStickyBucketService: NSObject, StickyBucketServiceProtocol {
         pendingCompletions.append(completion)
     }
 
-    /// Resolves the oldest pending request — the single-request behaviour most tests rely on.
+    /// Resolves the newest pending request and drops the rest, which is what this double did when
+    /// it held a single completion: a later `getAllAssignments` replaced — and so discarded — the
+    /// earlier one. Tests that drive one refresh at a time keep their previous behaviour.
     func flush(docs: [String: StickyAssignmentsDocument] = [:]) {
-        guard !pendingCompletions.isEmpty else { return }
-        let completion = pendingCompletions.removeFirst()
+        guard let completion = pendingCompletions.last else { return }
+        pendingCompletions.removeAll()
         completion(docs, nil)
     }
 

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -91,6 +91,86 @@ class StickyBucketUserSwitchTests: XCTestCase {
     }
 }
 
+class AttributeOverridesTests: XCTestCase {
+
+    // Verifies that refreshStickyBucketService uses merged (base + override) attributes
+    // for the getAllAssignments call, so docs keyed on override attributes are fetched.
+    func testAttributeOverridesAreUsedInStickyBucketLookup() {
+        let service = ManualStickyBucketService()
+        // Base attributes have no "id"; override supplies it.
+        let sdk = makeSdk(attributes: ["deviceId": "device-1"], service: service)
+        service.flush(docs: [:])
+
+        sdk.setAttributeOverrides(overrides: ["id": "user-from-override"])
+        let overrideDocs = ["id||user-from-override": StickyAssignmentsDocument(
+            attributeName: "id",
+            attributeValue: "user-from-override",
+            assignments: ["exp-1__0": "variant"]
+        )]
+        service.flush(docs: overrideDocs)
+
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||user-from-override"],
+                        "Sticky doc keyed on override attribute must be fetched and loaded")
+    }
+
+    // Verifies that setAttributes clears attributeOverrides so the previous user's
+    // overrides don't bleed into the new user's sticky bucket lookup.
+    func testSetAttributesResetsAttributeOverrides() {
+        let service = ManualStickyBucketService()
+        let sdk = makeSdk(attributes: ["deviceId": "device-1"], service: service)
+        service.flush(docs: [:])
+
+        sdk.setAttributeOverrides(overrides: ["id": "override-id"])
+        let overrideDocs = ["id||override-id": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "override-id",
+            assignments: ["exp-1__0": "control"]
+        )]
+        service.flush(docs: overrideDocs)
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||override-id"],
+                        "Precondition: override docs must be loaded")
+
+        // Switch user — must clear overrides so new user doesn't inherit them.
+        sdk.setAttributes(attributes: ["id": "new-user"])
+        let newUserDocs = ["id||new-user": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "new-user",
+            assignments: ["exp-1__0": "variant"]
+        )]
+        service.flush(docs: newUserDocs)
+
+        XCTAssertNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||override-id"],
+                     "Override docs from previous context must be gone after setAttributes")
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||new-user"],
+                        "New user docs must be loaded after setAttributes")
+    }
+
+    // Verifies that attributeOverrides are merged into userContext.attributes and
+    // therefore affect experiment evaluation (via hashAttribute lookup).
+    func testAttributeOverridesAreAppliedToEvaluation() {
+        let service = ManualStickyBucketService()
+        // Base attributes have no "id" — experiments hashing on "id" won't bucket the user.
+        let sdk = makeSdk(attributes: ["deviceId": "device-only"], service: service)
+        service.flush(docs: [:])
+
+        let experiment = Experiment(
+            key: "test-exp",
+            variations: [JSON("control"), JSON("variant")],
+            hashAttribute: "id",
+            coverage: 1.0
+        )
+
+        let before = sdk.run(experiment: experiment)
+        XCTAssertFalse(before.inExperiment, "Without id attribute, user must not be bucketed")
+
+        sdk.setAttributeOverrides(overrides: ["id": "user-with-override"])
+        // No flush needed: updateEvalData already invalidated the context cache,
+        // so the next run() call gets a fresh EvalContext with merged attributes.
+
+        let after = sdk.run(experiment: experiment)
+        XCTAssertTrue(after.inExperiment,
+                      "id from attributeOverrides must be applied to experiment evaluation")
+    }
+}
+
 class StickyBucketingFeatureTests: XCTestCase {
     var service: StickyBucketService!
     var evalConditions: [JSON]?

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -90,10 +90,13 @@ class StickyBucketUserSwitchTests: XCTestCase {
         let service = ManualStickyBucketService()
         let sdk = makeSdk(attributes: ["id": "userA"], service: service)
 
-        XCTAssertEqual(service.pendingCount, 1, "Precondition: init started a refresh for userA")
+        // Counts are compared relatively: how many refreshes init itself starts is a property of the
+        // build, not of the behaviour under test.
+        let afterInit = service.pendingCount
+        XCTAssertGreaterThan(afterInit, 0, "Precondition: init started a refresh for userA")
 
         sdk.setAttributes(attributes: ["id": "userB"])
-        XCTAssertEqual(service.pendingCount, 2, "setAttributes must start a second refresh")
+        XCTAssertGreaterThan(service.pendingCount, afterInit, "setAttributes must start another refresh")
 
         let userADocs = ["id||userA": StickyAssignmentsDocument(
             attributeName: "id", attributeValue: "userA",
@@ -104,8 +107,8 @@ class StickyBucketUserSwitchTests: XCTestCase {
             assignments: ["exp-1__0": "variant"]
         )]
 
-        service.complete(1, with: userBDocs)   // newer request wins the race
-        service.complete(0, with: userADocs)   // superseded request lands afterwards
+        service.complete(service.pendingCount - 1, with: userBDocs)   // newest request wins the race
+        service.complete(0, with: userADocs)                          // superseded one lands afterwards
 
         let docs = sdk.getGBContext().stickyBucketAssignmentDocs
         XCTAssertEqual(docs?["id||userB"]?.assignments["exp-1__0"], "variant",
@@ -120,7 +123,7 @@ class StickyBucketUserSwitchTests: XCTestCase {
         let sdk = makeSdk(attributes: ["id": "userA"], service: service)
 
         sdk.setAttributes(attributes: ["id": "userB"])
-        XCTAssertEqual(service.pendingCount, 2)
+        XCTAssertGreaterThan(service.pendingCount, 1)
 
         let userADocs = ["id||userA": StickyAssignmentsDocument(
             attributeName: "id", attributeValue: "userA",
@@ -131,8 +134,8 @@ class StickyBucketUserSwitchTests: XCTestCase {
             assignments: ["exp-1__0": "variant"]
         )]
 
-        service.complete(0, with: userADocs)   // stale request resolves first
-        service.complete(0, with: userBDocs)   // then the current one
+        service.complete(0, with: userADocs)                          // stale request resolves first
+        service.complete(service.pendingCount - 1, with: userBDocs)   // then the current one
 
         let docs = sdk.getGBContext().stickyBucketAssignmentDocs
         XCTAssertEqual(docs?["id||userB"]?.assignments["exp-1__0"], "variant")

--- a/GrowthBookTests/StickyBucketingTests.swift
+++ b/GrowthBookTests/StickyBucketingTests.swift
@@ -91,6 +91,40 @@ class StickyBucketUserSwitchTests: XCTestCase {
     }
 }
 
+class FeatureLoadRaceConditionTests: XCTestCase {
+
+    // Verifies that features are applied to the context only after sticky bucket
+    // docs are loaded, so an evaluation immediately after featuresFetchedSuccessfully
+    // never sees features without docs (Kotlin onPayloadReady pattern).
+    func testFeaturesAppliedAfterStickyDocsLoaded() {
+        let service = ManualStickyBucketService()
+        let sdk = makeSdk(attributes: ["id": "user-1"], service: service)
+
+        // Complete the init refresh.
+        service.flush(docs: [:])
+
+        // Simulate featuresFetchedSuccessfully by calling it directly.
+        let newFeatures: [String: Feature] = ["my-feature": Feature(defaultValue: JSON(true), rules: nil)]
+        sdk.featuresFetchedSuccessfully(features: newFeatures, isRemote: true)
+
+        // Before the sticky bucket refresh completion fires, features must NOT be applied yet.
+        XCTAssertNil(sdk.getFeatures()["my-feature"],
+                     "Features must not be visible before sticky bucket docs are loaded")
+
+        // Flush docs — features must appear together with docs.
+        let docs = ["id||user-1": StickyAssignmentsDocument(
+            attributeName: "id", attributeValue: "user-1",
+            assignments: ["exp-1__0": "variant"]
+        )]
+        service.flush(docs: docs)
+
+        XCTAssertNotNil(sdk.getFeatures()["my-feature"],
+                        "Features must be visible after sticky bucket docs are loaded")
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||user-1"],
+                        "Sticky docs must be loaded together with features")
+    }
+}
+
 class AttributeOverridesTests: XCTestCase {
 
     // Verifies that refreshStickyBucketService uses merged (base + override) attributes

--- a/Sources/CommonMain/ContextManager.swift
+++ b/Sources/CommonMain/ContextManager.swift
@@ -200,9 +200,20 @@ import Foundation
       savedGroups: evalData.savedGroups
     )
     
-    // UserContext is created from evalData
+    // UserContext is created from evalData.
+    // attributeOverrides are merged on top of base attributes so they take
+    // effect in both experiment evaluation and sticky bucket hash lookups.
+    let effectiveAttributes: JSON
+    if let overrides = evalData.attributeOverrides, overrides != JSON() {
+      var merged = evalData.attributes.dictionaryValue
+      merged.merge(overrides.dictionaryValue) { _, new in new }
+      effectiveAttributes = JSON(merged)
+    } else {
+      effectiveAttributes = evalData.attributes
+    }
+
     let userContext = UserContext(
-      attributes: evalData.attributes,
+      attributes: effectiveAttributes,
       stickyBucketAssignmentDocs: evalData.stickyBucketAssignmentDocs,
       forcedVariations: evalData.forcedVariations,
       forcedFeatureValues: evalData.forcedFeatureValues

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -387,6 +387,10 @@ protocol GrowthBookProtocol: AnyObject {
     /// True once the session's initial features have been applied.
     /// Set once and never reset — used as the stableSession latch.
     private var sessionEstablished: Bool = false
+    /// Incremented on every sticky bucket refresh, so a completion that resolves after a newer
+    /// refresh started can recognise itself as stale. Mutated under `lock`, except in `init()`
+    /// where the instance has not escaped to other threads yet.
+    private var stickyRefreshGeneration: Int = 0
 
     init(contextManager: ContextManager,
          refreshHandler: CacheRefreshHandler? = nil,
@@ -671,7 +675,12 @@ protocol GrowthBookProtocol: AnyObject {
             let forcedFeaturesArray = convertForcedFeaturesToArray(evalData.forcedFeatureValues)
             let forcedFeaturesJson = JSON(forcedFeaturesArray ?? [])
 
-            let payload = RemoteEvalParams(attributes: evalData.attributes, forcedFeatures: forcedFeaturesJson, forcedVariations: evalData.forcedVariations)
+            // Send what the SDK itself evaluates against: `getEvalContext()` merges
+            // `attributeOverrides` on top of the base attributes, so taking `evalData.attributes`
+            // here would ask the server to evaluate a user the local evaluator no longer sees.
+            let effectiveAttributes = contextManager.getEvalContext().userContext.attributes
+
+            let payload = RemoteEvalParams(attributes: effectiveAttributes, forcedFeatures: forcedFeaturesJson, forcedVariations: evalData.forcedVariations)
             featureVM.fetchFeatures(apiUrl: contextManager.getRemoteEvalUrl(), remoteEval: globalConfig.remoteEval, payload: payload)
         }
     }
@@ -809,6 +818,13 @@ protocol GrowthBookProtocol: AnyObject {
 
         let context = contextManager.getEvalContext()
 
+        // A custom service may resolve asynchronously and out of order: a request started for one
+        // user can complete after a request started for the next one. Tag this refresh with a
+        // generation so its completion can tell whether it is still the current one; the documents
+        // it carries belong to the attributes captured above, not to whatever is current now.
+        stickyRefreshGeneration += 1
+        let generation = stickyRefreshGeneration
+
         Utils.refreshStickyBuckets(
             stickyBucketService: service,
             context: context,
@@ -817,6 +833,12 @@ protocol GrowthBookProtocol: AnyObject {
         ) { [weak self] docs in
             guard let self = self else { return }
             self.withLock {
+                // Still invoke this call's own completion — its caller is waiting on it — but let
+                // the newer refresh own the state.
+                guard generation == self.stickyRefreshGeneration else {
+                    completion?()
+                    return
+                }
                 self.contextManager.updateEvalData { data in
                     data.stickyBucketAssignmentDocs = docs
                 }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -602,14 +602,19 @@ protocol GrowthBookProtocol: AnyObject {
                 return
             }
 
-            self.contextManager.updateEvalData { data in
-                data.features = features
-            }
-            self.refreshStickyBucketService()
-
-            if stableSession {
-                sessionEstablished = true
-                logger.info("stableSession: initial features established. Session is now locked — subsequent refreshes will update the cache only and apply on next SDK initialization.")
+            // Apply features only after sticky bucket docs are loaded so that the
+            // first evaluation after a payload update never sees features without docs.
+            // For the default sync StickyBucketService the completion fires immediately
+            // (zero behaviour change); for async services features are delayed until
+            // docs are ready, mirroring Kotlin's onPayloadReady pattern.
+            self.refreshStickyBucketService {
+                self.contextManager.updateEvalData { data in
+                    data.features = features
+                }
+                if stableSession {
+                    self.sessionEstablished = true
+                    logger.info("stableSession: initial features established. Session is now locked — subsequent refreshes will update the cache only and apply on next SDK initialization.")
+                }
             }
         }
     }
@@ -795,9 +800,12 @@ protocol GrowthBookProtocol: AnyObject {
         }
     }
 
-    @objc private func refreshStickyBucketService(_ data: FeaturesDataModel? = nil) {
+    @objc private func refreshStickyBucketService(_ data: FeaturesDataModel? = nil, completion: (() -> Void)? = nil) {
         let globalConfig = contextManager.getGlobalConfig()
-        guard let service = globalConfig.stickyBucketService else { return }
+        guard let service = globalConfig.stickyBucketService else {
+            completion?()
+            return
+        }
 
         let context = contextManager.getEvalContext()
 
@@ -812,6 +820,7 @@ protocol GrowthBookProtocol: AnyObject {
                 self.contextManager.updateEvalData { data in
                     data.stickyBucketAssignmentDocs = docs
                 }
+                completion?()
             }
         }
     }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -729,6 +729,7 @@ protocol GrowthBookProtocol: AnyObject {
         withLock {
             self.contextManager.updateEvalData { data in
                 data.attributes = JSON(attributes)
+                data.stickyBucketAssignmentDocs = nil
             }
             self.refreshStickyBucketService()
         }
@@ -742,6 +743,7 @@ protocol GrowthBookProtocol: AnyObject {
             let updatedAttributes = try evalData.attributes.merged(with: JSON(attributes))
             contextManager.updateEvalData { data in
                 data.attributes = updatedAttributes
+                data.stickyBucketAssignmentDocs = nil
             }
             refreshStickyBucketService()
         }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -378,7 +378,6 @@ protocol GrowthBookProtocol: AnyObject {
     private var contextManager: ContextManager
     private var featureVM: FeaturesViewModel!
     private var forcedFeatures: JSON = JSON()
-    private var attributeOverrides: JSON = JSON()
     private var savedGroupsValues: JSON?
     private var evalContext: EvalContext? = nil
     private var ttlSeconds: Int
@@ -729,6 +728,7 @@ protocol GrowthBookProtocol: AnyObject {
         withLock {
             self.contextManager.updateEvalData { data in
                 data.attributes = JSON(attributes)
+                data.attributeOverrides = nil
                 data.stickyBucketAssignmentDocs = nil
             }
             self.refreshStickyBucketService()
@@ -743,6 +743,7 @@ protocol GrowthBookProtocol: AnyObject {
             let updatedAttributes = try evalData.attributes.merged(with: JSON(attributes))
             contextManager.updateEvalData { data in
                 data.attributes = updatedAttributes
+                data.attributeOverrides = nil
                 data.stickyBucketAssignmentDocs = nil
             }
             refreshStickyBucketService()
@@ -750,14 +751,14 @@ protocol GrowthBookProtocol: AnyObject {
     }
 
     /// Sets custom attribute values that override the default ones
-    /// - Parameter overrides: Ant
+    /// - Parameter overrides: Any
     @objc public func setAttributeOverrides(overrides: Any) {
         withLock {
-            self.attributeOverrides = JSON(overrides)
-            let globalConfig = self.contextManager.getGlobalConfig()
-            if globalConfig.stickyBucketService != nil {
-                self.refreshStickyBucketService()
+            self.contextManager.updateEvalData { data in
+                data.attributeOverrides = JSON(overrides)
+                data.stickyBucketAssignmentDocs = nil
             }
+            self.refreshStickyBucketService()
             self.refreshForRemoteEval()
         }
     }
@@ -798,14 +799,12 @@ protocol GrowthBookProtocol: AnyObject {
         let globalConfig = contextManager.getGlobalConfig()
         guard let service = globalConfig.stickyBucketService else { return }
 
-        let evalData = contextManager.getEvaluationData()
         let context = contextManager.getEvalContext()
-
 
         Utils.refreshStickyBuckets(
             stickyBucketService: service,
             context: context,
-            attributes: evalData.attributes,
+            attributes: context.userContext.attributes,
             data: data
         ) { [weak self] docs in
             guard let self = self else { return }

--- a/Sources/CommonMain/Model/EvaluationData.swift
+++ b/Sources/CommonMain/Model/EvaluationData.swift
@@ -54,7 +54,11 @@ import Foundation
   public var url: String? = nil
 
   public var forcedFeatureValues: JSON? = nil
-  
+
+  /// Attribute values that override the base attributes during evaluation.
+  /// Merged on top of `attributes` when building an EvalContext.
+  public var attributeOverrides: JSON? = nil
+
   init(
     streamingHost: String?,
     attributes: JSON,
@@ -64,7 +68,8 @@ import Foundation
     features: Features = [:],
     savedGroups: JSON? = nil,
     url: String? = nil,
-    forcedFeatureValues: JSON? = nil) {
+    forcedFeatureValues: JSON? = nil,
+    attributeOverrides: JSON? = nil) {
       self.streamingHost = streamingHost
       self.attributes = attributes
       self.forcedVariations = forcedVariations
@@ -74,5 +79,6 @@ import Foundation
       self.savedGroups = savedGroups
       self.url = url
       self.forcedFeatureValues = forcedFeatureValues
+      self.attributeOverrides = attributeOverrides
     }
 }


### PR DESCRIPTION
  ## Summary
  
  - Clear sticky bucket assignment docs synchronously when `setAttributes` or
    `appendAttributes` is called, preventing stale docs from a previous user
    being used during the async refresh window
  - Wire `attributeOverrides` into evaluation — previously stored but never
    applied; now merged into `userContext.attributes` in `buildEvalContext()`
    so both experiment evaluation and sticky bucket lookup use the correct
    effective attributes
  - `setAttributes` and `appendAttributes` also clear `attributeOverrides` so
    the previous user's overrides don't bleed into the new user's session
  - Apply features to context only after sticky bucket docs are loaded, so the
    first evaluation after a payload update never sees features without docs

  ## Notes

  `getGBContext().attributes` and `getGBAttributes()` return base attributes
  without overrides applied — pre-existing behaviour, not changed in this PR.

  For the default `StickyBucketService` (local disk, synchronous) all fixes
  are zero-behaviour-change. Improvements are observable only with a custom
  async `StickyBucketServiceProtocol` implementation.