### PR TITLE
feat: add Combine publishers (features + experiments) for reactive updates

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */; };
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
+		CADE7A0000000000000000F1 /* ExperimentsPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE7A0000000000000000E1 /* ExperimentsPublisherTests.swift */; };
 		B1A0000000000000000C0009 /* FeaturesPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C000A /* FeaturesPublisherTests.swift */; };
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
@@ -149,6 +150,7 @@
 		84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKBuilderTests.swift; sourceTree = "<group>"; };
 		84391F1C27FD89F7003309DC /* MockNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkClient.swift; sourceTree = "<group>"; };
 		84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManagerTest.swift; sourceTree = "<group>"; };
+		CADE7A0000000000000000E1 /* ExperimentsPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentsPublisherTests.swift; sourceTree = "<group>"; };
 		B1A0000000000000000C000A /* FeaturesPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesPublisherTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 				84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */,
 				84391F1C27FD89F7003309DC /* MockNetworkClient.swift */,
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
+				CADE7A0000000000000000E1 /* ExperimentsPublisherTests.swift */,
 				B1A0000000000000000C000A /* FeaturesPublisherTests.swift */,
 				848B8043294B5CB900B22168 /* CryptoTests.swift */,
 			);
@@ -538,6 +541,7 @@
 				843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
+				CADE7A0000000000000000F1 /* ExperimentsPublisherTests.swift in Sources */,
 				B1A0000000000000000C0009 /* FeaturesPublisherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		849114CD280DA73100C0B9A5 /* GrowthBookSDKBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */; };
 		849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1C27FD89F7003309DC /* MockNetworkClient.swift */; };
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
+		B1A0000000000000000C0009 /* FeaturesPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C000A /* FeaturesPublisherTests.swift */; };
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
@@ -148,6 +149,7 @@
 		84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthBookSDKBuilderTests.swift; sourceTree = "<group>"; };
 		84391F1C27FD89F7003309DC /* MockNetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkClient.swift; sourceTree = "<group>"; };
 		84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManagerTest.swift; sourceTree = "<group>"; };
+		B1A0000000000000000C000A /* FeaturesPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesPublisherTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
 		84622ACF280AC1D70099AED2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 				84391F1A27FD810D003309DC /* GrowthBookSDKBuilderTests.swift */,
 				84391F1C27FD89F7003309DC /* MockNetworkClient.swift */,
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
+				B1A0000000000000000C000A /* FeaturesPublisherTests.swift */,
 				848B8043294B5CB900B22168 /* CryptoTests.swift */,
 			);
 			path = GrowthBookTests;
