### PR TITLE
fix: make $inGroup/$notInGroup correct for absent and array attributes

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8433160E2FA2B6AD00D1C388 /* ConstantsAndModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */; };
 		843316102FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */; };
 		843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */; };
+		84CB1C012FB2000100AA0001 /* SavedGroupOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB1C002FB2000100AA0001 /* SavedGroupOperatorTests.swift */; };
 		843316142FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */; };
 		843316162FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */; };
 		843316182FA3FD1800D1C388 /* MiscCoverageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */; };
@@ -128,6 +129,7 @@
 		8433160B2FA2B6AD00D1C388 /* UtilsStickyBucketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsStickyBucketTests.swift; sourceTree = "<group>"; };
 		8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureEvaluatorTests.swift; sourceTree = "<group>"; };
+		84CB1C002FB2000100AA0001 /* SavedGroupOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedGroupOperatorTests.swift; sourceTree = "<group>"; };
 		843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentEvaluatorTests.swift; sourceTree = "<group>"; };
 		843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesViewModelExtendedTests.swift; sourceTree = "<group>"; };
 		843316172FA3FD1800D1C388 /* MiscCoverageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscCoverageTests.swift; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				843316152FA3FAEF00D1C388 /* FeaturesViewModelExtendedTests.swift */,
 				843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */,
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
+				84CB1C002FB2000100AA0001 /* SavedGroupOperatorTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
 				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
 				8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */,
@@ -548,6 +551,7 @@
 				843315FD2FA22A1B00D1C388 /* UtilsExtendedTests.swift in Sources */,
 				843316182FA3FD1800D1C388 /* MiscCoverageTests.swift in Sources */,
 				843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */,
+				84CB1C012FB2000100AA0001 /* SavedGroupOperatorTests.swift in Sources */,
 				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
 				8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */,

