### PR TITLE
Fix forced rollout hashing and evaluator parity

### DIFF
--- a/GrowthBookTests/ExperimentEvaluatorTests.swift
+++ b/GrowthBookTests/ExperimentEvaluatorTests.swift
@@ -11,11 +11,17 @@ class ExperimentEvaluatorTests: XCTestCase {
         isEnabled: Bool = true,
         isQaMode: Bool = false,
         url: String? = nil,
-        features: Features = [:]
+        features: Features = [:],
+        stickyBucketService: StickyBucketServiceProtocol? = nil
     ) -> EvalContext {
         let globalContext = GlobalContext(features: features)
         let userContext = UserContext(attributes: attributes, forcedVariations: forcedVariations)
-        let options = ClientOptions(isEnabled: isEnabled, stickyBucketService: nil, isQaMode: isQaMode, trackingClosure: { _, _ in })
+        let options = ClientOptions(
+            isEnabled: isEnabled,
+            stickyBucketService: stickyBucketService,
+            isQaMode: isQaMode,
+            trackingClosure: { _, _ in }
+        )
         options.url = url
         return EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
     }
@@ -92,6 +98,43 @@ class ExperimentEvaluatorTests: XCTestCase {
         let exp = Experiment(key: "exp", variations: [JSON("a"), JSON("b")], hashAttribute: "custom-id")
         let result = evaluate(exp, context: makeContext(attributes: JSON(["id": "user-1"])))
         XCTAssertFalse(result.inExperiment)
+    }
+
+    func testFallbackAttributeUsedWhenStickyBucketingDefaultsEnabled() {
+        let exp = Experiment(
+            key: "exp",
+            variations: [JSON("a"), JSON("b")],
+            hashAttribute: "id",
+            fallBackAttribute: "anonymousId",
+            hashVersion: 2,
+            coverage: 1.0
+        )
+        let result = evaluate(
+            exp,
+            context: makeContext(
+                attributes: JSON(["anonymousId": "anon-1"]),
+                stickyBucketService: NoopStickyBucketService()
+            )
+        )
+
+        XCTAssertTrue(result.inExperiment)
+        XCTAssertEqual(result.hashAttribute, "anonymousId")
+    }
+
+    func testExperimentUsesExplicitSeedBeforeExperimentKey() {
+        // For user 4, v1(custom-seed)=0.242 while v1(experiment-key)=0.966.
+        let exp = Experiment(
+            key: "experiment-key",
+            variations: [JSON("included"), JSON("excluded")],
+            hashVersion: 1,
+            ranges: [BucketRange(number1: 0.0, number2: 0.5)],
+            seed: "custom-seed"
+        )
+        let result = evaluate(exp, context: makeContext(attributes: JSON(["id": "4"])))
+
+        XCTAssertTrue(result.inExperiment)
+        XCTAssertEqual(result.value, JSON("included"))
+        XCTAssertEqual(result.bucket, 0.242)
     }
 
     // MARK: - Condition fails

--- a/GrowthBookTests/FeatureEvaluatorTests.swift
+++ b/GrowthBookTests/FeatureEvaluatorTests.swift
@@ -9,11 +9,18 @@ class FeatureEvaluatorTests: XCTestCase {
         features: Features = [:],
         attributes: JSON = JSON(["id": "user-1"]),
         forcedFeatureValues: JSON? = nil,
-        savedGroups: JSON? = nil
+        savedGroups: JSON? = nil,
+        stickyBucketService: StickyBucketServiceProtocol? = nil,
+        trackingClosure: @escaping TrackingCallback = { _, _ in }
     ) -> EvalContext {
         let globalContext = GlobalContext(features: features, savedGroups: savedGroups)
         let userContext = UserContext(attributes: attributes, forcedFeatureValues: forcedFeatureValues)
-        let options = ClientOptions(isEnabled: true, stickyBucketService: nil, isQaMode: false, trackingClosure: { _, _ in })
+        let options = ClientOptions(
+            isEnabled: true,
+            stickyBucketService: stickyBucketService,
+            isQaMode: false,
+            trackingClosure: trackingClosure
+        )
         return EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
     }
 
@@ -123,8 +130,124 @@ class FeatureEvaluatorTests: XCTestCase {
         XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
     }
 
