### PR TITLE
feat: typed & convenience feature-value accessors

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */; };
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
+		B1A0000000000000000C0005 /* TypedFeatureValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */; };
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
@@ -148,6 +149,7 @@
 		84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKBuilderTests.swift; sourceTree = "<group>"; };
 		84391F1C27FD89F7003309DC /* MockNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkClient.swift; sourceTree = "<group>"; };
 		84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManagerTest.swift; sourceTree = "<group>"; };
+		B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedFeatureValueTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
 		84622ACF280AC1D70099AED2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 				84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */,
 				84391F1C27FD89F7003309DC /* MockNetworkClient.swift */,
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
+				B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */,
 				848B8043294B5CB900B22168 /* CryptoTests.swift */,
 			);
 			path = GrowthBookTests;
@@ -535,6 +538,7 @@
 				843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
+				B1A0000000000000000C0005 /* TypedFeatureValueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
 		B1A0000000000000000C0005 /* TypedFeatureValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */; };
+		B1A0000000000000000C0007 /* UtilityMethodsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0008 /* UtilityMethodsTests.swift */; };
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
@@ -150,6 +151,7 @@
 		84391F1C27FD89F7003309DC /* MockNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkClient.swift; sourceTree = "<group>"; };
 		84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManagerTest.swift; sourceTree = "<group>"; };
 		B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedFeatureValueTests.swift; sourceTree = "<group>"; };
+		B1A0000000000000000C0008 /* UtilityMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityMethodsTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
 		84622ACF280AC1D70099AED2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -348,6 +350,7 @@
 				84391F1C27FD89F7003309DC /* MockNetworkClient.swift */,
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
 				B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */,
+				B1A0000000000000000C0008 /* UtilityMethodsTests.swift */,
 				848B8043294B5CB900B22168 /* CryptoTests.swift */,
 			);
 			path = GrowthBookTests;
@@ -539,6 +542,7 @@
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
 				B1A0000000000000000C0005 /* TypedFeatureValueTests.swift in Sources */,
