### PR TITLE
fix: SSE reconnect exponential backoff and HTTP 200-only retry

### DIFF
--- a/GrowthBookTests/SSEHandlerReconnectTests.swift
+++ b/GrowthBookTests/SSEHandlerReconnectTests.swift
@@ -82,4 +82,90 @@ final class SSEHandlerReconnectTests: XCTestCase {
         XCTAssertFalse(handler.shouldReconnect(statusCode: 404))
         XCTAssertFalse(handler.shouldReconnect(statusCode: 500))
     }
+
+    // MARK: - Transport failures (no HTTP response)
+
+    private func transportError() -> NSError {
+        NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+    }
+
+    private func cancelledError() -> NSError {
+        NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil)
+    }
+
+    /// DNS failures, connection loss and timeouts complete without an `HTTPURLResponse`. They are
+    /// what the backoff exists for, so they must count as retryable.
+    func testTransportFailureWithoutStatusIsRetryable() {
+        XCTAssertTrue(handler.shouldReconnect(statusCode: nil))
+    }
+
+    func testTransportErrorSchedulesBoundedRetry() {
+        handler.connectionStatus = .connecting
+        let reported = expectation(description: "disconnect reported")
+        var reconnectFlag: Bool?
+        var forwardedError: NSError?
+        handler.onDissconnect { _, reconnect, error in
+            reconnectFlag = reconnect
+            forwardedError = error
+            reported.fulfill()
+        }
+
+        handler.handleStreamCompletion(statusCode: nil, error: transportError())
+
+        XCTAssertEqual(handler.retryCount, 1, "A transport failure must consume one retry, not stop streaming")
+        wait(for: [reported], timeout: 30.0)
+        XCTAssertEqual(reconnectFlag, true, "Callers must be told the stream will come back")
+        XCTAssertEqual(forwardedError?.code, NSURLErrorTimedOut, "The underlying error must still be surfaced")
+
+        handler.disconnect()  // keep the scheduled reconnect from reaching the network
+    }
+
+    /// The retry budget is shared with HTTP failures, so a permanently broken connection stops.
+    func testTransportErrorsStopAfterMaxRetries() {
+        handler.connectionStatus = .connecting
+
+        // The callback is installed up front: every completion queues its report on the main queue,
+        // and those reports only run once this test starts waiting.
+        let attempts = handler.maxRetryCount + 1
+        let reported = expectation(description: "every disconnect reported")
+        reported.expectedFulfillmentCount = attempts
+        var flags: [Bool?] = []
+        handler.onDissconnect { _, reconnect, _ in
+            flags.append(reconnect)
+            reported.fulfill()
+        }
+
+        for _ in 0..<attempts {
+            handler.handleStreamCompletion(statusCode: nil, error: transportError())
+        }
+        XCTAssertEqual(handler.retryCount, handler.maxRetryCount, "The retry limit must not be exceeded")
+
+        wait(for: [reported], timeout: 30.0)
+        XCTAssertEqual(flags.count, attempts)
+        XCTAssertEqual(flags.dropLast().compactMap { $0 }.filter { $0 }.count, handler.maxRetryCount,
+                       "Every attempt within the budget must promise a reconnect")
+        XCTAssertEqual(flags.last ?? nil, false, "Past the retry limit the stream must stay down")
+
+        handler.disconnect()
+    }
+
+    /// An explicitly requested disconnect must not be undone by the backoff.
+    func testExplicitDisconnectIsNotRetried() {
+        handler.connectionStatus = .connecting
+        handler.disconnect()
+
+        handler.handleStreamCompletion(statusCode: nil, error: cancelledError())
+
+        XCTAssertEqual(handler.retryCount, 0, "disconnect() must not schedule a reconnect")
+        XCTAssertEqual(handler.connectionStatus, .disconnected)
+    }
+
+    /// Cancellation from any other source is deliberate too, so it is not a transport failure.
+    func testCancelledTaskIsNotRetried() {
+        handler.connectionStatus = .connected
+
+        handler.handleStreamCompletion(statusCode: nil, error: cancelledError())
+
+        XCTAssertEqual(handler.retryCount, 0)
+    }
 }

