### PR TITLE
feat: caching improvements - TTL persistence, retry backoff, in-memory cache

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */; };
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
+		B1A0000000000000000C0003 /* InMemoryCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0004 /* InMemoryCacheTests.swift */; };
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
@@ -69,6 +70,7 @@
 		84CDE33E2812F454008B3E6F /* FeatureEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640327F845EB0072BFDC /* FeatureEvaluator.swift */; };
 		84CDE33F2812F454008B3E6F /* ConditionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640427F845EB0072BFDC /* ConditionEvaluator.swift */; };
 		84CDE3402812F454008B3E6F /* CachingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640627F845EB0072BFDC /* CachingManager.swift */; };
+		B1A0000000000000000C0001 /* InMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0002 /* InMemoryCache.swift */; };
 		84CDE3412812F454008B3E6F /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640827F845EB0072BFDC /* Feature.swift */; };
 		84CDE3422812F454008B3E6F /* Experiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640927F845EB0072BFDC /* Experiment.swift */; };
 		84CDE3432812F454008B3E6F /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433640A27F845EB0072BFDC /* Context.swift */; };
@@ -136,6 +138,7 @@
 		8433640327F845EB0072BFDC /* FeatureEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluator.swift; sourceTree = "<group>"; wrapsLines = 0; };
 		8433640427F845EB0072BFDC /* ConditionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluator.swift; sourceTree = "<group>"; };
 		8433640627F845EB0072BFDC /* CachingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManager.swift; sourceTree = "<group>"; };
+		B1A0000000000000000C0002 /* InMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryCache.swift; sourceTree = "<group>"; };
 		8433640827F845EB0072BFDC /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		8433640927F845EB0072BFDC /* Experiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Experiment.swift; sourceTree = "<group>"; };
 		8433640A27F845EB0072BFDC /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
@@ -148,6 +151,7 @@
 		84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKBuilderTests.swift; sourceTree = "<group>"; };
 		84391F1C27FD89F7003309DC /* MockNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkClient.swift; sourceTree = "<group>"; };
 		84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManagerTest.swift; sourceTree = "<group>"; };
+		B1A0000000000000000C0004 /* InMemoryCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryCacheTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
 		84622ACF280AC1D70099AED2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -288,6 +292,7 @@
 			isa = PBXGroup;
 			children = (
 				8433640627F845EB0072BFDC /* CachingManager.swift */,
+				B1A0000000000000000C0002 /* InMemoryCache.swift */,
 			);
 			path = Caching;
 			sourceTree = "<group>";
@@ -345,6 +350,7 @@
 				84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */,
 				84391F1C27FD89F7003309DC /* MockNetworkClient.swift */,
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
+				B1A0000000000000000C0004 /* InMemoryCacheTests.swift */,
 				848B8043294B5CB900B22168 /* CryptoTests.swift */,
 			);
 			path = GrowthBookTests;
@@ -535,6 +541,7 @@
 				843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
+				B1A0000000000000000C0003 /* InMemoryCacheTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -567,6 +574,7 @@
 				5D5EAD1D2EF1DEA70049F432 /* LruETagCache.swift in Sources */,
 				84CDE33F2812F454008B3E6F /* ConditionEvaluator.swift in Sources */,
 				84CDE3402812F454008B3E6F /* CachingManager.swift in Sources */,
+				B1A0000000000000000C0001 /* InMemoryCache.swift in Sources */,
 				846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */,
 				84CDE3412812F454008B3E6F /* Feature.swift in Sources */,
 				84AE3B1B2BE2466C006BA49B /* StickyAssignmentsDocument.swift in Sources */,