-    func testForceRuleWithRangeSkipsCoverageCheck() {
-        // When range is set, the separate coverage check block is skipped
+    func testForceRuleUsesHashVersionTwoWithoutLegacySecondGate() {
+        // Standard GrowthBook vector: v2 bucket is 0.134 (included), while v1 is 0.502 (excluded).
+        let rule = FeatureRule(coverage: 0.5, force: JSON(1), hashVersion: 2)
+        let feature = Feature(defaultValue: JSON(0), rules: [rule])
+        let result = evaluate(
+            "feature",
+            in: makeContext(features: ["feature": feature], attributes: JSON(["id": "user2"]))
+        )
+
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(result.value, JSON(1))
+    }
+
+    func testForceRuleUsesConfiguredSeed() {
+        // For user 4, v1(custom-seed)=0.242 while v1(feature)=0.943.
+        let rule = FeatureRule(coverage: 0.5, force: JSON(true), hashVersion: 1, seed: "custom-seed")
+        let feature = Feature(defaultValue: JSON(false), rules: [rule])
+        let result = evaluate(
+            "feature",
+            in: makeContext(features: ["feature": feature], attributes: JSON(["id": "4"]))
+        )
+
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertTrue(result.isOn)
+    }
+
+    func testForceRuleTracksAcceptedV2Assignment() {
+        let experimentKey = "remote-exp-\(UUID().uuidString)"
+        let track = Track(json: [
+            "experiment": JSON(["key": experimentKey, "variations": [false, true]]),
+            "result": JSON([
+                "inExperiment": true,
+                "variationId": 1,
+                "value": true,
+                "hashAttribute": "id",
+                "hashValue": "user2",
+                "key": "1"
+            ])
+        ])
+        let rule = FeatureRule(coverage: 0.5, force: JSON(true), hashVersion: 2, tracks: [track])
+        let feature = Feature(defaultValue: JSON(false), rules: [rule])
+        var tracked = 0
+        let result = evaluate(
+            "feature",
+            in: makeContext(
+                features: ["feature": feature],
+                attributes: JSON(["id": "user2"]),
+                trackingClosure: { _, _ in tracked += 1 }
+            )
+        )
+
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertEqual(tracked, 1)
+    }
+
+    func testForceRuleUsesFallbackAttributeWhenStickyBucketingDefaultsEnabled() {
+        let rule = FeatureRule(
+            force: JSON(true),
+            hashAttribute: "id",
+            fallBackAttribute: "anonymousId",
+            hashVersion: 2,
+            range: BucketRange(number1: 0.0, number2: 1.0)
+        )
+        let feature = Feature(defaultValue: JSON(false), rules: [rule])
+        let result = evaluate(
+            "feature",
+            in: makeContext(
+                features: ["feature": feature],
+                attributes: JSON(["anonymousId": "anon-1"]),
+                stickyBucketService: NoopStickyBucketService()
+            )
+        )
+
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertTrue(result.isOn)
+    }
+
+    func testForceRuleRangeUsesConfiguredHashAttribute() {
+        let rule = FeatureRule(
+            force: JSON(true),
+            hashAttribute: "userId",
+            hashVersion: 2,
+            range: BucketRange(number1: 0.0, number2: 1.0)
+        )
+        let feature = Feature(defaultValue: JSON(false), rules: [rule])
+        let result = evaluate(
+            "feature",
+            in: makeContext(features: ["feature": feature], attributes: JSON(["userId": "user-1"]))
+        )
+
+        XCTAssertEqual(result.source, FeatureSource.force.rawValue)
+        XCTAssertTrue(result.isOn)
+    }
+
+    func testExperimentRuleAppliesFilters() {
+        let filter = Filter(
+            attribute: nil,
+            seed: "filter-seed",
+            hashVersion: 2,
+            ranges: [BucketRange(number1: 0.0, number2: 0.0)],
+            fallbackAttribute: nil
+        )
+        let rule = FeatureRule(
+            variations: [JSON("control"), JSON("variant")],
+            hashVersion: 2,
+            filters: [filter]
+        )
+        let feature = Feature(defaultValue: JSON("default"), rules: [rule])
+        let result = evaluate(
+            "feature",
+            in: makeContext(features: ["feature": feature], attributes: JSON(["id": "user-1"]))
+        )
+
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+        XCTAssertEqual(result.value, JSON("default"))
+    }
+
+    func testForceRuleRangeTakesPrecedenceOverCoverage() {
         let range = BucketRange(json: JSON([0.0, 1.0]))
         let rule = FeatureRule(coverage: 1.0, force: JSON("forced"), range: range)
         let feature = Feature(defaultValue: JSON("default"), rules: [rule])

--- a/GrowthBookTests/TestHelper.swift
+++ b/GrowthBookTests/TestHelper.swift
@@ -2,6 +2,27 @@ import Foundation
 
 @testable import GrowthBook
 
+final class NoopStickyBucketService: NSObject, StickyBucketServiceProtocol {
+    func getAssignments(
+        attributeName: String,
+        attributeValue: String,
+        completion: @escaping (StickyAssignmentsDocument?, Error?) -> Void
+    ) {
+        completion(nil, nil)
+    }
+
+    func saveAssignments(doc: StickyAssignmentsDocument, completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+
+    func getAllAssignments(
+        attributes: [String: String],
+        completion: @escaping ([String: StickyAssignmentsDocument]?, Error?) -> Void
+    ) {
+        completion([:], nil)
+    }
+}
+
 class TestHelper {
     var testData: JSON? {
         get {

--- a/GrowthBookTests/UtilsExtendedTests.swift
+++ b/GrowthBookTests/UtilsExtendedTests.swift
@@ -38,6 +38,14 @@ class UtilsExtendedTests: XCTestCase {
         XCTAssertEqual(a, b)
     }
 
+    func testMalformedSingleValueRangeMatchesNobody() {
+        let range = BucketRange(json: JSON([0.5]))
+
+        XCTAssertEqual(range.number1, 0)
+        XCTAssertEqual(range.number2, 0)
+        XCTAssertFalse(Utils.inRange(n: 0.5, range: range))
+    }
+
     // MARK: - isFilteredOut
 
     func testIsFilteredOutReturnsFalseWhenHashInRange() {
@@ -67,6 +75,30 @@ class UtilsExtendedTests: XCTestCase {
     func testIsFilteredOutReturnsFalseForEmptyFilters() {
         let attributes = JSON(["id": "anything"])
         XCTAssertFalse(Utils.isFilteredOut(filters: [], attributes: attributes))
+    }
+
+    func testIsFilteredOutUsesEachFiltersHashAttribute() {
+        let attributes = JSON(["userId": "user-1"])
+        let filter = Filter(
+            attribute: "userId",
+            seed: "my-seed",
+            hashVersion: 2,
+            ranges: [BucketRange(number1: 0.0, number2: 1.0)],
+            fallbackAttribute: nil
+        )
+        XCTAssertFalse(Utils.isFilteredOut(filters: [filter], attributes: attributes))
+    }
+
+    func testIsFilteredOutReturnsTrueWhenHashAttributeIsMissing() {
+        let attributes = JSON(["id": "user-1"])
+        let filter = Filter(
+            attribute: "userId",
+            seed: "my-seed",
+            hashVersion: 2,
+            ranges: [BucketRange(number1: 0.0, number2: 1.0)],
+            fallbackAttribute: nil
+        )
+        XCTAssertTrue(Utils.isFilteredOut(filters: [filter], attributes: attributes))
     }
 
     // MARK: - isIncludedInRollout
@@ -146,6 +178,18 @@ class UtilsExtendedTests: XCTestCase {
             hashVersion: 1
         )
         XCTAssertTrue(withFallback)
+    }
+
+    func testIsIncludedInRolloutReturnsFalseWhenHashAttributeIsMissing() {
+        XCTAssertFalse(Utils.isIncludedInRollout(
+            attributes: JSON(["email": "user@example.com"]),
+            seed: "seed",
+            hashAttribute: "id",
+            fallbackAttribute: nil,
+            range: BucketRange(number1: 0.0, number2: 1.0),
+            coverage: nil,
+            hashVersion: 2
+        ))
     }
 
     // MARK: - getHashAttribute

--- a/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
@@ -228,6 +228,6 @@ class ExperimentEvaluator {
     }
     
     private func isStickyBucketingEnabledForExperiment(context: EvalContext, experiment: Experiment) -> Bool {
-        return (context.options.stickyBucketService != nil && !(experiment.disableStickyBucketing ?? true))
+        return (context.options.stickyBucketService != nil && !(experiment.disableStickyBucketing ?? false))
     }
 }

--- a/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
@@ -126,7 +126,7 @@ class FeatureEvaluator {
                         attributes: context.userContext.attributes,
                         seed: rule.seed ?? featureKey,
                         hashAttribute: rule.hashAttribute,
-                        fallbackAttribute: (context.options.stickyBucketService != nil && !(rule.disableStickyBucketing ?? true)) ? rule.fallbackAttribute : nil,
+                        fallbackAttribute: (context.options.stickyBucketService != nil && !(rule.disableStickyBucketing ?? false)) ? rule.fallbackAttribute : nil,
                         range: rule.range,
                         coverage: rule.coverage,
                         hashVersion: rule.hashVersion
@@ -147,28 +147,6 @@ class FeatureEvaluator {
                         }
                     }
                     
-                    // Ignore coverage if the rule has a range
-                    if rule.range == nil {
-                        // If rule.coverage is set
-                        if let coverage = rule.coverage {
-                            
-                            let key = rule.hashAttribute ?? Constants.idAttributeKey
-                            // Get the user hash value (context.attributes[rule.hashAttribute || "id"]) and if empty, skip the rule
-                            guard let attributeValue = context.userContext.attributes.dictionaryValue[key]?.stringValue,
-                                  attributeValue.isEmpty == false
-                            else {
-                                continue
-                            }
-                            
-                            // Compute a hash using the Fowler–Noll–Vo algorithm (specifically fnv32-1a)
-                            let hashFNV = Utils.hash(seed: featureKey, value: attributeValue, version: 1.0) ?? 0.0
-                            // If the hash is greater than rule.coverage, skip the rule
-                            if hashFNV > coverage {
-                                continue ruleLoop
-                            }
-                        }
-                    }
-
                     // Return (value = forced value, source = force)
                     
                     let forcedFeatureResult = prepareResult(value: force, source: FeatureSource.force, ruleId: rule.id)
@@ -245,4 +223,3 @@ struct FeatureEvalContext {
     var id: String?
     var evaluatedFeatures: Set<String>
 }
-

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -55,12 +55,13 @@ public struct BucketRange: Codable {
     }
     
     init(json: JSON) {
-        if json.arrayValue.isEmpty {
+        let values = json.arrayValue
+        if values.count < 2 {
             number1 = 0
             number2 = 0
         } else {
-            self.number1 = json.arrayValue[0].floatValue
-            self.number2 = json.arrayValue[1].floatValue
+            self.number1 = values[0].floatValue
+            self.number2 = values[1].floatValue
         }
     }
 

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -36,8 +36,8 @@ public class Utils {
     ///This is a helper method to evaluate `filters` for both feature flags and experiments.
     static func isFilteredOut(filters: [Filter], attributes: JSON) -> Bool {
         return filters.contains { filter in
-            let hashAttribute = Utils.getHashAttribute(attr: filter.attribute, attributes: attributes)
-            let hashValue = hashAttribute.hashValue
+            let hashValue = Utils.getHashAttribute(attr: filter.attribute, attributes: attributes).hashValue
+            guard !hashValue.isEmpty else { return true }
             
             let hash = hash(seed: filter.seed, value: hashValue, version: filter.hashVersion)
             guard let hashValue = hash else { return true }
@@ -59,6 +59,7 @@ public class Utils {
         }
         
         let hashValue = Utils.getHashAttribute(attr: hashAttribute, fallback: fallbackAttribute, attributes: attributes).hashValue
+        guard !hashValue.isEmpty else { return false }
         
         let hash = Utils.hash(seed: seed, value: hashValue, version: hashVersion ?? 1)
         


### PR DESCRIPTION
## Bug Fixes Summary

- remove the duplicate legacy coverage gate from forced feature rules
- honor configured seeds, hash versions, hash attributes, fallback attributes, and ranges through one rollout decision
- reject missing hash attributes for rollouts and filters instead of hashing an empty string
- enable sticky bucketing by default when a service is configured and `disableStickyBucketing` is omitted
- make malformed one-element ranges non-matching instead of allowing an out-of-bounds access

## Root cause and impact

Forced rules first used `isIncludedInRollout` with the configured hashing inputs, then ran a duplicate coverage check with the feature key and hash v1. For rules using hash v2 or a custom seed, users had to pass two different gates, reducing effective inclusion toward `coverage²`. Remote-evaluation tracking ran between those gates, so an exposure could be recorded even when the forced value was not returned.

The evaluator also hashed empty strings when rollout or filter attributes were missing, and treated an omitted `disableStickyBucketing` as disabled in two paths. These behaviors diverged from the evaluator contract and other SDK implementations.

## Validation

- `swift build` passes with the compatible local macOS SDK
- compiled runtime probes cover v2/custom-seed rollout assignment, tracking consistency, missing attributes, explicit experiment seeds, and sticky fallback hashing
- the bundled evaluator corpus passes: 15 hash, 46 feature, and 73 experiment cases
- added focused regression tests for the corrected rollout, filter, sticky-bucket, tracking, and malformed-range behavior
- `git diff --check` and Swift parser checks pass