--- a/GrowthBookTests/SSEHandlerReconnectTests.swift
+++ b/GrowthBookTests/SSEHandlerReconnectTests.swift
@@ -28,49 +28,41 @@ final class SSEHandlerReconnectTests: XCTestCase {
     // MARK: - Backoff delay calculation
 
     func testBackoffDelayAtRetry0Is1s() {
-        handler.retryCount = 0
-        XCTAssertEqual(handler.backoffDelay, 1_000)
+        XCTAssertEqual(handler.backoffDelay(for: 0), 1_000)
     }
 
     func testBackoffDelayDoublesEachRetry() {
         let expected = [1_000, 2_000, 4_000, 8_000, 16_000]
         for (i, ms) in expected.enumerated() {
-            handler.retryCount = i
-            XCTAssertEqual(handler.backoffDelay, ms, "retry \(i) should be \(ms)ms")
+            XCTAssertEqual(handler.backoffDelay(for: i), ms, "retry \(i) should be \(ms)ms")
         }
     }
 
     func testBackoffDelayCappedAt30s() {
-        handler.retryCount = 5   // 1000 * 2^5 = 32000 → capped at 30000
-        XCTAssertEqual(handler.backoffDelay, 30_000)
-
-        handler.retryCount = 10
-        XCTAssertEqual(handler.backoffDelay, 30_000)
+        XCTAssertEqual(handler.backoffDelay(for: 5), 30_000)  // 1000 * 2^5 = 32000 → capped
+        XCTAssertEqual(handler.backoffDelay(for: 10), 30_000)
     }
 
-    func testBackoffDelayRespectCustomRetryTime() {
+    func testBackoffDelayRespectsCustomRetryTime() {
         handler.retryTime = 2_000
-        handler.retryCount = 0
-        XCTAssertEqual(handler.backoffDelay, 2_000)
-
-        handler.retryCount = 1
-        XCTAssertEqual(handler.backoffDelay, 4_000)
-
-        handler.retryCount = 4   // 2000 * 2^4 = 32000 → capped at 30000
-        XCTAssertEqual(handler.backoffDelay, 30_000)
+        XCTAssertEqual(handler.backoffDelay(for: 0), 2_000)
+        XCTAssertEqual(handler.backoffDelay(for: 1), 4_000)
+        XCTAssertEqual(handler.backoffDelay(for: 4), 30_000)  // 2000 * 2^4 = 32000 → capped
     }
 
     // MARK: - disconnect() resets state
 
-    func testDisconnectResetsRetryCount() {
-        handler.retryCount = 7
-        handler.disconnect()
-        XCTAssertEqual(handler.retryCount, 0)
-    }
-
     func testDisconnectSetsStatusToDisconnected() {
         handler.disconnect()
         XCTAssertEqual(handler.connectionStatus, .disconnected)
+    }
+
+    func testDisconnectResetsRetryCountOnOperationQueue() {
+        // retryCount reset is dispatched to operationQueue to avoid data race;
+        // flush the queue before asserting.
+        handler.disconnect()
+        handler.operationQueue.waitUntilAllOperationsAreFinished()
+        XCTAssertEqual(handler.retryCount, 0)
     }
 
     // MARK: - shouldReconnect

--- a/GrowthBookTests/SSEHandlerReconnectTests.swift
+++ b/GrowthBookTests/SSEHandlerReconnectTests.swift
@@ -72,4 +72,22 @@ final class SSEHandlerReconnectTests: XCTestCase {
         handler.disconnect()
         XCTAssertEqual(handler.connectionStatus, .disconnected)
     }
+
+    // MARK: - shouldReconnect
+
+    func testReconnectsOnStatus200() {
+        XCTAssertTrue(handler.shouldReconnect(statusCode: 200))
+    }
+
+    func testDoesNotReconnectOnOther2xx() {
+        XCTAssertFalse(handler.shouldReconnect(statusCode: 201))
+        XCTAssertFalse(handler.shouldReconnect(statusCode: 204))
+        XCTAssertFalse(handler.shouldReconnect(statusCode: 299))
+    }
+
+    func testDoesNotReconnectOnClientOrServerErrors() {
+        XCTAssertFalse(handler.shouldReconnect(statusCode: 400))
+        XCTAssertFalse(handler.shouldReconnect(statusCode: 404))
+        XCTAssertFalse(handler.shouldReconnect(statusCode: 500))
+    }
 }

--- a/GrowthBookTests/SSEHandlerReconnectTests.swift
+++ b/GrowthBookTests/SSEHandlerReconnectTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import GrowthBook
+
+final class SSEHandlerReconnectTests: XCTestCase {
+
+    private var handler: SSEHandler!
+
+    override func setUp() {
+        super.setUp()
+        handler = SSEHandler(url: URL(string: "https://example.com/events")!)
+    }
+
+    // MARK: - Initial state
+
+    func testInitialRetryCountIsZero() {
+        XCTAssertEqual(handler.retryCount, 0)
+    }
+
+    func testDefaultRetryTimeIs1000ms() {
+        XCTAssertEqual(handler.retryTime, SSEHandler.DefaultRetryTime)
+        XCTAssertEqual(handler.retryTime, 1000)
+    }
+
+    func testMaxRetryCountIs10() {
+        XCTAssertEqual(handler.maxRetryCount, 10)
+    }
+
+    // MARK: - Backoff delay calculation
+
+    func testBackoffDelayAtRetry0Is1s() {
+        handler.retryCount = 0
+        XCTAssertEqual(handler.backoffDelay, 1_000)
+    }
+
+    func testBackoffDelayDoublesEachRetry() {
+        let expected = [1_000, 2_000, 4_000, 8_000, 16_000]
+        for (i, ms) in expected.enumerated() {
+            handler.retryCount = i
+            XCTAssertEqual(handler.backoffDelay, ms, "retry \(i) should be \(ms)ms")
+        }
+    }
+
+    func testBackoffDelayCappedAt30s() {
+        handler.retryCount = 5   // 1000 * 2^5 = 32000 → capped at 30000
+        XCTAssertEqual(handler.backoffDelay, 30_000)
+
+        handler.retryCount = 10
+        XCTAssertEqual(handler.backoffDelay, 30_000)
+    }
+
+    func testBackoffDelayRespectCustomRetryTime() {
+        handler.retryTime = 2_000
+        handler.retryCount = 0
+        XCTAssertEqual(handler.backoffDelay, 2_000)
+
+        handler.retryCount = 1
+        XCTAssertEqual(handler.backoffDelay, 4_000)
+
+        handler.retryCount = 4   // 2000 * 2^4 = 32000 → capped at 30000
+        XCTAssertEqual(handler.backoffDelay, 30_000)
+    }
+
+    // MARK: - disconnect() resets state
+
+    func testDisconnectResetsRetryCount() {
+        handler.retryCount = 7
+        handler.disconnect()
+        XCTAssertEqual(handler.retryCount, 0)
+    }
+
+    func testDisconnectSetsStatusToDisconnected() {
+        handler.disconnect()
+        XCTAssertEqual(handler.connectionStatus, .disconnected)
+    }
+}

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -61,7 +61,18 @@ class FeaturesViewModel {
         }
         streamingUpdate.connect()
         
-        streamingUpdate.onDissconnect { _, _, _ in }
+        // The handler owns reconnecting, so there is nothing to do while it still intends to come
+        // back. Once it gives up, streaming is over for this instance and nothing else reports it,
+        // which would otherwise leave features silently frozen — so log that much. A cancelled task
+        // is our own `disconnect()` above (or in deinit) and is not a failure.
+        streamingUpdate.onDissconnect { statusCode, willReconnect, error in
+            guard willReconnect != true else { return }
+            let cancelled = error?.domain == NSURLErrorDomain && error?.code == NSURLErrorCancelled
+            guard !cancelled else { return }
+
+            let reason = error?.localizedDescription ?? statusCode.map { "HTTP \($0)" } ?? "unknown reason"
+            logger.error("Streaming stopped and will not reconnect: \(reason)")
+        }
     }
     
     deinit {

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -61,11 +61,7 @@ class FeaturesViewModel {
         }
         streamingUpdate.connect()
         
-        streamingUpdate.onDissconnect { [weak streamingUpdate] _, shouldReconnect, _ in
-            if let shouldReconnect = shouldReconnect, shouldReconnect {
-                streamingUpdate?.connect()
-            }
-        }
+        streamingUpdate.onDissconnect { _, _, _ in }
     }
     
     deinit {

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -109,12 +109,24 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
                          task: URLSessionTask,
                          didCompleteWithError error: Error?) {
 
-        guard let responseStatusCode = (task.response as? HTTPURLResponse)?.statusCode else {
-            mainQueue.async { [weak self] in self?.onDisconnect?(nil, nil, error as NSError?) }
+        handleStreamCompletion(statusCode: (task.response as? HTTPURLResponse)?.statusCode,
+                               error: error as NSError?)
+    }
+
+    /// Decides whether a finished stream should be retried, and schedules it if so.
+    ///
+    /// Internal rather than private so tests can drive it: the delegate callback above carries a
+    /// `URLSessionTask`, which tests cannot construct.
+    func handleStreamCompletion(statusCode: Int?, error: NSError?) {
+        // A cancelled task means the stream was torn down deliberately — `disconnect()`, or the
+        // session being invalidated — so it must not come back on its own.
+        let wasCancelled = error?.domain == NSURLErrorDomain && error?.code == NSURLErrorCancelled
+        if connectionStatus == .disconnected || wasCancelled {
+            mainQueue.async { [weak self] in self?.onDisconnect?(statusCode, false, error) }
             return
         }
 
-        let reconnect = shouldReconnect(statusCode: responseStatusCode)
+        let reconnect = shouldReconnect(statusCode: statusCode)
 
         if reconnect && retryCount < maxRetryCount {
             let delay = backoffDelay
@@ -123,9 +135,9 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
                 guard let self, self.connectionStatus != .disconnected else { return }
                 self.connect(lastEventId: self.lastEventId)
             }
-            mainQueue.async { [weak self] in self?.onDisconnect?(responseStatusCode, true, nil) }
+            mainQueue.async { [weak self] in self?.onDisconnect?(statusCode, true, error) }
         } else {
-            mainQueue.async { [weak self] in self?.onDisconnect?(responseStatusCode, false, nil) }
+            mainQueue.async { [weak self] in self?.onDisconnect?(statusCode, false, error) }
         }
     }
 