--- a/GrowthBookTests/SavedGroupOperatorTests.swift
+++ b/GrowthBookTests/SavedGroupOperatorTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import GrowthBook
+
+/// Covers the `$inGroup` / `$notInGroup` operators across every combination of attribute presence
+/// and group resolution.
+///
+/// The pair must stay a true logical negation: an absent attribute makes the user a non-member, so
+/// `$inGroup` is false and `$notInGroup` is true. Returning false for both — which is what happens
+/// when the operators only return from inside a non-null guard and otherwise drop out of the
+/// switch — silently breaks any rule written as an exclusion.
+///
+/// The shared spec fixtures (`Source/json.json`, spec 0.7.0) contain no absent-attribute cases for
+/// these operators, so this behaviour is only covered here.
+class SavedGroupOperatorTests: XCTestCase {
+
+    private let savedGroups = JSON(["vips": ["u1", "u2"], "empty": [] as [String]])
+
+    private func eval(_ condition: [String: Any], _ attributes: [String: Any]) -> Bool {
+        ConditionEvaluator().isEvalCondition(
+            attributes: JSON(attributes),
+            conditionObj: JSON(condition),
+            savedGroups: savedGroups
+        )
+    }
+
+    private func inGroup(_ group: String, _ attributes: [String: Any]) -> Bool {
+        eval(["id": ["$inGroup": group]], attributes)
+    }
+
+    private func notInGroup(_ group: String, _ attributes: [String: Any]) -> Bool {
+        eval(["id": ["$notInGroup": group]], attributes)
+    }
+
+    // MARK: - Attribute present
+
+    func testInGroupMatchesMember() {
+        XCTAssertTrue(inGroup("vips", ["id": "u1"]))
+    }
+
+    func testInGroupDoesNotMatchNonMember() {
+        XCTAssertFalse(inGroup("vips", ["id": "other"]))
+    }
+
+    func testNotInGroupDoesNotMatchMember() {
+        XCTAssertFalse(notInGroup("vips", ["id": "u1"]))
+    }
+
+    func testNotInGroupMatchesNonMember() {
+        XCTAssertTrue(notInGroup("vips", ["id": "other"]))
+    }
+
+    // MARK: - Attribute absent
+
+    func testInGroupDoesNotMatchWhenAttributeIsAbsent() {
+        XCTAssertFalse(inGroup("vips", ["unrelated": "x"]))
+    }
+
+    func testNotInGroupMatchesWhenAttributeIsAbsent() {
+        XCTAssertTrue(notInGroup("vips", ["unrelated": "x"]),
+                      "An absent attribute makes the user a non-member, so $notInGroup must match")
+    }
+
+    func testGroupOperatorsStayNegationsOfEachOtherForAbsentAttribute() {
+        let attributes = ["unrelated": "x"]
+        XCTAssertNotEqual(inGroup("vips", attributes), notInGroup("vips", attributes))
+    }
+
+    // MARK: - Unknown or empty group
+
+    func testInGroupDoesNotMatchUnknownGroup() {
+        XCTAssertFalse(inGroup("no-such-group", ["id": "u1"]))
+    }
+
+    func testNotInGroupMatchesUnknownGroup() {
+        XCTAssertTrue(notInGroup("no-such-group", ["id": "u1"]))
+    }
+
+    func testInGroupDoesNotMatchEmptyGroup() {
+        XCTAssertFalse(inGroup("empty", ["id": "u1"]))
+    }
+
+    func testNotInGroupMatchesEmptyGroup() {
+        XCTAssertTrue(notInGroup("empty", ["id": "u1"]))
+    }
+
+    // MARK: - No savedGroups supplied at all
+
+    func testGroupOperatorsWithoutSavedGroups() {
+        let evaluator = ConditionEvaluator()
+        let attributes = JSON(["id": "u1"])
+
+        XCTAssertFalse(evaluator.isEvalCondition(
+            attributes: attributes,
+            conditionObj: JSON(["id": ["$inGroup": "vips"]]),
+            savedGroups: nil
+        ))
+        XCTAssertTrue(evaluator.isEvalCondition(
+            attributes: attributes,
+            conditionObj: JSON(["id": ["$notInGroup": "vips"]]),
+            savedGroups: nil
+        ))
+    }
+
+    // MARK: - Malformed group id
+
+    func testNonStringGroupIdResolvesToEmptyGroup() {
+        XCTAssertFalse(eval(["id": ["$inGroup": 42]], ["id": "u1"]))
+        XCTAssertTrue(eval(["id": ["$notInGroup": 42]], ["id": "u1"]))
+    }
+
+    // MARK: - Array attributes
+
+    func testInGroupMatchesWhenAnyArrayElementIsAMember() {
+        XCTAssertTrue(inGroup("vips", ["id": ["other", "u2"]]))
+        XCTAssertFalse(notInGroup("vips", ["id": ["other", "u2"]]))
+    }
+
+    func testInGroupDoesNotMatchWhenNoArrayElementIsAMember() {
+        XCTAssertFalse(inGroup("vips", ["id": ["a", "b"]]))
+        XCTAssertTrue(notInGroup("vips", ["id": ["a", "b"]]))
+    }
+}

--- a/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ConditionEvaluator.swift
@@ -295,6 +295,21 @@ class ConditionEvaluator {
         default: break
         }
 