+				B1A0000000000000000C0007 /* UtilityMethodsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GrowthBookTests/TypedFeatureValueTests.swift
+++ b/GrowthBookTests/TypedFeatureValueTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+@testable import GrowthBook
+
+class TypedFeatureValueTests: XCTestCase {
+
+    private struct PaymentConfig: Decodable, Equatable {
+        let provider: String
+        let retries: Int
+    }
+
+    /// Builds an offline SDK from a preloaded features payload (no network).
+    private func makeSDK(clientKey: String = "typed-value-test") -> GrowthBookSDK {
+        let payload = """
+        {
+          "features": {
+            "int-flag":    {"defaultValue": 42},
+            "string-flag": {"defaultValue": "hello"},
+            "bool-flag":   {"defaultValue": true},
+            "double-flag": {"defaultValue": 3.5},
+            "object-flag": {"defaultValue": {"provider": "stripe", "retries": 3}},
+            "array-flag":  {"defaultValue": ["a", "b", "c"]}
+          }
+        }
+        """.data(using: .utf8)!
+
+        return GrowthBookBuilder(
+            apiHost: "https://example.com",
+            clientKey: clientKey,
+            attributes: [:],
+            features: payload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+    }
+
+    // MARK: - Primitive overloads
+
+    func testInt() {
+        XCTAssertEqual(makeSDK().getFeatureValue(feature: "int-flag", as: Int.self, default: 0), 42)
+    }
+
+    func testString() {
+        XCTAssertEqual(makeSDK().getFeatureValue(feature: "string-flag", as: String.self, default: ""), "hello")
+    }
+
+    func testBool() {
+        XCTAssertTrue(makeSDK().getFeatureValue(feature: "bool-flag", as: Bool.self, default: false))
+    }
+
+    func testDouble() {
+        XCTAssertEqual(makeSDK().getFeatureValue(feature: "double-flag", as: Double.self, default: 0), 3.5)
+    }
+
+    // MARK: - Generic Decodable overload
+
+    func testDecodableObject() {
+        let cfg = makeSDK().getFeatureValue(
+            feature: "object-flag",
+            as: PaymentConfig.self,
+            default: PaymentConfig(provider: "none", retries: 0)
+        )
+        XCTAssertEqual(cfg, PaymentConfig(provider: "stripe", retries: 3))
+    }
+
+    func testDecodableArray() {
+        let arr = makeSDK().getFeatureValue(feature: "array-flag", as: [String].self, default: [])
+        XCTAssertEqual(arr, ["a", "b", "c"])
+    }
+
+    // MARK: - Fallbacks
+
+    func testMissingFeatureReturnsDefault() {
+        XCTAssertEqual(makeSDK().getFeatureValue(feature: "nope", as: Int.self, default: 99), 99)
+    }
+
+    func testTypeMismatchReturnsDefault() {
+        // "string-flag" holds a String; asking for Int must fall back to the default.
+        XCTAssertEqual(makeSDK().getFeatureValue(feature: "string-flag", as: Int.self, default: -1), -1)
+    }
+
+    func testDecodableMismatchReturnsDefault() {
+        // "int-flag" is a scalar; decoding into a struct must fall back to the default.
+        let fallback = PaymentConfig(provider: "fallback", retries: -1)
+        let cfg = makeSDK().getFeatureValue(feature: "int-flag", as: PaymentConfig.self, default: fallback)
+        XCTAssertEqual(cfg, fallback)
+    }
+
+    // MARK: - Backward compatibility
+
+    func testLegacyJSONOverloadStillWorks() {
+        // The original JSON-returning API must remain unchanged.
+        let value = makeSDK().getFeatureValue(feature: "int-flag", default: JSON(0))
+        XCTAssertEqual(value.int, 42)
+    }
+}

--- a/GrowthBookTests/UtilityMethodsTests.swift
+++ b/GrowthBookTests/UtilityMethodsTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import GrowthBook
+
+class UtilityMethodsTests: XCTestCase {
+
+    private func makeSDK(clientKey: String = "utility-methods-test") -> GrowthBookSDK {
+        let payload = """
+        {
+          "features": {
+            "enabled-flag":  {"defaultValue": true},
+            "disabled-flag": {"defaultValue": false},
+            "int-flag":      {"defaultValue": 7}
+          }
+        }
+        """.data(using: .utf8)!
+
+        return GrowthBookBuilder(
+            apiHost: "https://example.com",
+            clientKey: clientKey,
+            attributes: [:],
+            features: payload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+    }
+
+    // MARK: - isOff
+
+    func testIsOffForDisabledFeature() {
+        let sdk = makeSDK()
+        XCTAssertTrue(sdk.isOff(feature: "disabled-flag"))
+        XCTAssertFalse(sdk.isOn(feature: "disabled-flag"))
+    }
+
+    func testIsOffForEnabledFeature() {
+        let sdk = makeSDK()
+        XCTAssertFalse(sdk.isOff(feature: "enabled-flag"))
+        XCTAssertTrue(sdk.isOn(feature: "enabled-flag"))
+    }
+
+    func testIsOffMirrorsIsOn() {
+        let sdk = makeSDK()
+        for key in ["enabled-flag", "disabled-flag", "int-flag"] {
+            XCTAssertEqual(sdk.isOff(feature: key), !sdk.isOn(feature: key), "isOff must be the negation of isOn for \(key)")
+        }
+    }
+
+    // MARK: - getAllFeatureResults
+
+    func testGetAllFeatureResultsCount() {
+        let results = makeSDK().getAllFeatureResults()
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(Set(results.keys), ["enabled-flag", "disabled-flag", "int-flag"])
+    }
+
+    func testGetAllFeatureResultsValues() {
+        let results = makeSDK().getAllFeatureResults()
+        XCTAssertEqual(results["enabled-flag"]?.isOn, true)
+        XCTAssertEqual(results["disabled-flag"]?.isOff, true)
+        XCTAssertEqual(results["int-flag"]?.value?.int, 7)
+    }
+
+    func testGetAllFeatureResultsMatchesEvalFeature() {
+        let sdk = makeSDK()
+        let all = sdk.getAllFeatureResults()
+        // Each aggregated result must match an individual evalFeature call.
+        for key in all.keys {
+            XCTAssertEqual(all[key]?.value, sdk.evalFeature(id: key).value)
+            XCTAssertEqual(all[key]?.isOn, sdk.evalFeature(id: key).isOn)
+        }
+    }
+}

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -733,6 +733,27 @@ protocol GrowthBookProtocol: AnyObject {
         withLock { _evalFeature(id: id).isOn }
     }
 
+    /// The isOff method takes a single string argument, which is the unique identifier for the feature and returns whether the feature is off.
+    /// - Parameter id: String
+    /// - Returns: Bool
+    @objc public func isOff(feature id: String) -> Bool {
+        withLock { _evalFeature(id: id).isOff }
+    }
+
+    /// Evaluate every known feature and return their results keyed by feature id.
+    /// - Returns: a dictionary of feature id to its `FeatureResult`
+    @objc public func getAllFeatureResults() -> [String: FeatureResult] {
+        withLock {
+            let features = contextManager.getEvaluationData().features
+            var results: [String: FeatureResult] = [:]
+            results.reserveCapacity(features.count)
+            for key in features.keys {
+                results[key] = _evalFeature(id: key)
+            }
+            return results
+        }
+    }
+
     /// The run method takes an Experiment object and returns an experiment result
     /// - Parameter experiment: Experiment
     /// - Returns: ExperimentResult

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -585,6 +585,46 @@ protocol GrowthBookProtocol: AnyObject {
         withLock { _evalFeature(id: id).value ?? defaultValue }
     }
 
+    /// Get the value of a feature decoded into a `Decodable` type, with a fallback.
+    ///
+    /// Use this for structured values (objects and arrays). For primitive scalars
+    /// (`Int`/`String`/`Bool`/`Double`) the dedicated overloads below are preferred —
+    /// they read the value directly and avoid JSON fragment decoding edge cases.
+    /// - Parameters:
+    ///   - id: feature key
+    ///   - type: the type to decode into
+    ///   - defaultValue: returned if the feature is missing or cannot be decoded as `T`
+    /// - Returns: the decoded value, or `defaultValue`
+    public func getFeatureValue<T: Decodable>(feature id: String, as type: T.Type, default defaultValue: T) -> T {
+        withLock {
+            guard let value = _evalFeature(id: id).value,
+                  let data = try? value.rawData(),
+                  let decoded = try? JSONDecoder().decode(T.self, from: data)
+            else { return defaultValue }
+            return decoded
+        }
+    }
+
+    /// Get an `Int` feature value, with a fallback.
+    public func getFeatureValue(feature id: String, as type: Int.Type, default defaultValue: Int) -> Int {
+        withLock { _evalFeature(id: id).value?.int ?? defaultValue }
+    }
+
+    /// Get a `String` feature value, with a fallback.
+    public func getFeatureValue(feature id: String, as type: String.Type, default defaultValue: String) -> String {
+        withLock { _evalFeature(id: id).value?.string ?? defaultValue }
+    }
+
+    /// Get a `Bool` feature value, with a fallback.
+    public func getFeatureValue(feature id: String, as type: Bool.Type, default defaultValue: Bool) -> Bool {
+        withLock { _evalFeature(id: id).value?.bool ?? defaultValue }
+    }
+
+    /// Get a `Double` feature value, with a fallback.
+    public func getFeatureValue(feature id: String, as type: Double.Type, default defaultValue: Double) -> Double {
+        withLock { _evalFeature(id: id).value?.double ?? defaultValue }
+    }
+
     @objc public func featuresFetchedSuccessfully(features: [String: Feature], isRemote: Bool) {
         withLock {
             let stableSession = contextManager.getGlobalConfig().stableSession


### PR DESCRIPTION
 ## Summary
  Two small, purely additive API conveniences on top of existing feature
  evaluation. No existing API changes — all current methods behave as before.

  ### 1. Typed getFeatureValue(as:default:)
  The existing `getFeatureValue(feature:default:)` returns raw `JSON`, forcing
  callers to unwrap values by hand. Added overloads that return the value
  already typed:

  - Generic `Decodable` overload for structs/arrays (decoded via `JSONDecoder`)
  - `Int` / `String` / `Bool` / `Double` overloads (read directly from `JSON`)

        let cfg     = sdk.getFeatureValue(feature: "payment", as: PaymentConfig.self, default: .fallback)
        let timeout = sdk.getFeatureValue(feature: "api-timeout", as: Int.self, default: 30)

  All new overloads use an `as:` label on purpose: `JSON` is
  `ExpressibleBy*Literal`, so a plain `default: Int` overload would change
  overload resolution at existing call sites (e.g. `default: 30`). The `as:`
  label keeps the original `default: JSON` API untouched.

  ### 2. isOff and getAllFeatureResults
  - `isOff(feature:)` — negation of `isOn`, reads more naturally than `!isOn(...)`
  - `getAllFeatureResults()` — evaluates every known feature in one call,
    returning `[String: FeatureResult]` (handy for debugging / diagnostics)

        if sdk.isOff(feature: "legacy-flow") { ... }
        let all = sdk.getAllFeatureResults()

  ## Tests
  - `TypedFeatureValueTests` — primitives, Decodable object/array, missing &
    type-mismatch fallbacks, and a backward-compat check on the legacy JSON API
  - `UtilityMethodsTests` — isOff vs isOn, getAllFeatureResults count/values/parity