@@ -186,5 +198,13 @@ extension SSEHandler {
     
     func shouldReconnect(statusCode: Int) -> Bool {
         return statusCode == 200
+    }
+
+    /// A stream that completed without an HTTP response never reached the server: DNS failure,
+    /// connection loss, timeout. Those are exactly the failures a bounded backoff exists for, so
+    /// they are retryable; once there *is* a response, only 200 is.
+    func shouldReconnect(statusCode: Int?) -> Bool {
+        guard let statusCode else { return true }
+        return shouldReconnect(statusCode: statusCode)
     }
 }

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -179,14 +179,7 @@ extension SSEHandler {
         }
     }
     
-    private func shouldReconnect(statusCode: Int) -> Bool {
-        switch statusCode {
-        case 200:
-            return true
-        case _ where statusCode > 200 && statusCode < 300:
-            return true
-        default:
-            return false
-        }
+    func shouldReconnect(statusCode: Int) -> Bool {
+        return statusCode == 200
     }
 }

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -22,6 +22,14 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
     private var mainQueue = DispatchQueue.main
     private var urlSession: URLSession?
 
+    var retryCount = 0
+    let maxRetryCount = 10
+    let maxRetryDelayMs = 30_000
+
+    var backoffDelay: Int {
+        min(retryTime * (1 << retryCount), maxRetryDelayMs)
+    }
+
     public init(
         url: URL,
         headers: [String: String] = [:]
@@ -47,6 +55,7 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
 
     public func disconnect() {
         connectionStatus = .disconnected
+        retryCount = 0
         urlSession?.invalidateAndCancel()
     }
 
@@ -87,6 +96,7 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
 
         completionHandler(URLSession.ResponseDisposition.allow)
         connectionStatus = .connected
+        retryCount = 0
         mainQueue.async { [weak self] in self?.onConnect?() }
     }
 
