### PR TITLE
test: load conformance fixtures under SwiftPM as well

### DIFF
--- a/GrowthBookTests/TestHelper.swift
+++ b/GrowthBookTests/TestHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 @testable import GrowthBook
 
@@ -84,16 +85,37 @@ class TestHelper {
         testData?.dictionaryValue["decrypt"]?.arrayValue
     }
 
+    /// Loads the vendored conformance fixtures.
+    ///
+    /// The bundle differs per harness: SwiftPM puts declared resources in `Bundle.module`, while the
+    /// Xcode test target ships them inside the test bundle itself. Resolving only through
+    /// `Bundle(for:)` found nothing under SwiftPM, so every fixture-driven suite silently returned
+    /// early and reported success without evaluating a single case — `swift test` looked green while
+    /// testing none of the spec. Both bundles are consulted now, and a miss fails loudly instead of
+    /// degrading to a no-op.
     private func loadTestData() -> JSON? {
-        let bundle = Bundle(for: type(of: self))
-        guard
-            let path = bundle.path(forResource: "json", ofType: "json"),
-            let data = FileManager.default.contents(atPath: path)
-        else { return nil }
+        for bundle in Self.candidateBundles {
+            guard
+                let path = bundle.path(forResource: "json", ofType: "json"),
+                let data = FileManager.default.contents(atPath: path),
+                let testData = try? JSON(data: data)
+            else { continue }
 
-        let test = try? JSON(data: data)
+            return testData
+        }
 
-        return test
+        XCTFail("Could not load the conformance fixtures (GrowthBookTests/Source/json.json). "
+                + "Every spec-driven test depends on them, so they must never be missing.")
+        return nil
+    }
+
+    private static var candidateBundles: [Bundle] {
+        var bundles: [Bundle] = []
+        #if SWIFT_PACKAGE
+        bundles.append(.module)
+        #endif
+        bundles.append(Bundle(for: TestHelper.self))
+        return bundles
     }
 }
 


### PR DESCRIPTION
`TestHelper.loadTestData()` resolved the vendored fixtures only through `Bundle(for:)`. That works
  for the Xcode test target, which ships them inside the test bundle, but finds nothing under SwiftPM,
  where declared resources live in `Bundle.module`. Under `swift test` the load returned nil, every
  fixture-driven suite hit its own `guard let … else { return }`, and the run passed having evaluated
  no spec case at all — `testFeatures` finished in 0.000 s.

  CI has never been affected: `Scripts/runTest.sh` runs `xcodebuild` across four simulator platforms
  before `swift test`, so the suite has always really run there. The gap was `swift test` on its own,
  which is what contributors run locally.

  Both bundles are consulted now, and missing fixtures fail loudly instead of degrading to a no-op —
  the silent guards in ten call sites are exactly what hid this.

  Verified by provoking failures rather than observing a green run: corrupting an expected value now
  fails the run, `testFeatures` takes 0.047 s instead of 0.000 s, and replacing the fixtures with
  invalid JSON fails with an explicit message. With the fixtures loading, both `swift test` and
  `xcodebuild test` pass — so this uncovers no existing debt, it only makes the local harness honest.

  Test-only change; no production code is touched.