--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -253,6 +253,39 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
+    // MARK: - persistent TTL survives VM restart
+
+    func testCachedAtTimestampSkipsNetworkOnRestart() {
+        let apiKey = UUID().uuidString
+        let manager = CachingManager(apiKey: apiKey)
+        manager.clearCache()
+
+        // First VM: fetch successfully, writes cachedAt to disk
+        let firstClient = MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)
+        let firstCapture = Capture()
+        let firstVM = FeaturesViewModel(
+            delegate: firstCapture,
+            dataSource: FeaturesDataSource(dispatcher: firstClient),
+            cachingManager: manager,
+            ttlSeconds: 3600
+        )
+        firstVM.fetchFeatures(apiUrl: "https://example.com")
+        XCTAssertEqual(firstClient.callCount, 1)
+
+        // Second VM simulates cold restart with same cache — TTL still fresh, no network call
+        let secondClient = MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)
+        let secondCapture = Capture()
+        let secondVM = FeaturesViewModel(
+            delegate: secondCapture,
+            dataSource: FeaturesDataSource(dispatcher: secondClient),
+            cachingManager: manager,
+            ttlSeconds: 3600
+        )
+        secondVM.fetchFeatures(apiUrl: "https://example.com")
+        XCTAssertEqual(secondClient.callCount, 0, "Network should not be called when cache is fresh after restart")
+        XCTAssertGreaterThan(secondCapture.successCount, 0, "Cache should still serve features")
+    }
+
     // MARK: - fetchFeatures is not stale reports featuresAreUpToDate to the delegate
 
     func testFetchFeaturesReportIfNotStale() {

--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -341,6 +341,72 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         XCTAssertEqual(capture.lastError, .failedParsedData)
     }
 
