### PR TITLE
fix: $notRegex/$notRegexi report true for incomparable patterns

### DIFF
--- a/GrowthBookTests/ConditionEvaluatorTests.swift
+++ b/GrowthBookTests/ConditionEvaluatorTests.swift
@@ -308,6 +308,25 @@ class ConditionEvaluatorTests: XCTestCase {
         XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$notRegexi", attributeValue: JSON("Hello"), conditionValue: JSON("hello")))
     }
 
+    // An invalid pattern can't be matched, so $regex/$regexi report "no match" (false)
+    // while their negations $notRegex/$notRegexi report "not matching" (true) —
+    // matching the corrected behavior in the JS/Go/Rust/Python SDKs.
+    func testRegexOperatorReturnsFalseForInvalidPattern() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$regex", attributeValue: JSON("hello"), conditionValue: JSON("[")))
+    }
+
+    func testRegexiOperatorReturnsFalseForInvalidPattern() {
+        XCTAssertFalse(eval.isEvalOperatorCondition(operatorKey: "$regexi", attributeValue: JSON("hello"), conditionValue: JSON("[")))
+    }
+
+    func testNotRegexReturnsTrueForInvalidPattern() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$notRegex", attributeValue: JSON("hello"), conditionValue: JSON("[")))
+    }
+
+    func testNotRegexiReturnsTrueForInvalidPattern() {
+        XCTAssertTrue(eval.isEvalOperatorCondition(operatorKey: "$notRegexi", attributeValue: JSON("hello"), conditionValue: JSON("[")))
+    }
+
     // MARK: - Version operators
 
     func testVeqOperator() {

--- a/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
@@ -526,7 +526,9 @@ class ConditionEvaluator {
             
             return negate ? !isMatch : isMatch
         } catch {
-            return false
+            // An invalid/incomparable pattern can't match, so the negated
+            // operator ($notRegex/$notRegexi) should report "not matching" as true.
+            return negate
         }
     }
 


### PR DESCRIPTION
  ## Summary
On an invalid or incomparable pattern, $notRegex/$notRegexi returned false,
  where "did not match" should be true.

  The operators, the `negate` parameter and the existing test cases are left in
  place — the removal that was originally part of this PR has been dropped.