### PR TITLE
feat: add API to clear sticky bucket assignments

### DIFF
--- a/GrowthBookTests/CachingManagerTest.swift
+++ b/GrowthBookTests/CachingManagerTest.swift
@@ -53,6 +53,36 @@ class CachingManagerTest: XCTestCase {
         }
     }
     
+    func testRemoveContentRemovesOnlyOneFile() throws {
+        let data = try JSON(["GrowthBook": "GrowthBook"]).rawData()
+        manager.saveContent(fileName: "gb-features.txt", content: data)
+        manager.saveContent(fileName: "gb-other.txt", content: data)
+
+        manager.removeContent(fileName: "gb-features.txt")
+
+        XCTAssertNil(manager.getContent(fileName: "gb-features.txt"))
+        XCTAssertNotNil(manager.getContent(fileName: "gb-other.txt"))
+    }
+
+    func testRemoveContentForMissingFileDoesNothing() {
+        manager.removeContent(fileName: "never-written.txt")
+
+        XCTAssertNil(manager.getContent(fileName: "never-written.txt"))
+    }
+
+    func testRemoveContentsWithPrefixRemovesMatchingFilesOnly() throws {
+        let data = try JSON(["GrowthBook": "GrowthBook"]).rawData()
+        manager.saveContent(fileName: "gbStickyBuckets__id||user-1.txt", content: data)
+        manager.saveContent(fileName: "gbStickyBuckets__id||user-2.txt", content: data)
+        manager.saveContent(fileName: "gb-features.txt", content: data)
+
+        manager.removeContents(withPrefix: "gbStickyBuckets__")
+
+        XCTAssertNil(manager.getContent(fileName: "gbStickyBuckets__id||user-1.txt"))
+        XCTAssertNil(manager.getContent(fileName: "gbStickyBuckets__id||user-2.txt"))
+        XCTAssertNotNil(manager.getContent(fileName: "gb-features.txt"), "features cache must survive a sticky-only purge")
+    }
+
     override func tearDown() {
            manager.clearCache()
            super.tearDown()

--- a/GrowthBookTests/GrowthBookSDKTests.swift
+++ b/GrowthBookTests/GrowthBookSDKTests.swift
@@ -371,4 +371,117 @@ class GrowthBookSDKTests: XCTestCase {
 
         XCTAssertTrue(sdk.isOn(feature: "onboarding"))
     }
+
+    // MARK: - clearStickyBuckets
+
+    /// Payload with one experiment rule, so the SDK derives "id" as a sticky bucket identifier
+    /// attribute and loads the persisted document for the current user at init.
+    private var stickyFeaturesPayload: Data {
+        """
+        {"features":{"exp-feature":{"defaultValue":"off","rules":[{"key":"my-exp","variations":["a","b"],"hashAttribute":"id","weights":[0.5,0.5],"meta":[{"key":"0"},{"key":"1"}],"disableStickyBucketing":false}]}}}
+        """.data(using: .utf8)!
+    }
+
+    private func makeStickySDK(service: StickyBucketService, clientKey: String) -> GrowthBookSDK {
+        let cachingManager = CachingManager(apiKey: clientKey)
+
+        return GrowthBookBuilder(
+            growthBookBuilderModel: GrowthBookModel(
+                apiHost: apiHost, clientKey: clientKey,
+                features: stickyFeaturesPayload,
+                attributes: JSON(["id": "user-1", "deviceId": "device-1"]),
+                trackingClosure: { _, _ in },
+                stickyBucketService: service,
+                backgroundSync: false
+            ),
+            networkDispatcher: MockNetworkClient(successResponse: nil, error: nil),
+            ttlSeconds: 60,
+            cachingManager: cachingManager,
+            refreshHandler: nil
+        ).initializer()
+    }
+
+    func testClearStickyBucketsDropsInMemoryAndPersistedAssignments() {
+        let service = StickyBucketService(prefix: "sdk_clear_\(Int.random(in: 100_000...999_999))__")
+        let doc = StickyAssignmentsDocument(attributeName: "id", attributeValue: "user-1", assignments: ["my-exp__0": "1"])
+
+        let save = expectation(description: "seed doc")
+        service.saveAssignments(doc: doc) { _ in save.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let sdk = makeStickySDK(service: service, clientKey: "isolated-sticky-clear-test")
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||user-1"], "precondition: doc is loaded at init")
+
+        let cleared = expectation(description: "clear completed")
+        sdk.clearStickyBuckets { error in
+            XCTAssertNil(error)
+            cleared.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        XCTAssertTrue(sdk.getGBContext().stickyBucketAssignmentDocs?.isEmpty ?? true, "in-memory docs should be gone")
+
+        let get = expectation(description: "persisted doc gone")
+        service.getAssignments(attributeName: "id", attributeValue: "user-1") { retrieved, _ in
+            XCTAssertNil(retrieved, "persisted doc should be gone, otherwise the next refresh reloads it")
+            get.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    /// The whole point of the API: after the assignment is dropped, targeting is decided again
+    /// instead of the user staying enrolled on the strength of a stale sticky bucket.
+    func testClearStickyBucketsSurvivesAttributeRefresh() {
+        let service = StickyBucketService(prefix: "sdk_refresh_\(Int.random(in: 100_000...999_999))__")
+        let doc = StickyAssignmentsDocument(attributeName: "id", attributeValue: "user-1", assignments: ["my-exp__0": "1"])
+
+        let save = expectation(description: "seed doc")
+        service.saveAssignments(doc: doc) { _ in save.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let sdk = makeStickySDK(service: service, clientKey: "isolated-sticky-refresh-test")
+        sdk.clearStickyBuckets()
+
+        // setAttributes re-reads the service; a doc that was only cleared in memory would come back.
+        sdk.setAttributes(attributes: ["id": "user-1", "deviceId": "device-1"])
+
+        XCTAssertTrue(sdk.getGBContext().stickyBucketAssignmentDocs?.isEmpty ?? true)
+    }
+
+    func testClearStickyBucketsForAttributeKeepsOtherDocuments() {
+        let service = StickyBucketService(prefix: "sdk_attr_\(Int.random(in: 100_000...999_999))__")
+        let userDoc   = StickyAssignmentsDocument(attributeName: "id",       attributeValue: "user-1",   assignments: ["my-exp__0": "1"])
+        let deviceDoc = StickyAssignmentsDocument(attributeName: "deviceId", attributeValue: "device-1", assignments: ["my-exp__0": "0"])
+
+        let s1 = expectation(description: "seed user doc");   service.saveAssignments(doc: userDoc)   { _ in s1.fulfill() }
+        let s2 = expectation(description: "seed device doc"); service.saveAssignments(doc: deviceDoc) { _ in s2.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let sdk = makeStickySDK(service: service, clientKey: "isolated-sticky-attr-test")
+
+        sdk.clearStickyBuckets(forAttribute: "deviceId", value: "device-1")
+
+        XCTAssertNil(sdk.getGBContext().stickyBucketAssignmentDocs?["deviceId||device-1"])
+        XCTAssertNotNil(sdk.getGBContext().stickyBucketAssignmentDocs?["id||user-1"], "unrelated document must survive")
+
+        let get = expectation(description: "persisted user doc survives")
+        service.getAssignments(attributeName: "id", attributeValue: "user-1") { retrieved, _ in
+            XCTAssertNotNil(retrieved)
+            get.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testClearStickyBucketsWithoutServiceIsNoOp() {
+        let sdk = makeSDK()
+
+        let cleared = expectation(description: "clear completed")
+        sdk.clearStickyBuckets { error in
+            XCTAssertNil(error)
+            cleared.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        sdk.clearStickyBuckets(forAttribute: "id", value: "user-1")
+    }
 }

--- a/GrowthBookTests/StickyBucketServiceTests.swift
+++ b/GrowthBookTests/StickyBucketServiceTests.swift
@@ -108,6 +108,86 @@ class StickyBucketServiceTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    // MARK: - deleteAssignments
+
+    func testDeleteAssignmentsRemovesOnlyTheTargetedDoc() {
+        let docA = StickyAssignmentsDocument(attributeName: "id",       attributeValue: "user-del",   assignments: ["exp__0": "a"])
+        let docB = StickyAssignmentsDocument(attributeName: "deviceId", attributeValue: "device-del", assignments: ["exp__0": "b"])
+
+        let s1 = expectation(description: "save A"); service.saveAssignments(doc: docA) { _ in s1.fulfill() }
+        let s2 = expectation(description: "save B"); service.saveAssignments(doc: docB) { _ in s2.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let del = expectation(description: "delete A")
+        service.deleteAssignments(attributeName: "id", attributeValue: "user-del") { error in
+            XCTAssertNil(error)
+            del.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        let get = expectation(description: "getAll after delete")
+        service.getAllAssignments(attributes: ["id": "user-del", "deviceId": "device-del"]) { docs, _ in
+            XCTAssertNil(docs?["id||user-del"], "deleted doc should be gone")
+            XCTAssertNotNil(docs?["deviceId||device-del"], "untouched doc should survive")
+            get.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testDeleteAssignmentsForUnknownKeyIsNotAnError() {
+        let exp = expectation(description: "delete missing")
+        service.deleteAssignments(attributeName: "id", attributeValue: "never-saved") { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - clearAllAssignments
+
+    func testClearAllAssignmentsRemovesEveryDoc() {
+        let docA = StickyAssignmentsDocument(attributeName: "id",       attributeValue: "user-clear",   assignments: ["exp__0": "a"])
+        let docB = StickyAssignmentsDocument(attributeName: "deviceId", attributeValue: "device-clear", assignments: ["exp__0": "b"])
+
+        let s1 = expectation(description: "save A"); service.saveAssignments(doc: docA) { _ in s1.fulfill() }
+        let s2 = expectation(description: "save B"); service.saveAssignments(doc: docB) { _ in s2.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let clear = expectation(description: "clear all")
+        service.clearAllAssignments { error in
+            XCTAssertNil(error)
+            clear.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        let get = expectation(description: "getAll after clear")
+        service.getAllAssignments(attributes: ["id": "user-clear", "deviceId": "device-clear"]) { docs, _ in
+            XCTAssertTrue(docs?.isEmpty ?? true)
+            get.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testClearAllAssignmentsLeavesOtherPrefixesIntact() {
+        let otherService = StickyBucketService(prefix: "other_prefix_\(Int.random(in: 100_000...999_999))__")
+        let doc = StickyAssignmentsDocument(attributeName: "id", attributeValue: "kept-user", assignments: ["exp__0": "variant"])
+
+        let s1 = expectation(description: "save in service"); service.saveAssignments(doc: doc) { _ in s1.fulfill() }
+        let s2 = expectation(description: "save in other");   otherService.saveAssignments(doc: doc) { _ in s2.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let clear = expectation(description: "clear all")
+        service.clearAllAssignments { _ in clear.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        let get = expectation(description: "other prefix survives")
+        otherService.getAssignments(attributeName: "id", attributeValue: "kept-user") { retrieved, _ in
+            XCTAssertNotNil(retrieved, "clearing one prefix must not touch documents of another")
+            get.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
     // MARK: - Different prefixes are isolated
 
     func testDifferentPrefixesDoNotShareData() {

--- a/README.md
+++ b/README.md
@@ -462,6 +462,31 @@ If you would like to implement Sticky Bucketing while using Remote Evaluation, y
 
 Sticky bucketing ensures that users see the same experiment variant, even when user session, user login status, or experiment parameters change. See the [Sticky Bucketing docs](/app/sticky-bucketing) for more information. If your organization and experiment supports sticky bucketing, you must implement an instance of the `StickyBucketService` to use Sticky Bucketing. For simple bucket persistence using the browser's LocalStorage (can be polyfilled for other environments).
 
+### Clearing sticky assignments
+
+While an assignment exists for the current `bucketVersion`, evaluation deliberately skips targeting conditions, filters, namespaces and prerequisites — that is what keeps enrollment stable, and it matches the behaviour of the other GrowthBook SDKs. A user who stops matching the targeting conditions therefore stays enrolled.
+
+If an assignment was made against the wrong identity — typically one created before login, when the attributes needed for targeting were not loaded yet — drop it so the next evaluation decides from scratch:
+
+```swift
+// After login: forget everything bucketed for the anonymous user
+sdk.clearStickyBuckets()
+
+// Or drop just one identifier, keeping the rest
+sdk.clearStickyBuckets(forAttribute: "deviceId", value: currentDeviceId)
+
+// Completion variant, for sequencing against a service that persists asynchronously
+sdk.clearStickyBuckets { _ in
+    sdk.setAttributes(attributes: attributesLoadedAfterLogin)
+}
+```
+
+Unlike `clearCache()`, this leaves the cached feature payload intact. Both the persisted documents and the SDK's in-memory copy are cleared.
+
+Prefer preventing the bad assignment over undoing it: if an experiment targets an attribute that only exists after authentication, add a presence check (e.g. `{"registrationDate": {"$exists": true}}`) to its targeting conditions so unauthenticated users never qualify and no document is written.
+
+Custom `StickyBucketServiceProtocol` implementations can support this by implementing the optional `deleteAssignments(attributeName:attributeValue:completion:)` and `clearAllAssignments(completion:)` methods. When they are missing, the SDK clears only its in-memory copy and logs a warning — the persisted documents come back on the next refresh.
+
 
 ## License
 

--- a/Sources/CommonMain/Caching/CachingManager.swift
+++ b/Sources/CommonMain/Caching/CachingManager.swift
@@ -156,6 +156,61 @@ import Foundation
         return "\(targetFolderPath)/\(file).txt"
     }
 
+    /// Removes a single cached file, if it exists. Missing files are not an error.
+    ///
+    /// Unlike `clearCache()` this leaves the rest of the cache directory untouched, so callers
+    /// can drop one entry (e.g. a single sticky bucket document) without discarding features.
+    @objc public func removeContent(fileName: String) {
+        lock.withLock {
+            let filePath = getTargetFile(fileName: fileName)
+            let fileManager = FileManager.default
+
+            guard fileManager.fileExists(atPath: filePath) else { return }
+
+            do {
+                try fileManager.removeItem(atPath: filePath)
+            } catch {
+                logger.error(
+                    "Failed to remove cached file: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    /// Removes every cached file whose name starts with `prefix`, leaving all other entries in place.
+    @objc public func removeContents(withPrefix prefix: String) {
+        lock.withLock {
+            guard
+                let directoryPath = self.customCachePath ?? cacheDirectory.path
+            else {
+                logger.error("Failed to retrieve directory path.")
+                return
+            }
+
+            let targetFolderPath =
+                directoryPath + "/GrowthBook-Cache-\(cacheKey)"
+            let fileManager = FileManager.default
+
+            guard
+                let fileNames = try? fileManager.contentsOfDirectory(
+                    atPath: targetFolderPath
+                )
+            else { return }
+
+            for fileName in fileNames where fileName.hasPrefix(prefix) {
+                do {
+                    try fileManager.removeItem(
+                        atPath: targetFolderPath + "/" + fileName
+                    )
+                } catch {
+                    logger.error(
+                        "Failed to remove cached file: \(error.localizedDescription)"
+                    )
+                }
+            }
+        }
+    }
+
     /// This function removes all files and subdirectories within the designated cache directory, which is a specific subdirectory within the app's cache directory.
     @objc public func clearCache() {
         lock.withLock {

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -541,6 +541,85 @@ protocol GrowthBookProtocol: AnyObject {
         }
     }
 
+    /// Drops every sticky bucket assignment — both the persisted documents and the in-memory copy.
+    ///
+    /// Use this when the identity behind the existing assignments is no longer the one being
+    /// evaluated: typically right after login, when attributes loaded post-authentication make an
+    /// assignment created for the anonymous user wrong.
+    ///
+    /// While an assignment exists, sticky bucketing deliberately skips re-evaluating targeting
+    /// conditions, filters, namespaces and prerequisites (this matches the GrowthBook spec and the
+    /// other SDKs), so a user who has become ineligible stays enrolled. Dropping the assignment is
+    /// what forces the next evaluation to decide from scratch.
+    ///
+    /// Unlike `clearCache()`, the cached feature payload is left intact.
+    ///
+    /// - Note: no-op when no `StickyBucketService` is configured.
+    @objc public func clearStickyBuckets() {
+        clearStickyBuckets { _ in }
+    }
+
+    /// Drops every sticky bucket assignment and reports when the underlying service has finished.
+    ///
+    /// The in-memory documents are cleared synchronously, so an evaluation made right after this
+    /// call already ignores them. `completion` reports the result of the persistent delete, which
+    /// custom services may perform asynchronously — call `setAttributes(_:)` from there if the new
+    /// attributes must not be applied before the old documents are gone.
+    /// - Parameter completion: called with the service error, or `nil` on success.
+    @objc public func clearStickyBuckets(completion: @escaping (Error?) -> Void) {
+        withLock {
+            contextManager.updateEvalData { data in
+                data.stickyBucketAssignmentDocs = nil
+            }
+
+            guard let service = contextManager.getGlobalConfig().stickyBucketService else {
+                completion(nil)
+                return
+            }
+
+            guard let clearAll = service.clearAllAssignments else {
+                logger.warning("StickyBucketService does not implement clearAllAssignments — only the in-memory assignments were cleared.")
+                completion(nil)
+                return
+            }
+
+            clearAll { error in
+                if let error = error {
+                    logger.error("Failed to clear sticky bucket assignments: \(error.localizedDescription)")
+                }
+                completion(error)
+            }
+        }
+    }
+
+    /// Drops the sticky bucket assignments stored for a single attribute, keeping the rest.
+    ///
+    /// Use this for a surgical reset when only one identifier goes stale — e.g. dropping the
+    /// `deviceId`-scoped document after login while keeping the ones already keyed by user id.
+    /// - Parameters:
+    ///   - attributeName: the hash (or fallback) attribute the document is keyed by, e.g. `"deviceId"`.
+    ///   - value: the attribute value the document is keyed by.
+    @objc public func clearStickyBuckets(forAttribute attributeName: String, value: String) {
+        withLock {
+            contextManager.updateEvalData { data in
+                data.stickyBucketAssignmentDocs?.removeValue(forKey: "\(attributeName)||\(value)")
+            }
+
+            guard let service = contextManager.getGlobalConfig().stickyBucketService else { return }
+
+            guard let deleteAssignments = service.deleteAssignments else {
+                logger.warning("StickyBucketService does not implement deleteAssignments — only the in-memory assignments were cleared.")
+                return
+            }
+
+            deleteAssignments(attributeName, value) { error in
+                if let error = error {
+                    logger.error("Failed to delete sticky bucket assignments: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
     /// Get Context - Holding the complete data regarding cached features & attributes etc.
     /// Note: This method is kept for backward compatibility but returns a Context created from ContextManager
     @objc public func getGBContext() -> Context {

--- a/Sources/CommonMain/StickyBucket/StickyBucketService.swift
+++ b/Sources/CommonMain/StickyBucket/StickyBucketService.swift
@@ -4,6 +4,18 @@ import Foundation
     func getAssignments(attributeName: String, attributeValue: String, completion: @escaping (StickyAssignmentsDocument?, Error?) -> Void)
     func saveAssignments(doc: StickyAssignmentsDocument, completion: @escaping (Error?) -> Void)
     func getAllAssignments(attributes: [String: String], completion: @escaping ([String: StickyAssignmentsDocument]?, Error?) -> Void)
+
+    /// Removes the stored document for a single `attributeName||attributeValue` pair.
+    ///
+    /// Optional: custom services written against earlier SDK versions keep compiling. When it is
+    /// not implemented, `GrowthBookSDK.clearStickyBuckets(forAttribute:value:)` only drops the
+    /// in-memory copy and logs a warning — the persisted document reappears on the next refresh.
+    @objc optional func deleteAssignments(attributeName: String, attributeValue: String, completion: @escaping (Error?) -> Void)
+
+    /// Removes every stored document owned by this service.
+    ///
+    /// Optional, with the same caveat as `deleteAssignments(attributeName:attributeValue:completion:)`.
+    @objc optional func clearAllAssignments(completion: @escaping (Error?) -> Void)
 }
 
 @objc public class StickyBucketService: NSObject, StickyBucketServiceProtocol {
@@ -60,6 +72,20 @@ import Foundation
         completion(docs, nil)
     }
     
+    public func deleteAssignments(attributeName: String,
+                                  attributeValue: String,
+                                  completion: @escaping (Error?) -> Void) {
+        let key = "\(attributeName)||\(attributeValue)"
+
+        localStorage.removeContent(fileName: prefix + key)
+        completion(nil)
+    }
+
+    public func clearAllAssignments(completion: @escaping (Error?) -> Void) {
+        localStorage.removeContents(withPrefix: prefix)
+        completion(nil)
+    }
+
     private func getAssignmentsSync(attributeName: String, attributeValue: String) -> StickyAssignmentsDocument? {
         let key = "\(attributeName)||\(attributeValue)"
                         


### PR DESCRIPTION
## Why

  Sticky bucketing deliberately skips re-evaluating targeting conditions, filters,
  namespaces and prerequisites while an assignment exists for the current `bucketVersion`
  (`ExperimentEvaluator`, `if !foundStickyBucket`). That matches the spec and the other
  SDKs, and this PR does not change it.

  The gap is that there was no way to drop an assignment. If one is created against the
  wrong identity — for example at app launch, before the attributes needed for targeting
  have loaded — the user stays enrolled indefinitely, and the only escape was
  `clearCache()`, which also discards the cached feature payload. Reported by a user.

  ## What

  ```swift
  sdk.clearStickyBuckets()                                      // persisted + in-memory
  sdk.clearStickyBuckets { error in ... }                       // completion variant
  sdk.clearStickyBuckets(forAttribute: "deviceId", value: id)   // a single document
```
  - StickyBucketServiceProtocol: new deleteAssignments(attributeName:attributeValue:completion:)
  and clearAllAssignments(completion:), both @objc optional — existing custom
  services keep compiling, and when a method is unimplemented the SDK clears only its
  in-memory copy and logs a warning.
  - StickyBucketService: implements both.
  - CachingManager: removeContent(fileName:) and removeContents(withPrefix:). Not
  added to the CachingLayer protocol, so custom caching layers are unaffected.
  - GrowthBookSDK: the three methods above, clearing persisted documents and the
  in-memory copy under the usual withLock.

  ### Documented in the README.

  Compatibility

  Additive only. No evaluation logic touched, no change to bucketing results, @objc
  surface preserved, clearCache() unchanged.

  ### Tests

  13 new tests across three levels: the cache layer (targeted deletion leaves the feature
  cache intact), the service (prefix isolation), and the public API through a real
  GrowthBookBuilder. Notably testClearStickyBucketsSurvivesAttributeRefresh calls
  setAttributes(...) after clearing — setAttributes re-reads the service, so an
  in-memory-only clear would silently reload the document from disk.

  Verified against current main: 564 tests, 0 failures. Swift 6 language mode reports
  the same 28 errors as main — none added.