+    // MARK: - retry classification
+
+    private func httpError(_ status: Int) -> NSError {
+        NSError(domain: Constants.httpErrorDomain, code: status)
+    }
+
+    private func urlError(_ code: Int) -> NSError {
+        NSError(domain: NSURLErrorDomain, code: code)
+    }
+
+    func testPermanentFailuresAreNotRetryable() {
+        for status in [400, 401, 403, 404, 410, 422, 501] {
+            XCTAssertFalse(FeaturesViewModel.isRetryable(httpError(status)),
+                           "HTTP \(status) cannot be fixed by asking again")
+        }
+        for code in [NSURLErrorCancelled, NSURLErrorBadURL, NSURLErrorUnsupportedURL,
+                     NSURLErrorUserAuthenticationRequired, NSURLErrorClientCertificateRejected] {
+            XCTAssertFalse(FeaturesViewModel.isRetryable(urlError(code)),
+                           "URLError \(code) is deliberate or impossible, not transient")
+        }
+    }
+
+    func testTransientFailuresAreRetryable() {
+        for status in [408, 429, 500, 502, 503, 504] {
+            XCTAssertTrue(FeaturesViewModel.isRetryable(httpError(status)),
+                          "HTTP \(status) means 'not now', so the backoff applies")
+        }
+        for code in [NSURLErrorTimedOut, NSURLErrorNotConnectedToInternet,
+                     NSURLErrorNetworkConnectionLost, NSURLErrorDNSLookupFailed,
+                     NSURLErrorCannotConnectToHost] {
+            XCTAssertTrue(FeaturesViewModel.isRetryable(urlError(code)),
+                          "URLError \(code) never reached an answer")
+        }
+    }
+
+    /// Unrecognised failures keep the previous behaviour rather than silently giving up.
+    func testUnknownErrorDomainStaysRetryable() {
+        XCTAssertTrue(FeaturesViewModel.isRetryable(NSError(domain: "EmptyResponse", code: -2)))
+    }
+
+    /// The point of the classification: an auth or configuration failure must reach the caller
+    /// straight away instead of after five backoff rounds.
+    func testPermanentFailureReportsImmediatelyWithoutRetrying() {
+        let capture = Capture()
+        let vm = makeVM(error: httpError(401), delegate: capture)
+
+        vm.fetchFeatures(apiUrl: "https://example.com")
+
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 1,
+                       "A permanent failure must complete the refresh on the first attempt")
+        XCTAssertEqual(capture.featuresUpdateIsCompleteArguments.first?.error?.code, .failedToFetchData)
+    }
+
+    /// The mirror case: a retryable failure must not report completion yet, because another attempt
+    /// is already scheduled. Asserting the absence of the callback keeps this free of wall-clock
+    /// waiting for the backoff itself.
+    func testRetryableFailureDefersCompletion() {
+        let capture = Capture()
+        let vm = makeVM(error: httpError(503), delegate: capture)
+
+        vm.fetchFeatures(apiUrl: "https://example.com")
+
+        XCTAssertEqual(capture.featuresUpdateIsCompleteCallCount, 0,
+                       "A retryable failure must wait for the scheduled attempt before reporting")
+    }
+
     // MARK: - fetchFeatures is not stale reports featuresAreUpToDate to the delegate
 
     func testFetchFeaturesReportIfNotStale() {

--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -244,6 +244,7 @@ class FeaturesViewModelExtendedTests: XCTestCase {
             cachingManager: manager,
             ttlSeconds: 0
         )
+        failVM.maxRetryAttempts = 0  // disable retry so failure is immediate in this test
         failVM.fetchFeatures(apiUrl: "https://example.com")
         // After network fail, falls back to cache → at least one success
         XCTAssertGreaterThan(capture.successCount, 0)

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -13,7 +13,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
     
     override func setUp() {
         super.setUp()
-        
+        cachingManager.clearCache()
         isSuccess = false
         isError = true
         hasFeatures = false
@@ -71,7 +71,8 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
             return
         }
         
-        if let features = try? JSONDecoder().decode(Features.self, from: featureData), features != [:] {
+        struct CacheEnvelope: Decodable { let features: Features }
+        if let envelope = try? JSONDecoder().decode(CacheEnvelope.self, from: featureData), !envelope.features.isEmpty {
             XCTAssertTrue(true)
         } else {
             XCTFail()
@@ -108,10 +109,8 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
             return
         }
         
-        let crypto: CryptoProtocol = Crypto()
-        if let encryptedString = String(data: featureData, encoding: .utf8), crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) != nil {
-            XCTAssertTrue(true)
-        } else if let _ = try? JSONDecoder().decode(Features.self, from: featureData) {
+        struct CacheEnvelope: Decodable { let features: Features }
+        if let envelope = try? JSONDecoder().decode(CacheEnvelope.self, from: featureData), !envelope.features.isEmpty {
             XCTAssertTrue(true)
         } else {
             XCTFail()
@@ -275,6 +274,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
             cachingManager: CachingManager(),
             ttlSeconds: 0
         )
+        viewModel.maxRetryAttempts = 0
         viewModel.manager.clearCache()
         viewModel.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
 
@@ -310,6 +310,7 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
             cachingManager: cachingManager,
             ttlSeconds: 0
         )
+        vm.maxRetryAttempts = 0
         vm.fetchFeatures(apiUrl: "https://cdn.growthbook.io/api/features/key")
 
         XCTAssertTrue(fetchFailedCalledRemote, "featuresFetchFailed(isRemote: true) must be reported for network error")

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -320,9 +320,10 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         isSuccess = false
         isError = true
         let viewModel = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: MockNetworkClient(successResponse: nil, error: .failedToLoadData)), cachingManager: cachingManager, ttlSeconds: ttlSeconds)
+        viewModel.maxRetryAttempts = 0  // disable retry so failure is immediate in this test
 
         viewModel.manager.clearCache()
-        
+
         viewModel.fetchFeatures(apiUrl: "")
 
         XCTAssertFalse(isSuccess)

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -300,8 +300,8 @@ class GrowthBookSDKTests: XCTestCase {
                 if error != nil { exp.fulfill() }
             }
         ).initializer()
+        sdk.featureVM.maxRetryAttempts = 0  // disable retry so failure is immediate in this test
 
-        _ = sdk
         wait(for: [exp], timeout: 2.0)
     }
 

