### PR TITLE
feat: add async/await refresh() and evaluate()

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */; };
 		B1A0000000000000000C0005 /* TypedFeatureValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */; };
 		B1A0000000000000000C0007 /* UtilityMethodsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A0000000000000000C0008 /* UtilityMethodsTests.swift */; };
+		CADE7A0000000000000000D1 /* AsyncRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADE7A0000000000000000C1 /* AsyncRefreshTests.swift */; };
 		849952512ACDB676003BBCF7 /* SSEHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952502ACDB676003BBCF7 /* SSEHandler.swift */; };
 		849952572ADD6D66003BBCF7 /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952562ADD6D66003BBCF7 /* EventModel.swift */; };
 		849952592ADD704A003BBCF7 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849952582ADD704A003BBCF7 /* EventHandler.swift */; };
@@ -164,6 +165,7 @@
 		84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingManagerTest.swift; sourceTree = "<group>"; };
 		B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedFeatureValueTests.swift; sourceTree = "<group>"; };
 		B1A0000000000000000C0008 /* UtilityMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityMethodsTests.swift; sourceTree = "<group>"; };
+		CADE7A0000000000000000C1 /* AsyncRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncRefreshTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
 		84622ACF280AC1D70099AED2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -377,6 +379,7 @@
 				84391F1E27FD8C3B003309DC /* CachingManagerTest.swift */,
 				B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */,
 				B1A0000000000000000C0008 /* UtilityMethodsTests.swift */,
+				CADE7A0000000000000000C1 /* AsyncRefreshTests.swift */,
 				848B8043294B5CB900B22168 /* CryptoTests.swift */,
 			);
 			path = GrowthBookTests;
@@ -571,6 +574,7 @@
 				849114CF280DA73100C0B9A5 /* CachingManagerTest.swift in Sources */,
 				B1A0000000000000000C0005 /* TypedFeatureValueTests.swift in Sources */,
 				B1A0000000000000000C0007 /* UtilityMethodsTests.swift in Sources */,
