### PR TITLE
fix: prevent spurious errors on empty SSE event payloads

### DIFF
--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -252,6 +252,94 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
+    // MARK: - persistent TTL survives VM restart
+
+    func testCachedAtTimestampSkipsNetworkOnRestart() {
+        let apiKey = UUID().uuidString
+        let manager = CachingManager(apiKey: apiKey)
+        manager.clearCache()
+
+        // First VM: fetch successfully, writes cachedAt to disk
+        let firstClient = MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)
+        let firstCapture = Capture()
+        let firstVM = FeaturesViewModel(
+            delegate: firstCapture,
+            dataSource: FeaturesDataSource(dispatcher: firstClient),
+            cachingManager: manager,
+            ttlSeconds: 3600
+        )
+        firstVM.fetchFeatures(apiUrl: "https://example.com")
+        XCTAssertEqual(firstClient.callCount, 1)
+
+        // Second VM simulates cold restart with same cache — TTL still fresh, no network call
+        let secondClient = MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)
+        let secondCapture = Capture()
+        let secondVM = FeaturesViewModel(
+            delegate: secondCapture,
+            dataSource: FeaturesDataSource(dispatcher: secondClient),
+            cachingManager: manager,
+            ttlSeconds: 3600
+        )
+        secondVM.fetchFeatures(apiUrl: "https://example.com")
+        XCTAssertEqual(secondClient.callCount, 0, "Network should not be called when cache is fresh after restart")
+        XCTAssertGreaterThan(secondCapture.successCount, 0, "Cache should still serve features")
+    }
+
+    // MARK: - SSE empty / heartbeat payload handling
+
+    /// Empty SSE data ("") must not reach prepareFeaturesData.
+    /// Regression: before the fix, `"".data(using: .utf8)` is non-nil so the guard
+    /// `guard let jsonData = data?.data(using: .utf8)` passed, triggering a spurious
+    /// featuresFetchFailed(error: .failedParsedData) call.
+    func testPrepareFeaturesDataEmptyPayloadTriggersError() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        vm.prepareFeaturesData(data: Data())
+        XCTAssertGreaterThan(capture.failCount, 0, "Empty Data should be treated as a parse error")
+        XCTAssertEqual(capture.lastError, .failedParsedData)
+    }
+
+    /// SSE comment lines (heartbeat / keepalive, e.g. ": heartbeat") must be filtered
+    /// before any listener is invoked — SSEEvent.init returns nil for them.
+    func testSSEEventHeartbeatCommentIsNil() {
+        let newlines = ["\r\n", "\n", "\r"]
+        XCTAssertNil(SSEEvent(eventString: ": heartbeat", newLineCharacters: newlines))
+        XCTAssertNil(SSEEvent(eventString: ":", newLineCharacters: newlines))
+        XCTAssertNil(SSEEvent(eventString: ": keepalive", newLineCharacters: newlines))
+    }
+
+    /// A well-formed SSE event with an empty data field should produce a non-nil SSEEvent
+    /// whose data property is the empty string — confirming the guard `!data.isEmpty` in
+    /// connectBackgroundSync is what prevents the empty payload from reaching prepareFeaturesData.
+    func testSSEEventEmptyDataFieldIsEmptyString() {
+        let newlines = ["\r\n", "\n", "\r"]
+        let event = SSEEvent(eventString: "event: features\ndata: ", newLineCharacters: newlines)
+        XCTAssertNotNil(event)
+        XCTAssertEqual(event?.data ?? "non-empty", "")
+    }
+
+    /// An SSE event with a valid JSON payload must be passed through to prepareFeaturesData
+    /// and result in a successful feature load.
+    func testSSEEventValidJsonPayloadProducesSuccess() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        let validJSON = """
+        {"status":200,"features":{"sse-flag":{"defaultValue":true}}}
+        """
+        vm.prepareFeaturesData(data: validJSON.data(using: .utf8)!)
+        XCTAssertEqual(capture.successCount, 1)
+        XCTAssertNotNil(capture.lastFeatures?["sse-flag"])
+    }
+
+    /// An SSE event with an invalid JSON payload must not crash and must fire featuresFetchFailed.
+    func testSSEEventInvalidJsonPayloadProducesError() {
+        let capture = Capture()
+        let vm = makeVM(delegate: capture)
+        vm.prepareFeaturesData(data: "not-json".data(using: .utf8)!)
+        XCTAssertGreaterThan(capture.failCount, 0)
+        XCTAssertEqual(capture.lastError, .failedParsedData)
+    }
+
     // MARK: - fetchFeatures is not stale reports featuresAreUpToDate to the delegate
 
     func testFetchFeaturesReportIfNotStale() {

--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -252,39 +252,6 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         XCTAssertTrue(capture.featuresUpdateIsCompleteArguments[0].isRemote)
     }
 