--- a/GrowthBookTests/InMemoryCacheTests.swift
+++ b/GrowthBookTests/InMemoryCacheTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+@testable import GrowthBook
+
+class InMemoryCacheTests: XCTestCase {
+
+    private func data(_ value: String) -> Data {
+        Data(value.utf8)
+    }
+
+    func testSaveAndGet() {
+        let cache = InMemoryCache()
+        cache.saveContent(fileName: "FeatureCache", content: data("payload"))
+        XCTAssertEqual(cache.getContent(fileName: "FeatureCache"), data("payload"))
+    }
+
+    func testGetMissingReturnsNil() {
+        let cache = InMemoryCache()
+        XCTAssertNil(cache.getContent(fileName: "missing"))
+    }
+
+    func testOverwrite() {
+        let cache = InMemoryCache()
+        cache.saveContent(fileName: "key", content: data("first"))
+        cache.saveContent(fileName: "key", content: data("second"))
+        XCTAssertEqual(cache.getContent(fileName: "key"), data("second"))
+    }
+
+    func testTxtSuffixIsNormalized() {
+        let cache = InMemoryCache()
+        cache.saveContent(fileName: "Foo.txt", content: data("payload"))
+        // Mirrors CachingManager: ".txt" is stripped, so both names resolve to one entry.
+        XCTAssertEqual(cache.getContent(fileName: "Foo"), data("payload"))
+        XCTAssertEqual(cache.getContent(fileName: "Foo.txt"), data("payload"))
+    }
+
+    func testClearCacheRemovesCurrentKeyEntries() {
+        let cache = InMemoryCache()
+        cache.saveContent(fileName: "FeatureCache", content: data("payload"))
+        cache.clearCache()
+        XCTAssertNil(cache.getContent(fileName: "FeatureCache"))
+    }
+
+    func testCacheKeyNamespacesEntries() {
+        let cache = InMemoryCache()
+        cache.setCacheKey("key-a")
+        cache.saveContent(fileName: "FeatureCache", content: data("a"))
+
+        cache.setCacheKey("key-b")
+        // Different key => isolated namespace, no leakage from key-a.
+        XCTAssertNil(cache.getContent(fileName: "FeatureCache"))
+
+        cache.saveContent(fileName: "FeatureCache", content: data("b"))
+        XCTAssertEqual(cache.getContent(fileName: "FeatureCache"), data("b"))
+
+        cache.setCacheKey("key-a")
+        XCTAssertEqual(cache.getContent(fileName: "FeatureCache"), data("a"))
+    }
+
+    func testClearCacheOnlyClearsCurrentKey() {
+        let cache = InMemoryCache()
+        cache.setCacheKey("key-a")
+        cache.saveContent(fileName: "FeatureCache", content: data("a"))
+
+        cache.setCacheKey("key-b")
+        cache.saveContent(fileName: "FeatureCache", content: data("b"))
+        cache.clearCache()
+
+        // key-b cleared...
+        XCTAssertNil(cache.getContent(fileName: "FeatureCache"))
+        // ...but key-a is untouched.
+        cache.setCacheKey("key-a")
+        XCTAssertEqual(cache.getContent(fileName: "FeatureCache"), data("a"))
+    }
+
+    func testConformsToCachingLayer() {
+        // Drop-in replacement: usable anywhere a CachingLayer is expected.
+        let cache: CachingLayer = InMemoryCache()
+        cache.setSystemCacheDirectory(.caches) // no-op, must not crash
+        cache.setCustomCachePath("/tmp/ignored") // no-op, must not crash
+        cache.saveContent(fileName: "k", content: data("v"))
+        XCTAssertEqual(cache.getContent(fileName: "k"), data("v"))
+    }
+
+    func testConcurrentAccessIsSafe() {
+        let cache = InMemoryCache()
+        let iterations = 1_000
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            let name = "file-\(i % 16)"
+            cache.saveContent(fileName: name, content: data("\(i)"))
+            _ = cache.getContent(fileName: name)
+        }
+        // No assertion on values (interleaving is nondeterministic); the test
+        // passes if it completes without a crash under the thread sanitizer.
+        XCTAssertNotNil(cache.getContent(fileName: "file-0"))
+    }
+}