+				CADE7A0000000000000000D1 /* AsyncRefreshTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GrowthBookTests/AsyncRefreshTests.swift
+++ b/GrowthBookTests/AsyncRefreshTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import GrowthBook
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+final class AsyncRefreshTests: XCTestCase {
+
+    private let apiHost = "https://host.com"
+    private let clientKey = "async-refresh-tests"
+
+    private func makeSDK(
+        successResponse: String?,
+        error: SDKError?,
+        refreshHandler: CacheRefreshHandler? = nil
+    ) -> GrowthBookSDK {
+        GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            encryptionKey: nil,
+            attributes: [:],
+            trackingCallback: { _, _ in },
+            refreshHandler: refreshHandler,
+            backgroundSync: false,
+            ttlSeconds: 0 // force a network attempt on every refresh
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: successResponse, error: error))
+        .initializer()
+    }
+
+    func testRefreshSucceeds() async throws {
+        let sdk = makeSDK(successResponse: MockResponse().successResponse, error: nil)
+
+        // Should complete without throwing and apply features.
+        try await sdk.refresh()
+
+        XCTAssertFalse(sdk.getFeatures().isEmpty, "Features should be available after a successful refresh")
+    }
+
+    func testRefreshThrowsOnNetworkFailure() async throws {
+        sdk_clearCache()
+        let sdk = makeSDK(successResponse: nil, error: .failedToLoadData)
+
+        do {
+            try await sdk.refresh()
+            XCTFail("refresh() should throw when the network fetch fails")
+        } catch let error as SDKError {
+            XCTAssertEqual(error.code, .failedToFetchData)
+        }
+    }
+
+    func testRefreshResumesExactlyOnceForConcurrentCallers() async throws {
+        let sdk = makeSDK(successResponse: MockResponse().successResponse, error: nil)
+
+        // Multiple concurrent awaiters must all resume (no hang, no double-resume crash).
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask { try await sdk.refresh() }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    func testExistingRefreshHandlerStillFiresAlongsideAsyncRefresh() async throws {
+        final class Flag: @unchecked Sendable {
+            private let lock = NSLock()
+            private var _count = 0
+            var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
+            func bump() { lock.lock(); _count += 1; lock.unlock() }
+        }
+        let flag = Flag()
+
+        let sdk = makeSDK(
+            successResponse: MockResponse().successResponse,
+            error: nil,
+            refreshHandler: { _ in flag.bump() }
+        )
+        let baseline = flag.count // may include the init-time refresh
+
+        try await sdk.refresh()
+
+        XCTAssertGreaterThan(flag.count, baseline, "The persistent refreshHandler must still fire for an async refresh")
+    }
+
+    private func sdk_clearCache() {
+        CachingManager(apiKey: clientKey).clearCache()
+    }
+}

--- a/GrowthBookTests/AsyncRefreshTests.swift
+++ b/GrowthBookTests/AsyncRefreshTests.swift
@@ -81,6 +81,56 @@ final class AsyncRefreshTests: XCTestCase {
         XCTAssertGreaterThan(flag.count, baseline, "The persistent refreshHandler must still fire for an async refresh")
     }
 
+    // MARK: - evaluate() (remote evaluation)
+
+    private func makeRemoteEvalSDK(successResponse: String?, error: SDKError?) -> GrowthBookSDK {
+        GrowthBookBuilder(
+            apiHost: apiHost,
+            clientKey: clientKey,
+            encryptionKey: nil,
+            attributes: [:],
+            trackingCallback: { _, _ in },
+            refreshHandler: nil,
+            backgroundSync: false,
+            remoteEval: true,
+            ttlSeconds: 0
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: successResponse, error: error))
+        .initializer()
+    }
+
+    func testEvaluateThrowsWhenRemoteEvalDisabled() async {
+        // makeSDK builds an SDK without remoteEval — evaluate() must fail fast, not hang.
+        let sdk = makeSDK(successResponse: MockResponse().successResponse, error: nil)
+        do {
+            try await sdk.evaluate()
+            XCTFail("evaluate() must throw when remote eval is not enabled")
+        } catch let error as SDKError {
+            XCTAssertEqual(error.code, .remoteEvalNotEnabled)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testEvaluateSucceedsWithRemoteEval() async throws {
+        let sdk = makeRemoteEvalSDK(successResponse: MockResponse().successResponse, error: nil)
+        try await sdk.evaluate()
+        XCTAssertFalse(sdk.getFeatures().isEmpty, "Remote eval should apply features on success")
+    }
+
+    func testEvaluateThrowsOnNetworkFailure() async {
+        sdk_clearCache()
+        let sdk = makeRemoteEvalSDK(successResponse: nil, error: .failedToLoadData)
+        do {
+            try await sdk.evaluate()
+            XCTFail("evaluate() should throw on a remote-eval network failure")
+        } catch is SDKError {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
     private func sdk_clearCache() {
         CachingManager(apiKey: clientKey).clearCache()
     }

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -548,9 +548,32 @@ protocol GrowthBookProtocol: AnyObject {
     /// - Note: Swift-only (async/continuation is not representable in Objective-C).
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
     public func refresh() async throws {
+        try await awaitRefreshCycle { [self] in refreshCache() }
+    }
+
+    /// Asynchronously trigger a remote evaluation.
+    ///
+    /// Swift Concurrency wrapper over `refreshForRemoteEval()`: posts the current attributes
+    /// and forced values to the remote-eval endpoint, suspends until the result is applied,
+    /// and rethrows any `SDKError`. Requires the SDK to be configured with `remoteEval: true`;
+    /// otherwise throws `SDKError.remoteEvalNotEnabled` — without this guard the continuation
+    /// would never resume, since `refreshForRemoteEval()` no-ops when remote eval is disabled.
+    ///
+    /// - Note: Swift-only (async/continuation is not representable in Objective-C).
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
+    public func evaluate() async throws {
+        guard contextManager.getGlobalConfig().remoteEval else {
+            throw SDKError.remoteEvalNotEnabled
+        }
+        try await awaitRefreshCycle { [self] in refreshForRemoteEval() }
+    }
+
+    /// Shared continuation plumbing for the async `refresh()` / `evaluate()` APIs. Registers a
+    /// one-shot completion *before* invoking `trigger` (so a synchronous completion is never
+    /// missed) and resumes exactly once when the next refresh cycle finishes.
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
+    private func awaitRefreshCycle(_ trigger: () -> Void) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            // Register the one-shot completion *before* triggering the refresh so a
-            // synchronous completion (e.g. the cache-not-expired path) is never missed.
             withLock {
                 refreshCompletions.append { error in
                     if let error {
@@ -560,7 +583,7 @@ protocol GrowthBookProtocol: AnyObject {
                     }
                 }
             }
-            refreshCache()
+            trigger()
         }
     }
 

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -383,6 +383,10 @@ protocol GrowthBookProtocol: AnyObject {
 @objc public class GrowthBookSDK: NSObject, FeaturesFlowDelegate {
     var refreshHandler: CacheRefreshHandler?
     private var subscriptions: [ExperimentRunCallback] = []
+    /// One-shot completions awaiting the next refresh cycle, used by the async `refresh()`
+    /// API. Kept separate from `refreshHandler` so the async wrapper never overwrites the
+    /// caller's persistent handler. Drained (and cleared) on the next `featuresUpdateIsComplete`.
+    private var refreshCompletions: [(SDKError?) -> Void] = []
     private var networkDispatcher: NetworkProtocol
     private var contextManager: ContextManager
     private var featureVM: FeaturesViewModel!
@@ -531,6 +535,32 @@ protocol GrowthBookProtocol: AnyObject {
             } else {
                 featureVM.fetchFeatures(apiUrl: contextManager.getFeaturesURL())
             }
+        }
+    }
+
+    /// Asynchronously refresh the feature cache.
+    ///
+    /// Swift Concurrency wrapper over `refreshCache()`: suspends until the refresh cycle
+    /// completes and rethrows any `SDKError` reported by the pipeline (e.g. a network
+    /// failure). The callback-based `refreshCache()` and `setRefreshHandler` remain
+    /// available and are not affected — a persistent `refreshHandler` still fires as well.
+    ///
+    /// - Note: Swift-only (async/continuation is not representable in Objective-C).
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
+    public func refresh() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            // Register the one-shot completion *before* triggering the refresh so a
+            // synchronous completion (e.g. the cache-not-expired path) is never missed.
+            withLock {
+                refreshCompletions.append { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                }
+            }
+            refreshCache()
         }
     }
 
@@ -697,6 +727,11 @@ protocol GrowthBookProtocol: AnyObject {
     func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {
         withLock {
             refreshHandler?(error)
+            // Fulfil any pending async refresh() callers. Snapshot-and-clear before
+            // invoking so each completion fires exactly once per refresh cycle.
+            let completions = refreshCompletions
+            refreshCompletions.removeAll()
+            completions.forEach { $0(error) }
         }
     }
 

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -89,6 +89,7 @@ public enum SDKErrorCode: String {
     case failedParsedEncryptedData
     case failedToFetchData
     case invalidAPIURL
+    case remoteEvalNotEnabled
 }
 
 /// GrowthBook Error Class to handle any error / exception scenario
@@ -101,6 +102,7 @@ public enum SDKErrorCode: String {
     static let failedParsedEncryptedData = SDKError(code: .failedParsedEncryptedData)
     static let failedToFetchData = SDKError(code: .failedToFetchData)
     static let invalidAPIURL = SDKError(code: .invalidAPIURL)
+    static let remoteEvalNotEnabled = SDKError(code: .remoteEvalNotEnabled)
 
     static func failedToFetchData(_ error: Error?) -> SDKError { .init(code: .failedToFetchData, underlying: error) }
     


### PR DESCRIPTION
## Summary

  Swift Concurrency wrappers over the existing refresh pipeline:

  - `try await growthBook.refresh()` — over the callback-based `refreshCache()`
  - `try await growthBook.evaluate()` — over `refreshForRemoteEval()`

  Both suspend until the refresh cycle completes and rethrow whatever `SDKError` the
  pipeline reports. Purely additive: the callback API is unchanged and nothing is
  deprecated.

  ## API

  ```swift
  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
  public func refresh() async throws

  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, visionOS 1.0, *)
  public func evaluate() async throws

  do {
      try await growthBook.refresh()
  } catch {
      // SDKError: network failure, invalid URL, ...
  }
```
  ## Implementation

  - Both share a private awaitRefreshCycle(_:) that bridges the pipeline through
  withCheckedThrowingContinuation.
  - One-shot completions live in a list kept separate from the caller's persistent
  refreshHandler, so an async call never overwrites it — a handler set through
  setRefreshHandler still fires. Completions are registered before the refresh is
  triggered (so a synchronous path is not missed) and are snapshot-and-cleared in
  featuresUpdateIsComplete, so each continuation resumes exactly once per cycle.
  - evaluate() guards on remoteEval and throws SDKError.remoteEvalNotEnabled
  otherwise: refreshForRemoteEval() no-ops when remote eval is off, which would
  otherwise leave the continuation suspended forever.

  ## Compatibility

  No breaking changes — refreshCache(), refreshForRemoteEval(), setRefreshHandler
  and the refreshHandler callback all behave exactly as before. refresh() and
  evaluate() are Swift-only, since async is not representable in Objective-C. Adds
  one new SDKErrorCode.remoteEvalNotEnabled case (additive).

  ## Tests

  AsyncRefreshTests — 7 tests: refresh applies features on success; a network failure
  rethrows .failedToFetchData; five concurrent callers all resume (no hang, no double
  resume); a persistent refreshHandler still fires alongside an async refresh; and for
  evaluate() — success, failure, and .remoteEvalNotEnabled when remote eval is off.