-    // MARK: - persistent TTL survives VM restart
-
-    func testCachedAtTimestampSkipsNetworkOnRestart() {
-        let apiKey = UUID().uuidString
-        let manager = CachingManager(apiKey: apiKey)
-        manager.clearCache()
-
-        // First VM: fetch successfully, writes cachedAt to disk
-        let firstClient = MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)
-        let firstCapture = Capture()
-        let firstVM = FeaturesViewModel(
-            delegate: firstCapture,
-            dataSource: FeaturesDataSource(dispatcher: firstClient),
-            cachingManager: manager,
-            ttlSeconds: 3600
-        )
-        firstVM.fetchFeatures(apiUrl: "https://example.com")
-        XCTAssertEqual(firstClient.callCount, 1)
-
-        // Second VM simulates cold restart with same cache — TTL still fresh, no network call
-        let secondClient = MockNetworkClient(successResponse: MockResponse().successResponse, error: nil)
-        let secondCapture = Capture()
-        let secondVM = FeaturesViewModel(
-            delegate: secondCapture,
-            dataSource: FeaturesDataSource(dispatcher: secondClient),
-            cachingManager: manager,
-            ttlSeconds: 3600
-        )
-        secondVM.fetchFeatures(apiUrl: "https://example.com")
-        XCTAssertEqual(secondClient.callCount, 0, "Network should not be called when cache is fresh after restart")
-        XCTAssertGreaterThan(secondCapture.successCount, 0, "Cache should still serve features")
-    }
-
     // MARK: - SSE empty / heartbeat payload handling
 
     /// Empty SSE data ("") must not reach prepareFeaturesData.

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -56,7 +56,8 @@ class FeaturesViewModel {
         sseHandler = streamingUpdate
         
         streamingUpdate.addEventListener(event: "features") { [weak self] id, event, data in
-            guard let jsonData = data?.data(using: .utf8) else { return }
+            guard let data = data, !data.isEmpty,
+                  let jsonData = data.data(using: .utf8) else { return }
             self?.prepareFeaturesData(data: jsonData)
         }
         streamingUpdate.connect()


### PR DESCRIPTION
## Problem
  When an SSE event arrived with an empty `data` field, `"".data(using: .utf8)`
  returned non-nil empty `Data`, bypassing the nil-guard and triggering a spurious
  `featuresFetchFailed(.failedParsedData)` delegate call.

  ## Changes
  - Added `!data.isEmpty` check in the SSE listener inside `connectBackgroundSync`
    so empty payloads are silently skipped before reaching `prepareFeaturesData`

  ## Tests
  Added 4 tests in `FeaturesViewModelExtendedTests`:
  - `testSSEEventHeartbeatCommentIsNil` — heartbeat/keepalive comments produce nil
  - `testSSEEventEmptyDataFieldIsEmptyString` — confirms empty data is `""` not `nil`
  - `testSSEEventValidJsonPayloadProducesSuccess` — valid JSON processes correctly
  - `testSSEEventInvalidJsonPayloadProducesError` — invalid JSON fires error without crash