--- a/Sources/CommonMain/Caching/InMemoryCache.swift
+++ b/Sources/CommonMain/Caching/InMemoryCache.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// In-memory implementation of `CachingLayer`.
+///
+/// Stores cached content in a dictionary instead of on disk. Useful for unit
+/// tests and ephemeral sessions where persistence across app launches is not
+/// wanted. Entries are namespaced by cache key to mirror `CachingManager`, so
+/// switching keys isolates content, and `clearCache()` only removes entries for
+/// the current key. Access is synchronized for thread safety.
+///
+/// Filesystem-oriented configuration (`setSystemCacheDirectory` /
+/// `setCustomCachePath`) is intentionally a no-op — an in-memory cache has no
+/// directory.
+@objc public class InMemoryCache: NSObject, CachingLayer {
+
+    private var storage: [String: Data] = [:]
+    private var cacheKey: String = ""
+
+    private let lock = NSLock()
+
+    public override init() {
+        super.init()
+    }
+
+    public func setCacheKey(_ key: String) {
+        lock.withLock {
+            self.cacheKey = key
+        }
+    }
+
+    /// No-op: an in-memory cache has no filesystem directory.
+    @objc public func setSystemCacheDirectory(_ directory: CacheDirectory) {}
+
+    /// No-op: an in-memory cache has no filesystem path.
+    @objc public func setCustomCachePath(_ path: String) {}
+
+    /// Save content in memory
+    @objc public func saveContent(fileName: String, content: Data) {
+        lock.withLock {
+            storage[namespacedKey(for: fileName)] = content
+        }
+    }
+
+    /// Get content from memory
+    @objc public func getContent(fileName: String) -> Data? {
+        lock.withLock {
+            storage[namespacedKey(for: fileName)]
+        }
+    }
+
+    /// Remove all entries stored under the current cache key.
+    @objc public func clearCache() {
+        lock.withLock {
+            let prefix = "\(cacheKey)/"
+            storage = storage.filter { !$0.key.hasPrefix(prefix) }
+        }
+    }
+
+    /// Build the storage key, mirroring `CachingManager`: entries are namespaced
+    /// by cache key and the optional `.txt` suffix is stripped so that
+    /// `"Foo"` and `"Foo.txt"` resolve to the same entry.
+    private func namespacedKey(for fileName: String) -> String {
+        let file = fileName.replacingOccurrences(of: ".txt", with: "")
+        return "\(cacheKey)/\(file)"
+    }
+}

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -118,6 +118,11 @@ class FeaturesViewModel {
     }
     
     