+        // The saved-group operators resolve the group themselves and work for any attribute shape —
+        // scalar, array or absent — so they are handled before the dispatch below, which branches on
+        // the shape of the attribute and would otherwise leave them unreachable for array attributes.
+        //
+        // Both always return: an absent attribute simply makes the user a non-member, so $inGroup is
+        // false and $notInGroup is true. Returning only from inside a non-null guard would drop out
+        // of the switch and yield false for both, breaking the negation.
+        switch operatorKey {
+        case "$inGroup":
+            return Common.isIn(actual: attributeValue, expected: resolveSavedGroup(conditionValue, savedGroups))
+        case "$notInGroup":
+            return !Common.isIn(actual: attributeValue, expected: resolveSavedGroup(conditionValue, savedGroups))
+        default: break
+        }
+
         /// There are three operators where conditionValue is an array
         if let conditionValue = conditionJson.array, attributeValue != .null {
             switch operatorKey {
@@ -361,14 +376,6 @@ class ConditionEvaluator {
             case "$vlte":
                 if let attributeString = attributeValue.string, let conditionString = conditionValue.string {
                     return Utils.paddedVersionString(input: attributeString) <= Utils.paddedVersionString(input: conditionString)
-                }
-            case "$inGroup":
-                if attributeValue != .null, let conditionString = conditionValue.string {
-                    return Common.isIn(actual: attributeValue, expected: savedGroups?[conditionString].array ?? [] )
-                }
-            case "$notInGroup": 
-                if attributeValue != .null, let conditionString = conditionValue.string {
-                    return !Common.isIn(actual: attributeValue, expected: savedGroups?[conditionString].array ?? [])
                 }
             // Evaluate EQ operator - whether condition equals to attribute
             case "$eq":
@@ -528,6 +535,16 @@ class ConditionEvaluator {
         } catch {
             return false
         }
+    }
+
+    /// Resolves the members of a saved group for the `$inGroup` / `$notInGroup` operators.
+    ///
+    /// An unknown group id, a missing `savedGroups` object, a non-array group value, or a group id
+    /// that is not a string all resolve to an empty group — so membership is simply false and the
+    /// negation stays meaningful.
+    private func resolveSavedGroup(_ conditionValue: JSON, _ savedGroups: JSON?) -> [JSON] {
+        guard let groupId = conditionValue.string else { return [] }
+        return savedGroups?[groupId].array ?? []
     }
 
     private func isPrimitive(value: JSON) -> Bool {


### PR DESCRIPTION
Fixes two defects in the saved-group operators.

  ## Behaviour change

  This changes evaluated feature values for rules using `$notInGroup` on an attribute a user may not
  have, and for either operator on array attributes: those rules previously never matched, and now
  they do. Worth a line in the release notes.

  ## Defect 1 — the negation was broken for absent attributes

  Both operators only returned from inside a non-null attribute guard, so with the attribute absent
  neither guard held, the switch ended, and execution reached the trailing `return false` — making
  `$inGroup` and `$notInGroup` both false. They are logical negations of each other, so they cannot
  both be false for the same input: a user without the attribute is not a member, so `$inGroup` is
  false and `$notInGroup` true. In practice a rule written as an exclusion silently never matched.

  ## Defect 2 — the operators were unreachable for array attributes

  The dispatch branches on the shape of the attribute. `$inGroup`'s condition value is a string (the
  group id), so the array-condition branch never applies; but when the *attribute* is an array,
  control goes to a branch that only handles `$elemMatch` and `$size`, and the group operators are
  never reached. `Common.isIn` already supports array attributes — it simply never got called.

  ## The fix

  - Both operators always return, so neither can fall out of the switch.
  - The group is resolved through a `resolveSavedGroup` helper, mapping an unknown group id, absent
    `savedGroups`, a non-array group value or a non-string group id to an empty group.
  - Both are hoisted above the shape-based dispatch, since their semantics don't depend on the shape
    of the attribute.

  ## Scope note

  The report was about absent attributes only; Defect 2 surfaced while fixing Defect 1, in the same
  two operators, and leaving it would knowingly ship a fix that is still wrong for array attributes.
  Happy to split it out if you'd prefer.

  ## Testing

  15 tests in `SavedGroupOperatorTests` — membership, absence, unknown/empty group, absent
  `savedGroups`, non-string group id, array attributes, plus an explicit check that the pair stays a
  mutual negation. **5 of them fail against current `main`.**

  All 233 `evalCondition` cases of the vendored spec still pass with the fixtures actually loading,
  so conformance does not regress. Test file registered in `project.pbxproj`; `plutil -lint` passes.

  The spec fixtures contain no absent-attribute cases for these operators, which is why neither
  defect was caught — possibly worth adding upstream.