@@ -535,6 +538,7 @@
 				843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */,
 				849114CE280DA73100C0B9A5 /* MockNetworkClient.swift in Sources */,
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
+				B1A0000000000000000C0009 /* FeaturesPublisherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GrowthBookTests/ExperimentsPublisherTests.swift
+++ b/GrowthBookTests/ExperimentsPublisherTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import Combine
+
+@testable import GrowthBook
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+class ExperimentsPublisherTests: XCTestCase {
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    /// Offline SDK preloaded with a single feature so no network is needed.
+    private func makeSDK(clientKey: String = "experiments-publisher-test") -> GrowthBookSDK {
+        let payload = """
+        {"features": {"alpha": {"defaultValue": 1}}}
+        """.data(using: .utf8)!
+
+        return GrowthBookBuilder(
+            apiHost: "https://example.com",
+            clientKey: clientKey,
+            attributes: [:],
+            features: payload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+    }
+
+    private func experiment(_ key: String) -> Experiment {
+        Experiment(key: key, variations: [JSON("control"), JSON("variant")])
+    }
+
+    func testEmitsOnRun() {
+        let sdk = makeSDK()
+        var received: [ExperimentRun] = []
+        sdk.experimentsPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        let result = sdk.run(experiment: experiment("exp-1"))
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first?.experiment.key, "exp-1")
+        XCTAssertEqual(received.first?.result.variationId, result.variationId)
+    }
+
+    func testNoReplayForNewSubscriber() {
+        let sdk = makeSDK()
+        var received: [ExperimentRun] = []
+        // PassthroughSubject: subscribing without a prior run yields nothing.
+        sdk.experimentsPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        XCTAssertEqual(received.count, 0)
+    }
+
+    func testLateSubscriberMissesEarlierRuns() {
+        let sdk = makeSDK()
+
+        // Run before subscribing — must not be replayed.
+        _ = sdk.run(experiment: experiment("early"))
+
+        var received: [ExperimentRun] = []
+        sdk.experimentsPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        _ = sdk.run(experiment: experiment("late"))
+
+        XCTAssertEqual(received.map { $0.experiment.key }, ["late"])
+    }
+
+    func testMultipleSubscribersAllReceiveRun() {
+        let sdk = makeSDK()
+        var a: [ExperimentRun] = []
+        var b: [ExperimentRun] = []
+        sdk.experimentsPublisher.sink { a.append($0) }.store(in: &cancellables)
+        sdk.experimentsPublisher.sink { b.append($0) }.store(in: &cancellables)
+
+        _ = sdk.run(experiment: experiment("shared"))
+
+        XCTAssertEqual(a.map { $0.experiment.key }, ["shared"])
+        XCTAssertEqual(b.map { $0.experiment.key }, ["shared"])
+    }
+
+    func testExistingSubscribeCallbackStillFires() {
+        let sdk = makeSDK()
+        var callbackKeys: [String] = []
+        sdk.subscribe { exp, _ in callbackKeys.append(exp.key) }
+
+        var publisherKeys: [String] = []
+        sdk.experimentsPublisher.sink { publisherKeys.append($0.experiment.key) }.store(in: &cancellables)
+
+        _ = sdk.run(experiment: experiment("both"))
+
+        // The legacy callback and the new publisher must both fire.
+        XCTAssertEqual(callbackKeys, ["both"])
+        XCTAssertEqual(publisherKeys, ["both"])
+    }
+}

--- a/GrowthBookTests/FeaturesPublisherTests.swift
+++ b/GrowthBookTests/FeaturesPublisherTests.swift
@@ -65,6 +65,66 @@ class FeaturesPublisherTests: XCTestCase {
         XCTAssertEqual(Set(b.last?.keys ?? [:].keys), ["gamma"])
     }
 
+    // MARK: - Emission ordering
+
+    /// The SDK lock is released before sending, so two concurrent updates can be applied in one
+    /// order and reach the subject in the other. The later-applied update must win: otherwise
+    /// CurrentValueSubject keeps replaying features the SDK no longer holds.
+    func testSupersededEmissionIsNotDelivered() {
+        let sdk = makeSDK(clientKey: "features-publisher-ordering")
+        var received: [[String: Feature]] = []
+        sdk.featuresPublisher.sink { received.append($0) }.store(in: &cancellables)
+        XCTAssertEqual(received.count, 1, "Precondition: the replayed initial value")
+
+        let newer: [String: Feature] = ["newer": Feature(defaultValue: JSON(2))]
+        let older: [String: Feature] = ["older": Feature(defaultValue: JSON(1))]
+
+        // Applied as 6 then 7, but arriving here in the opposite order.
+        sdk.emitFeaturesChange(newer, generation: 7)
+        sdk.emitFeaturesChange(older, generation: 6)
+
+        XCTAssertEqual(received.count, 2, "The superseded update must not be delivered")
+        XCTAssertEqual(Set(received.last?.keys ?? [:].keys), ["newer"],
+                       "Subscribers must be left holding the update that was applied last")
+    }
+
+    /// Control: emissions that arrive in applied order are all delivered.
+    func testEmissionsInAppliedOrderAreAllDelivered() {
+        let sdk = makeSDK(clientKey: "features-publisher-ordering-control")
+        var received: [[String: Feature]] = []
+        sdk.featuresPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        sdk.emitFeaturesChange(["first": Feature(defaultValue: JSON(1))], generation: 1)
+        sdk.emitFeaturesChange(["second": Feature(defaultValue: JSON(2))], generation: 2)
+
+        XCTAssertEqual(received.count, 3)
+        XCTAssertEqual(Set(received.last?.keys ?? [:].keys), ["second"])
+    }
+
+    /// End-to-end invariant under concurrency: once every update has been applied, what the
+    /// subject holds must match what the SDK holds.
+    func testConcurrentUpdatesLeaveSubjectMatchingSDK() {
+        let sdk = makeSDK(clientKey: "features-publisher-concurrency")
+        var received: [[String: Feature]] = []
+        let guardLock = NSLock()
+        sdk.featuresPublisher.sink { value in
+            guardLock.lock(); received.append(value); guardLock.unlock()
+        }.store(in: &cancellables)
+
+        let group = DispatchGroup()
+        for i in 0..<20 {
+            DispatchQueue.global().async(group: group) {
+                sdk.featuresFetchedSuccessfully(features: ["flag-\(i)": Feature(defaultValue: JSON(i))], isRemote: true)
+            }
+        }
+        group.wait()
+
+        let sdkFeatures = Set(sdk.getFeatures().keys)
+        guardLock.lock(); let last = Set(received.last?.keys ?? [:].keys); guardLock.unlock()
+        XCTAssertEqual(last, sdkFeatures,
+                       "The value replayed to new subscribers must be the features the SDK actually holds")
+    }
+
     func testNoEmitWhenStableSessionLatched() {
         // With stableSession enabled, a second update must NOT be applied or emitted.
         let payload = """

--- a/GrowthBookTests/FeaturesPublisherTests.swift
+++ b/GrowthBookTests/FeaturesPublisherTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+import Combine
+
+@testable import GrowthBook
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+class FeaturesPublisherTests: XCTestCase {
+
+    private var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    /// Offline SDK preloaded with a single "alpha" feature.
+    private func makeSDK(clientKey: String = "features-publisher-test") -> GrowthBookSDK {
+        let payload = """
+        {"features": {"alpha": {"defaultValue": 1}}}
+        """.data(using: .utf8)!
+
+        return GrowthBookBuilder(
+            apiHost: "https://example.com",
+            clientKey: clientKey,
+            attributes: [:],
+            features: payload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+    }
+
+    func testCurrentValueReplayedToNewSubscriber() {
+        let sdk = makeSDK()
+        var received: [[String: Feature]] = []
+        sdk.featuresPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        // CurrentValueSubject replays the latest features to a new subscriber immediately.
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(Set(received.first?.keys ?? [:].keys), ["alpha"])
+    }
+
+    func testEmitsOnUpdate() {
+        let sdk = makeSDK()
+        var received: [[String: Feature]] = []
+        sdk.featuresPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        sdk.featuresFetchedSuccessfully(features: ["beta": Feature(defaultValue: JSON(2))], isRemote: true)
+
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(Set(received.last?.keys ?? [:].keys), ["beta"])
+    }
+
+    func testMultipleSubscribersAllReceiveUpdate() {
+        let sdk = makeSDK()
+        var a: [[String: Feature]] = []
+        var b: [[String: Feature]] = []
+        sdk.featuresPublisher.sink { a.append($0) }.store(in: &cancellables)
+        sdk.featuresPublisher.sink { b.append($0) }.store(in: &cancellables)
+
+        sdk.featuresFetchedSuccessfully(features: ["gamma": Feature(defaultValue: JSON(3))], isRemote: true)
+
+        XCTAssertEqual(Set(a.last?.keys ?? [:].keys), ["gamma"])
+        XCTAssertEqual(Set(b.last?.keys ?? [:].keys), ["gamma"])
+    }
+
+    func testNoEmitWhenStableSessionLatched() {
+        // With stableSession enabled, a second update must NOT be applied or emitted.
+        let payload = """
+        {"features": {"alpha": {"defaultValue": 1}}}
+        """.data(using: .utf8)!
+        let sdk = GrowthBookBuilder(
+            apiHost: "https://example.com",
+            clientKey: "features-publisher-stable",
+            attributes: [:],
+            features: payload,
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setStableSession(true)
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        var received: [[String: Feature]] = []
+        sdk.featuresPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        sdk.featuresFetchedSuccessfully(features: ["beta": Feature(defaultValue: JSON(2))], isRemote: true)
+
+        // Only the initial replay; the locked-session update is ignored.
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(Set(received.first?.keys ?? [:].keys), ["alpha"])
+    }
+}

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -409,6 +409,18 @@ protocol GrowthBookProtocol: AnyObject {
     /// concrete `PassthroughSubject` type is only referenced inside `@available`-gated members.
     private var experimentsSubjectStorage: AnyObject?
 
+    /// Guards emission so two threads cannot interleave sends. Deliberately separate from `lock`:
+    /// subscriber code runs while this is held, and it must not run holding the SDK lock. Always
+    /// taken *after* `lock` is released, never the other way round, so the two cannot deadlock.
+    private let emissionLock = NSRecursiveLock()
+
+    /// Order in which feature updates were applied. Assigned under `lock`.
+    private var featuresGeneration = 0
+
+    /// Highest generation already delivered to the features subject; read and written only under
+    /// `emissionLock`.
+    private var lastEmittedFeaturesGeneration = 0
+
     /// True once the session's initial features have been applied.
     /// Set once and never reset — used as the stableSession latch.
     private var sessionEstablished: Bool = false
@@ -617,14 +629,29 @@ protocol GrowthBookProtocol: AnyObject {
     }
 #endif
 
-    /// Emit a features change to the Combine subject, if one exists and the platform
-    /// supports Combine. Sends outside `lock` so subscriber code never runs while the
-    /// SDK lock is held.
-    private func emitFeaturesChange(_ features: [String: Feature]) {
+    /// Emit a features change to the Combine subject, if one exists and the platform supports
+    /// Combine. Sends outside `lock` so subscriber code never runs while the SDK lock is held.
+    ///
+    /// Because the lock is released before sending, two concurrent updates can be applied in one
+    /// order and reach this point in the other. `generation` is the order in which they were
+    /// applied, so an update that has already been overtaken is dropped rather than sent: it is
+    /// history, and letting it through would leave `CurrentValueSubject` replaying features the SDK
+    /// no longer holds. Dropping is safe here precisely because this is a current-value stream —
+    /// subscribers care about the latest state, not about every intermediate step.
+    ///
+    /// Internal rather than private so tests can drive the ordering directly instead of racing two
+    /// threads and hoping for the interleaving that matters.
+    func emitFeaturesChange(_ features: [String: Feature], generation: Int) {
 #if canImport(Combine)
         guard #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) else { return }
         let subject = withLock { featuresSubjectStorage as? CurrentValueSubject<[String: Feature], Never> }
-        subject?.send(features)
+        guard let subject else { return }
+
+        emissionLock.lock()
+        defer { emissionLock.unlock() }
+        guard generation > lastEmittedFeaturesGeneration else { return }
+        lastEmittedFeaturesGeneration = generation
+        subject.send(features)
 #endif
     }
 
@@ -651,13 +678,24 @@ protocol GrowthBookProtocol: AnyObject {
     }
 #endif
 
-    /// Emit an experiment run to the Combine subject, if one exists and the platform
-    /// supports Combine. Sends outside `lock`, mirroring `emitFeaturesChange`.
+    /// Emit an experiment run to the Combine subject, if one exists and the platform supports
+    /// Combine. Sends outside `lock`, mirroring `emitFeaturesChange`.
+    ///
+    /// This is an event stream, not a current value, so nothing may be dropped: every run has to
+    /// reach subscribers. What the shared `emissionLock` buys here is that two concurrent runs
+    /// cannot interleave inside a subscriber, and that a run is never delivered in the middle of a
+    /// features emission. The relative order of two truly concurrent runs is not defined — the
+    /// experiments themselves are independent, and preserving it would mean holding the SDK lock
+    /// across subscriber code.
     private func emitExperimentRun(_ run: ExperimentRun) {
 #if canImport(Combine)
         guard #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) else { return }
         let subject = withLock { experimentsSubjectStorage as? PassthroughSubject<ExperimentRun, Never> }
-        subject?.send(run)
+        guard let subject else { return }
+
+        emissionLock.lock()
+        defer { emissionLock.unlock() }
+        subject.send(run)
 #endif
     }
 
@@ -724,6 +762,7 @@ protocol GrowthBookProtocol: AnyObject {
     }
 
     @objc public func featuresFetchedSuccessfully(features: [String: Feature], isRemote: Bool) {
+        var generation = 0
         let didApply: Bool = withLock {
             let stableSession = contextManager.getGlobalConfig().stableSession
 
@@ -750,11 +789,15 @@ protocol GrowthBookProtocol: AnyObject {
                 sessionEstablished = true
                 logger.info("stableSession: initial features established. Session is now locked — subsequent refreshes will update the cache only and apply on next SDK initialization.")
             }
+            // Stamp the update with its position in the applied order while still serialized, so
+            // the emission below can tell whether a newer update has overtaken it.
+            featuresGeneration += 1
+            generation = featuresGeneration
             return true
         }
 
         if didApply {
-            emitFeaturesChange(features)
+            emitFeaturesChange(features, generation: generation)
         }
     }
 
@@ -771,13 +814,15 @@ protocol GrowthBookProtocol: AnyObject {
         let crypto: CryptoProtocol = subtle ?? Crypto()
         guard let features = crypto.getFeaturesFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) else { return }
 
-        withLock {
+        let generation: Int = withLock {
             self.contextManager.updateEvalData { data in
                 data.features = features
             }
             self.refreshStickyBucketService()
+            featuresGeneration += 1
+            return featuresGeneration
         }
-        emitFeaturesChange(features)
+        emitFeaturesChange(features, generation: generation)
     }
 
     func featuresFetchFailed(error: SDKError, isRemote: Bool) {}

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -395,6 +395,11 @@ protocol GrowthBookProtocol: AnyObject {
     /// only referenced inside `@available`-gated members.
     private var featuresSubjectStorage: AnyObject?
 
+    /// Type-erased storage for the Combine experiments subject, created lazily on first
+    /// `experimentsPublisher` access. Same rationale as `featuresSubjectStorage`; the
+    /// concrete `PassthroughSubject` type is only referenced inside `@available`-gated members.
+    private var experimentsSubjectStorage: AnyObject?
+
     /// True once the session's initial features have been applied.
     /// Set once and never reset — used as the stableSession latch.
     private var sessionEstablished: Bool = false
@@ -607,6 +612,39 @@ protocol GrowthBookProtocol: AnyObject {
 #endif
     }
 
+#if canImport(Combine)
+    /// A publisher that emits an event for every experiment executed via `run(experiment:)`.
+    /// Unlike `featuresPublisher`, this is an event stream with no "current" value: new
+    /// subscribers receive only subsequent runs, not past ones. Emissions are delivered on
+    /// the thread that ran the experiment; use `.receive(on:)` for the main queue.
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    public var experimentsPublisher: AnyPublisher<ExperimentRun, Never> {
+        withLock { experimentsSubject().eraseToAnyPublisher() }
+    }
+
+    /// Returns the backing subject, creating it lazily on first use. Must be called
+    /// under `lock` (it mutates `experimentsSubjectStorage`).
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    private func experimentsSubject() -> PassthroughSubject<ExperimentRun, Never> {
+        if let existing = experimentsSubjectStorage as? PassthroughSubject<ExperimentRun, Never> {
+            return existing
+        }
+        let subject = PassthroughSubject<ExperimentRun, Never>()
+        experimentsSubjectStorage = subject
+        return subject
+    }
+#endif
+
+    /// Emit an experiment run to the Combine subject, if one exists and the platform
+    /// supports Combine. Sends outside `lock`, mirroring `emitFeaturesChange`.
+    private func emitExperimentRun(_ run: ExperimentRun) {
+#if canImport(Combine)
+        guard #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) else { return }
+        let subject = withLock { experimentsSubjectStorage as? PassthroughSubject<ExperimentRun, Never> }
+        subject?.send(run)
+#endif
+    }
+
     /// Subscribe to all experiment execution events.
     /// - Parameter result: ExperimentRunCallback
     @objc public func subscribe(_ result: @escaping ExperimentRunCallback) {
@@ -747,11 +785,15 @@ protocol GrowthBookProtocol: AnyObject {
     /// - Parameter experiment: Experiment
     /// - Returns: ExperimentResult
     @objc public func run(experiment: Experiment) -> ExperimentResult {
-        withLock {
+        let result: ExperimentResult = withLock {
             let result = _runExperiment(experiment: experiment)
             self.subscriptions.forEach { $0(experiment, result) }
             return result
         }
+        // Emit to the Combine subject outside the lock, mirroring emitFeaturesChange,
+        // so subscriber code never runs while the SDK lock is held.
+        emitExperimentRun(ExperimentRun(experiment: experiment, result: result))
+        return result
     }
 
     private func _runExperiment(experiment: Experiment) -> ExperimentResult {
@@ -876,5 +918,18 @@ protocol GrowthBookProtocol: AnyObject {
 
 
         return result
+    }
+}
+
+/// A single experiment execution event, delivered by `GrowthBookSDK.experimentsPublisher`.
+/// Mirrors the `(Experiment, ExperimentResult)` pair passed to `subscribe(_:)`, exposed as a
+/// public value type so Combine subscribers can read both sides of the run.
+public struct ExperimentRun {
+    public let experiment: Experiment
+    public let result: ExperimentResult
+
+    public init(experiment: Experiment, result: ExperimentResult) {
+        self.experiment = experiment
+        self.result = result
     }
 }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Combine)
+import Combine
+#endif
 
 /// GrowthBookBuilder - Root Class for SDK Initializers for GrowthBook SDK
 protocol GrowthBookProtocol: AnyObject {
@@ -385,6 +388,13 @@ protocol GrowthBookProtocol: AnyObject {
     var cachingManager: CachingLayer
 
     private let lock = NSRecursiveLock()
+
+    /// Type-erased storage for the Combine features subject, created lazily on first
+    /// `featuresPublisher` access. Stored as `AnyObject?` so the property stays available
+    /// on OS versions that predate Combine; the concrete `CurrentValueSubject` type is
+    /// only referenced inside `@available`-gated members.
+    private var featuresSubjectStorage: AnyObject?
+
     /// True once the session's initial features have been applied.
     /// Set once and never reset — used as the stableSession latch.
     private var sessionEstablished: Bool = false
@@ -563,6 +573,40 @@ protocol GrowthBookProtocol: AnyObject {
         withLock { contextManager.getEvaluationData().features }
     }
 
+#if canImport(Combine)
+    /// A publisher that emits the current feature set and then every subsequent update
+    /// (from cache, network, streaming, or `setEncryptedFeatures`). New subscribers
+    /// immediately receive the latest features. Emissions are delivered on the thread
+    /// that applied the update; use `.receive(on:)` if you need them on the main queue.
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    public var featuresPublisher: AnyPublisher<[String: Feature], Never> {
+        withLock { featuresSubject().eraseToAnyPublisher() }
+    }
+
+    /// Returns the backing subject, creating it lazily on first use. Must be called
+    /// under `lock` (it mutates `featuresSubjectStorage`).
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    private func featuresSubject() -> CurrentValueSubject<[String: Feature], Never> {
+        if let existing = featuresSubjectStorage as? CurrentValueSubject<[String: Feature], Never> {
+            return existing
+        }
+        let subject = CurrentValueSubject<[String: Feature], Never>(contextManager.getEvaluationData().features)
+        featuresSubjectStorage = subject
+        return subject
+    }
+#endif
+
+    /// Emit a features change to the Combine subject, if one exists and the platform
+    /// supports Combine. Sends outside `lock` so subscriber code never runs while the
+    /// SDK lock is held.
+    private func emitFeaturesChange(_ features: [String: Feature]) {
+#if canImport(Combine)
+        guard #available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *) else { return }
+        let subject = withLock { featuresSubjectStorage as? CurrentValueSubject<[String: Feature], Never> }
+        subject?.send(features)
+#endif
+    }
+
     /// Subscribe to all experiment execution events.
     /// - Parameter result: ExperimentRunCallback
     @objc public func subscribe(_ result: @escaping ExperimentRunCallback) {
@@ -586,7 +630,7 @@ protocol GrowthBookProtocol: AnyObject {
     }
 
     @objc public func featuresFetchedSuccessfully(features: [String: Feature], isRemote: Bool) {
-        withLock {
+        let didApply: Bool = withLock {
             let stableSession = contextManager.getGlobalConfig().stableSession
 
             // In stableSession mode, block every update once the session is established.
@@ -600,7 +644,7 @@ protocol GrowthBookProtocol: AnyObject {
                 } else {
                     logger.debug("stableSession: ignoring cache refresh — session features already established")
                 }
-                return
+                return false
             }
 
             self.contextManager.updateEvalData { data in
@@ -612,6 +656,11 @@ protocol GrowthBookProtocol: AnyObject {
                 sessionEstablished = true
                 logger.info("stableSession: initial features established. Session is now locked — subsequent refreshes will update the cache only and apply on next SDK initialization.")
             }
+            return true
+        }
+
+        if didApply {
+            emitFeaturesChange(features)
         }
     }
 
@@ -634,6 +683,7 @@ protocol GrowthBookProtocol: AnyObject {
             }
             self.refreshStickyBucketService()
         }
+        emitFeaturesChange(features)
     }
 
     func featuresFetchFailed(error: SDKError, isRemote: Bool) {}


### PR DESCRIPTION
## Summary

  Adds Combine publishers for reactive observation of the SDK: `featuresPublisher`
  (current feature set + every subsequent update) and `experimentsPublisher` (an event
  for every experiment run). Purely additive and fully gated by availability — no existing
  API changes, and nothing is exposed on OS versions without Combine.

  This is phase 1 of the Combine + SwiftUI work. A SwiftUI layer (`@GBFeatureFlag` property
  wrapper) can follow in a separate PR, built on top of these publishers.

  ## What's added

  `GrowthBookSDK.featuresPublisher: AnyPublisher<[String: Feature], Never>`

  - Backed by a `CurrentValueSubject`: new subscribers immediately receive the latest
    features, then every update.
  - Emits on every runtime feature change — from cache, network, streaming, and
    `setEncryptedFeatures`. The `stableSession` lock is respected (no emission when a
    locked session ignores an update).

  `GrowthBookSDK.experimentsPublisher: AnyPublisher<ExperimentRun, Never>`

  - Backed by a `PassthroughSubject`: an **event stream** with no current value. New
    subscribers receive only subsequent runs, not past ones.
  - Emits an `ExperimentRun` for every `run(experiment:)`. The legacy `subscribe(_:)`
    callback is unchanged and still fires.

  New public value type:

  ```swift
  public struct ExperimentRun {
      public let experiment: Experiment
      public let result: ExperimentResult
  }
  ```

  Usage:

  ```swift
  sdk.featuresPublisher
      .receive(on: DispatchQueue.main)
      .sink { features in /* react to changes */ }

  sdk.experimentsPublisher
      .receive(on: DispatchQueue.main)
      .sink { run in /* run.experiment, run.result */ }
  ```

  Emissions are delivered on the thread that applied the update / ran the experiment; use
  `.receive(on:)` for the main queue.

  ## Platform gating (important)

  Combine requires iOS 13 / tvOS 13 / watchOS 6 / macOS 10.15, but the SDK deploys down to
  iOS 12 / tvOS 12 / watchOS 5. So:

  - All Combine code is wrapped in `#if canImport(Combine)` + an
    `@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)` gate.
  - Each backing subject is stored type-erased as `AnyObject?`, so the stored property stays
    valid on pre-Combine OS versions; the concrete `CurrentValueSubject` / `PassthroughSubject`
    types are only referenced inside gated members.
  - Deployment target is unchanged — the feature is opt-in on supported OSes.

  ## Thread safety

  Each subject is `send()` outside the SDK lock (the reference is read under the
  `NSRecursiveLock`, then sent outside it), so subscriber code never runs while the SDK lock
  is held.

  ## Tests

  `FeaturesPublisherTests` (4): current value replayed to a new subscriber; emission on
  feature update; multiple subscribers all receive the update; no emission when a
  stableSession is locked.

  `ExperimentsPublisherTests` (5): emission on `run(experiment:)`; no replay for a new
  subscriber; a late subscriber misses earlier runs; multiple subscribers all receive the
  run; the legacy `subscribe(_:)` callback still fires alongside the publisher.

  Verified with `swift test` (494 passing) and `xcodebuild build-for-testing` (CI path).