@@ -100,7 +110,18 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
         }
 
         let reconnect = shouldReconnect(statusCode: responseStatusCode)
-        mainQueue.async { [weak self] in self?.onDisconnect?(responseStatusCode, reconnect, nil) }
+
+        if reconnect && retryCount < maxRetryCount {
+            let delay = backoffDelay
+            retryCount += 1
+            mainQueue.asyncAfter(deadline: .now() + .milliseconds(delay)) { [weak self] in
+                guard let self, self.connectionStatus != .disconnected else { return }
+                self.connect(lastEventId: self.lastEventId)
+            }
+            mainQueue.async { [weak self] in self?.onDisconnect?(responseStatusCode, true, nil) }
+        } else {
+            mainQueue.async { [weak self] in self?.onDisconnect?(responseStatusCode, false, nil) }
+        }
     }
 
     open func urlSession(_ session: URLSession,

--- a/Sources/CommonMain/Network/SSEHandler.swift
+++ b/Sources/CommonMain/Network/SSEHandler.swift
@@ -18,17 +18,20 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
     private var onDisconnect: ((Int?, Bool?, NSError?) -> Void)?
     private var eventListeners: [String: (_ id: String?, _ event: String?, _ data: String?) -> Void] = [:]
     private var eventHandler: EventHandler?
-    private var operationQueue: OperationQueue
+    var operationQueue: OperationQueue
     private var mainQueue = DispatchQueue.main
     private var urlSession: URLSession?
 
-    var retryCount = 0
+    private(set) var retryCount = 0
     let maxRetryCount = 10
     let maxRetryDelayMs = 30_000
 
-    var backoffDelay: Int {
-        min(retryTime * (1 << retryCount), maxRetryDelayMs)
+    // Internal for testing: accepts an explicit count so tests don't need to mutate retryCount.
+    func backoffDelay(for count: Int) -> Int {
+        min(retryTime * Int(pow(2, Double(count))), maxRetryDelayMs)
     }
+
+    var backoffDelay: Int { backoffDelay(for: retryCount) }
 
     public init(
         url: URL,
@@ -55,8 +58,10 @@ class SSEHandler: NSObject, URLSessionDataDelegate {
 
     public func disconnect() {
         connectionStatus = .disconnected
-        retryCount = 0
         urlSession?.invalidateAndCancel()
+        // Reset on operationQueue to avoid a data race with delegate methods
+        // that also mutate retryCount on that queue.
+        operationQueue.addOperation { [weak self] in self?.retryCount = 0 }
     }
 
     public func onConnect(onConnect: @escaping (() -> ())) {


### PR DESCRIPTION
  ## Summary
  - Added exponential backoff (1s→30s) and 10-retry limit to SSE reconnect —
    previously the client reconnected immediately in a tight loop
  - SSEHandler now manages reconnect internally; FeaturesViewModel no longer
    calls connect() manually on disconnect
  - shouldReconnect now returns true only for HTTP 200 (was any 2xx)