+    private static let initialRetryDelay: TimeInterval = 1.0
+    private static let maxRetryDelay: TimeInterval = 60.0
+    // Internal so tests can set to 0 to skip retry delays
+    var maxRetryAttempts: Int = 5
+
     /// Fetch Features
     func fetchFeatures(apiUrl: String?, remoteEval: Bool = false, payload: RemoteEvalParams? = nil, forceRefresh: Bool = false) {
         // Check for cache data
@@ -144,18 +149,30 @@ class FeaturesViewModel {
                 }
             }
         } else {
-            dataSource.fetchFeatures(apiUrl: apiUrl) { result in
-                switch result {
-                case .success(let data):
-                    self.prepareFeaturesData(data: data)
-                case .failure(let error):
-                    if (error as NSError).code == 304 {
-                        self.refreshExpiresAt()
-                        let fetchCachedFeaturesError = self.fetchCachedFeatures(isRemote: true)
-                        self.delegate?.featuresUpdateIsComplete(error: fetchCachedFeaturesError, isRemote: true)
-                        return
+            doFetchFeatures(apiUrl: apiUrl, attempt: 0, delay: Self.initialRetryDelay)
+        }
+    }
+
+    private func doFetchFeatures(apiUrl: String, attempt: Int, delay: TimeInterval) {
+        dataSource.fetchFeatures(apiUrl: apiUrl) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let data):
+                self.prepareFeaturesData(data: data)
+            case .failure(let error):
+                if (error as NSError).code == 304 {
+                    self.refreshExpiresAt()
+                    let cachedError = self.fetchCachedFeatures(isRemote: true)
+                    self.delegate?.featuresUpdateIsComplete(error: cachedError, isRemote: true)
+                    return
+                }
+                if attempt < maxRetryAttempts {
+                    logger.info("GrowthBook: fetch failed, retrying in \(Int(delay))s (attempt \(attempt + 1)/\(maxRetryAttempts))")
+                    DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
+                        self?.doFetchFeatures(apiUrl: apiUrl, attempt: attempt + 1, delay: min(delay * 2, Self.maxRetryDelay))
                     }
-                    logger.info("Failed to get features from remote: \(error.localizedDescription)")
+                } else {
+                    logger.info("Failed to get features from remote after \(maxRetryAttempts) retries: \(error.localizedDescription)")
                     let sdkError: SDKError = .failedToFetchData(error)
                     self.delegate?.featuresFetchFailed(error: sdkError, isRemote: true)
                     self.fetchCachedFeatures(isRemote: true)

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -182,6 +182,46 @@ class FeaturesViewModel {
         }
     }
 
+    /// Whether repeating a failed fetch has any chance of succeeding.
+    ///
+    /// Retrying a permanent answer only delays the refresh callback — five attempts with the
+    /// backoff below take about half a minute — while telling the host nothing new. An expired key
+    /// or a wrong client key is not going to fix itself, so those fail immediately; congestion,
+    /// dropped connections and server-side hiccups are what the backoff exists for.
+    ///
+    /// Internal so tests can enumerate the classification without driving the network.
+    static func isRetryable(_ error: Error) -> Bool {
+        let error = error as NSError
+
+        switch error.domain {
+        case Constants.httpErrorDomain:
+            // 408 Request Timeout and 429 Too Many Requests explicitly invite a later attempt, and
+            // these 5xx mean "not now". Everything else in 4xx — 400, 401, 403, 404 — is a
+            // configuration or authentication problem that repeating cannot change.
+            return [408, 429, 500, 502, 503, 504].contains(error.code)
+
+        case NSURLErrorDomain:
+            // Transport failures never reached an answer, so they are retryable unless the request
+            // was impossible to make or was stopped on purpose.
+            switch error.code {
+            case NSURLErrorCancelled,
+                 NSURLErrorBadURL,
+                 NSURLErrorUnsupportedURL,
+                 NSURLErrorUserAuthenticationRequired,
+                 NSURLErrorClientCertificateRejected,
+                 NSURLErrorServerCertificateUntrusted,
+                 NSURLErrorAppTransportSecurityRequiresSecureConnection:
+                return false
+            default:
+                return true
+            }
+
+        default:
+            // Unknown failure shapes keep the previous behaviour rather than silently going quiet.
+            return true
+        }
+    }
+
     private func doFetchFeatures(apiUrl: String, attempt: Int, delay: TimeInterval) {
         dataSource.fetchFeatures(apiUrl: apiUrl) { [weak self] result in
             guard let self else { return }
@@ -195,13 +235,14 @@ class FeaturesViewModel {
                     self.delegate?.featuresUpdateIsComplete(error: cachedError, isRemote: true)
                     return
                 }
-                if attempt < maxRetryAttempts {
+                if attempt < maxRetryAttempts, Self.isRetryable(error) {
                     logger.info("GrowthBook: fetch failed, retrying in \(Int(delay))s (attempt \(attempt + 1)/\(maxRetryAttempts))")
                     DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
                         self?.doFetchFeatures(apiUrl: apiUrl, attempt: attempt + 1, delay: min(delay * 2, Self.maxRetryDelay))
                     }
                 } else {
-                    logger.info("Failed to get features from remote after \(maxRetryAttempts) retries: \(error.localizedDescription)")
+                    let cause = Self.isRetryable(error) ? "after \(maxRetryAttempts) retries" : "without retrying, the failure is permanent"
+                    logger.info("Failed to get features from remote \(cause): \(error.localizedDescription)")
                     let sdkError: SDKError = .failedToFetchData(error)
                     self.delegate?.featuresFetchFailed(error: sdkError, isRemote: true)
                     self.fetchCachedFeatures(isRemote: true)

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -35,15 +35,41 @@ class FeaturesViewModel {
     }
     
     
+    private struct CachedFeaturesEnvelope: Codable {
+        let features: Features
+        let cachedAt: TimeInterval
+    }
+
     private func isCacheExpired() -> Bool {
-        guard let expiresAt = expiresAt else {
-            return true
+        if expiresAt == nil,
+           let data = manager.getContent(fileName: Constants.featureCache),
+           let envelope = try? JSONDecoder().decode(CachedFeaturesEnvelope.self, from: data) {
+            expiresAt = envelope.cachedAt + Double(ttlSeconds)
         }
+        guard let expiresAt else { return true }
         return Date().timeIntervalSince1970 >= expiresAt
     }
-    
+
+    private func saveFeatures(_ features: Features) {
+        let now = Date().timeIntervalSince1970
+        expiresAt = now + Double(ttlSeconds)
+        let envelope = CachedFeaturesEnvelope(features: features, cachedAt: now)
+        if let data = try? JSONEncoder().encode(envelope) {
+            manager.saveContent(fileName: Constants.featureCache, content: data)
+        }
+    }
+
     private func refreshExpiresAt() {
-        expiresAt = Date().timeIntervalSince1970 + Double(ttlSeconds)
+        guard let data = manager.getContent(fileName: Constants.featureCache) else { return }
+        let features: Features
+        if let envelope = try? JSONDecoder().decode(CachedFeaturesEnvelope.self, from: data) {
+            features = envelope.features
+        } else if let plain = try? JSONDecoder().decode(Features.self, from: data) {
+            features = plain
+        } else {
+            return
+        }
+        saveFeatures(features)
     }
     
     func connectBackgroundSync(sseUrl: String) {
@@ -88,8 +114,10 @@ class FeaturesViewModel {
                     if logging { logger.error("Failed get features from cached encrypted features") }
                     return error
                 }
+            } else if let envelope = try? decoder.decode(CachedFeaturesEnvelope.self, from: data) {
+                delegate?.featuresFetchedSuccessfully(features: envelope.features, isRemote: isRemote)
             } else if let features = try? decoder.decode(Features.self, from: data) {
-                // Call Success Delegate with mention of data available but its not remote
+                // migration: old cache format without envelope
                 delegate?.featuresFetchedSuccessfully(features: features, isRemote: isRemote)
             } else {
                 let error = SDKError.failedParsedData
@@ -197,12 +225,7 @@ class FeaturesViewModel {
                 if let encryptionKey = encryptionKey, !encryptionKey.isEmpty {
                     let crypto: CryptoProtocol = Crypto()
                     if let features = crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) {
-                        if let featureData = try? JSONEncoder().encode(features) {
-                            manager.saveContent(fileName: Constants.featureCache, content: featureData)
-                            refreshExpiresAt()
-                        } else {
-                            logger.error("Failed encode features")
-                        }
+                        saveFeatures(features)
                         delegate?.featuresFetchedSuccessfully(features: features, isRemote: true)
                     } else {
                         let error: SDKError = .failedEncryptedFeatures
@@ -219,10 +242,7 @@ class FeaturesViewModel {
                     return
                 }
             } else if let features = jsonPetitions.features {
-                if let featureData = try? JSONEncoder().encode(features) {
-                    manager.saveContent(fileName: Constants.featureCache, content: featureData)
-                    refreshExpiresAt()
-                }
+                saveFeatures(features)
                 delegate?.featuresFetchedSuccessfully(features: features, isRemote: true)
             } else {
                 let error: SDKError = .failedMissingKey

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -119,14 +119,14 @@ class FeaturesViewModel {
     
     
     /// Fetch Features
-    func fetchFeatures(apiUrl: String?, remoteEval: Bool = false, payload: RemoteEvalParams? = nil) {
+    func fetchFeatures(apiUrl: String?, remoteEval: Bool = false, payload: RemoteEvalParams? = nil, forceRefresh: Bool = false) {
         // Check for cache data
         fetchCachedFeatures(logging: true)
         guard let apiUrl else {
             delegate?.featuresUpdateIsComplete(error: .invalidAPIURL, isRemote: false)
             return
         }
-        guard isCacheExpired() else {
+        guard isCacheExpired() || forceRefresh else {
             delegate?.featuresUpdateIsComplete(error: nil, isRemote: true)
             return
         }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -511,9 +511,9 @@ protocol GrowthBookProtocol: AnyObject {
         withLock {
             let globalConfig = contextManager.getGlobalConfig()
             if globalConfig.remoteEval {
-                refreshForRemoteEval()
+                refreshForRemoteEval(forceRefresh: true)
             } else {
-                featureVM.fetchFeatures(apiUrl: contextManager.getFeaturesURL())
+                featureVM.fetchFeatures(apiUrl: contextManager.getFeaturesURL(), forceRefresh: true)
             }
         }
     }
@@ -660,6 +660,10 @@ protocol GrowthBookProtocol: AnyObject {
 
     /// If remote eval is enabled, send needed data to backend to proceed remote evaluation
     @objc public func refreshForRemoteEval() {
+        refreshForRemoteEval(forceRefresh: false)
+    }
+
+    private func refreshForRemoteEval(forceRefresh: Bool) {
         withLock {
             let globalConfig = contextManager.getGlobalConfig()
             let evalData = contextManager.getEvaluationData()
@@ -668,7 +672,7 @@ protocol GrowthBookProtocol: AnyObject {
             let forcedFeaturesJson = JSON(forcedFeaturesArray ?? [])
 
             let payload = RemoteEvalParams(attributes: evalData.attributes, forcedFeatures: forcedFeaturesJson, forcedVariations: evalData.forcedVariations)
-            featureVM.fetchFeatures(apiUrl: contextManager.getRemoteEvalUrl(), remoteEval: globalConfig.remoteEval, payload: payload)
+            featureVM.fetchFeatures(apiUrl: contextManager.getRemoteEvalUrl(), remoteEval: globalConfig.remoteEval, payload: payload, forceRefresh: forceRefresh)
         }
     }
 

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -376,7 +376,7 @@ protocol GrowthBookProtocol: AnyObject {
     private var subscriptions: [ExperimentRunCallback] = []
     private var networkDispatcher: NetworkProtocol
     private var contextManager: ContextManager
-    private var featureVM: FeaturesViewModel!
+    var featureVM: FeaturesViewModel!
     private var forcedFeatures: JSON = JSON()
     private var attributeOverrides: JSON = JSON()
     private var savedGroupsValues: JSON?

--- a/Sources/CommonMain/Network/NetworkClient.swift
+++ b/Sources/CommonMain/Network/NetworkClient.swift
@@ -98,7 +98,7 @@ class CoreNetworkClient: NetworkProtocol {
                 
                 // Handle 304 Not Modified - data hasn't changed
                 if status == 304 {
-                    let notModifiedError = NSError(domain: "HTTPError", code: 304, userInfo: [
+                    let notModifiedError = NSError(domain: Constants.httpErrorDomain, code: 304, userInfo: [
                         NSLocalizedDescriptionKey: "Not Modified - Use cached data"
                     ])
                     errorResult(notModifiedError)
@@ -106,7 +106,7 @@ class CoreNetworkClient: NetworkProtocol {
                 }
                 
                 if status >= 400 {
-                    let httpError = NSError(domain: "HTTPError", code: httpResponse.statusCode, userInfo: [
+                    let httpError = NSError(domain: Constants.httpErrorDomain, code: httpResponse.statusCode, userInfo: [
                         NSLocalizedDescriptionKey: "HTTP Error: \(httpResponse.statusCode)"
                     ])
                     errorResult(httpError)

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -8,6 +8,10 @@ public enum Constants {
     public static let featureCache = "FeatureCache"
     
     public static let savedGroupsCache = "SavedGroupsCache"
+
+    /// Error domain the network layer uses when it turns an HTTP status into an `NSError`, so the
+    /// status can be read back from `NSError.code`.
+    static let httpErrorDomain = "HTTPError"
 }
 
 /// Type Alias for Feature in GrowthBook


### PR DESCRIPTION
  ## Summary
  - refreshCache() now always bypasses TTL and forces a network fetch
  - Feature fetch retries with exponential backoff on network failure (1s → 4s → 8s → 16s, max 5 attempts)
  - Cache timestamp persisted to disk so TTL survives app restarts — cold start skips network if cache is fresh
  - Add InMemoryCache: an optional in-memory CachingLayer for tests and ephemeral
    sessions. Purely additive — disk-based CachingManager remains the default.