### PR TITLE
feat: consume contextual bandit payload

### DIFF
--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		15147AEF2F7E746400FC9112 /* GrowthBookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15147AEE2F7E746300FC9112 /* GrowthBookModel.swift */; };
 		231FB2292910F78D0035546E /* json.json in Resources */ = {isa = PBXBuildFile; fileRef = 84391F2628016C85003309DC /* json.json */; };
+		843317122910F78D0035546E /* local-cases.json in Resources */ = {isa = PBXBuildFile; fileRef = 8433171328016C85003309DC /* local-cases.json */; };
 		5D5EAD1D2EF1DEA70049F432 /* LruETagCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5EAD1C2EF1DEA70049F432 /* LruETagCache.swift */; };
 		5D5EAD1F2EF1DED60049F432 /* LruETagCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5EAD1E2EF1DED60049F432 /* LruETagCacheTests.swift */; };
 		84095C792817EC7800ADDF19 /* JsonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84095C772817EAB700ADDF19 /* JsonManager.swift */; };
@@ -41,6 +42,7 @@
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
 		84CB1A012FB0000100AA0001 /* ContextualBandit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB1A002FB0000100AA0001 /* ContextualBandit.swift */; };
 		84CB1A032FB0000200AA0001 /* ContextualBanditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB1A022FB0000200AA0001 /* ContextualBanditTests.swift */; };
+		843317102FB0000200AA0001 /* ContextualBanditSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843317112FB0000200AA0001 /* ContextualBanditSpecTests.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
 		8484CC0C2817D7230092A39B /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8043294B5CB900B22168 /* CryptoTests.swift */; };
@@ -167,6 +169,7 @@
 		B1A0000000000000000C0006 /* TypedFeatureValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedFeatureValueTests.swift; sourceTree = "<group>"; };
 		B1A0000000000000000C0008 /* UtilityMethodsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityMethodsTests.swift; sourceTree = "<group>"; };
 		84391F2628016C85003309DC /* json.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = json.json; sourceTree = "<group>"; };
+		8433171328016C85003309DC /* local-cases.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "local-cases.json"; sourceTree = "<group>"; };
 		844838342E054AD200784A36 /* NetworkRetryHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetryHandler.swift; sourceTree = "<group>"; };
 		84622ACF280AC1D70099AED2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84628062280DAE2900C83CDE /* Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
@@ -175,6 +178,7 @@
 		846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalContext.swift; sourceTree = "<group>"; };
 		84CB1A002FB0000100AA0001 /* ContextualBandit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualBandit.swift; sourceTree = "<group>"; };
 		84CB1A022FB0000200AA0001 /* ContextualBanditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualBanditTests.swift; sourceTree = "<group>"; };
+		843317112FB0000200AA0001 /* ContextualBanditSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualBanditSpecTests.swift; sourceTree = "<group>"; };
 		8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptionUtils.swift; sourceTree = "<group>"; };
 		848B8043294B5CB900B22168 /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		849114BD280DA71E00C0B9A5 /* GrowthBookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowthBookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -344,6 +348,7 @@
 			isa = PBXGroup;
 			children = (
 				84391F2628016C85003309DC /* json.json */,
+				8433171328016C85003309DC /* local-cases.json */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -358,6 +363,7 @@
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
 				84CB1C002FB2000100AA0001 /* SavedGroupOperatorTests.swift */,
 				84CB1A022FB0000200AA0001 /* ContextualBanditTests.swift */,
+				843317112FB0000200AA0001 /* ContextualBanditSpecTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
 				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
 				8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */,
@@ -529,6 +535,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				231FB2292910F78D0035546E /* json.json in Resources */,
+				843317122910F78D0035546E /* local-cases.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -559,6 +566,7 @@
 				843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */,
 				84CB1C012FB2000100AA0001 /* SavedGroupOperatorTests.swift in Sources */,
 				84CB1A032FB0000200AA0001 /* ContextualBanditTests.swift in Sources */,
+				843317102FB0000200AA0001 /* ContextualBanditSpecTests.swift in Sources */,
 				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
 				8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */,

--- a/GrowthBook-IOS.xcodeproj/project.pbxproj
+++ b/GrowthBook-IOS.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		8433161F2FA9FFB000D1C388 /* GrowthBookTrackingPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8433161E2FA9FFB000D1C388 /* GrowthBookTrackingPluginTests.swift */; };
 		844838362E054AD200784A36 /* NetworkRetryHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844838342E054AD200784A36 /* NetworkRetryHandler.swift */; };
 		846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */; };
+		84CB1A012FB0000100AA0001 /* ContextualBandit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB1A002FB0000100AA0001 /* ContextualBandit.swift */; };
+		84CB1A032FB0000200AA0001 /* ContextualBanditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB1A022FB0000200AA0001 /* ContextualBanditTests.swift */; };
 		8483E6FA2ABC60B900306B55 /* DecryptionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */; };
 		8484CC0C2817D7230092A39B /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		848B8044294B5CB900B22168 /* CryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B8043294B5CB900B22168 /* CryptoTests.swift */; };
@@ -171,6 +173,8 @@
 		846280E7280DBE9C00C83CDE /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		84628147280F2AC400C83CDE /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalContext.swift; sourceTree = "<group>"; };
+		84CB1A002FB0000100AA0001 /* ContextualBandit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualBandit.swift; sourceTree = "<group>"; };
+		84CB1A022FB0000200AA0001 /* ContextualBanditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualBanditTests.swift; sourceTree = "<group>"; };
 		8483E6F92ABC60B900306B55 /* DecryptionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptionUtils.swift; sourceTree = "<group>"; };
 		848B8043294B5CB900B22168 /* CryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoTests.swift; sourceTree = "<group>"; };
 		849114BD280DA71E00C0B9A5 /* GrowthBookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GrowthBookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -324,6 +328,7 @@
 			isa = PBXGroup;
 			children = (
 				846A7A552D6CAE53007CCFD1 /* GlobalContext.swift */,
+				84CB1A002FB0000100AA0001 /* ContextualBandit.swift */,
 				8433640827F845EB0072BFDC /* Feature.swift */,
 				8433640927F845EB0072BFDC /* Experiment.swift */,
 				8433640A27F845EB0072BFDC /* Context.swift */,
@@ -352,6 +357,7 @@
 				843316132FA3F9B900D1C388 /* ExperimentEvaluatorTests.swift */,
 				843316112FA3F76100D1C388 /* FeatureEvaluatorTests.swift */,
 				84CB1C002FB2000100AA0001 /* SavedGroupOperatorTests.swift */,
+				84CB1A022FB0000200AA0001 /* ContextualBanditTests.swift */,
 				8433160F2FA3F3AE00D1C388 /* ConditionEvaluatorTests.swift */,
 				843316092FA2B6AD00D1C388 /* ConstantsAndModelTests.swift */,
 				8433160A2FA2B6AD00D1C388 /* ExtensionsTests.swift */,
@@ -552,6 +558,7 @@
 				843316182FA3FD1800D1C388 /* MiscCoverageTests.swift in Sources */,
 				843316122FA3F76100D1C388 /* FeatureEvaluatorTests.swift in Sources */,
 				84CB1C012FB2000100AA0001 /* SavedGroupOperatorTests.swift in Sources */,
+				84CB1A032FB0000200AA0001 /* ContextualBanditTests.swift in Sources */,
 				843315FE2FA22A1B00D1C388 /* FeatureModelTests.swift in Sources */,
 				843315FF2FA22A1B00D1C388 /* CommonTests.swift in Sources */,
 				8433160C2FA2B6AD00D1C388 /* ExtensionsTests.swift in Sources */,
@@ -604,6 +611,7 @@
 				84CDE33F2812F454008B3E6F /* ConditionEvaluator.swift in Sources */,
 				84CDE3402812F454008B3E6F /* CachingManager.swift in Sources */,
 				846A7A562D6CAE56007CCFD1 /* GlobalContext.swift in Sources */,
+				84CB1A012FB0000100AA0001 /* ContextualBandit.swift in Sources */,
 				84CDE3412812F454008B3E6F /* Feature.swift in Sources */,
 				84AE3B1B2BE2466C006BA49B /* StickyAssignmentsDocument.swift in Sources */,
 				84095C792817EC7800ADDF19 /* JsonManager.swift in Sources */,

--- a/GrowthBookTests/ConditionTests.swift
+++ b/GrowthBookTests/ConditionTests.swift
@@ -7,7 +7,9 @@ class ConditionTests: XCTestCase {
     var evalConditions: [JSON]?
 
     override func setUp() {
-        evalConditions = TestHelper().getEvalConditionData()
+        let helper = TestHelper()
+        // The canonical corpus plus the cases this fork keeps on its own (see getLocalEvalConditionData).
+        evalConditions = (helper.getEvalConditionData() ?? []) + (helper.getLocalEvalConditionData() ?? [])
     }
 
     func testConditions() throws {

--- a/GrowthBookTests/ContextualBanditSpecTests.swift
+++ b/GrowthBookTests/ContextualBanditSpecTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import GrowthBook
+
+/// Runs the `contextualBandit` section of the vendored conformance suite.
+///
+/// The existing `feature` runner cannot be reused: these cases assert the bandit fields the SDK adds
+/// to the result (`leafId`, `variationWeights`, `banditVersion`) and the selection recorded on the
+/// experiment, none of which `FeatureResultTest` models. They also carry `contextualBandits`,
+/// `qaMode`, `enabled` and `url` in the case context.
+///
+/// A field is only compared when the case declares it, so cases that deliberately omit
+/// `banditVersion` assert its absence rather than accidentally passing.
+class ContextualBanditSpecTests: XCTestCase {
+
+    func testContextualBanditSpec() throws {
+        guard let cases = TestHelper().getContextualBanditData(), !cases.isEmpty else {
+            XCTFail("contextualBandit section is missing from the conformance fixtures")
+            return
+        }
+
+        var failures: [String] = []
+
+        for testCase in cases {
+            let name = testCase[0].stringValue
+            let input = testCase[1].dictionaryValue
+            let featureKey = testCase[2].stringValue
+            let expected = testCase[3].dictionaryValue
+
+            let result = evaluate(input: input, featureKey: featureKey)
+            let mismatches = compare(result: result, expected: expected)
+
+            if !mismatches.isEmpty {
+                failures.append("• \(name)\n    " + mismatches.joined(separator: "\n    "))
+            }
+        }
+
+        if !failures.isEmpty {
+            XCTFail("\(failures.count) of \(cases.count) contextual bandit cases failed:\n"
+                    + failures.joined(separator: "\n"))
+        }
+    }
+
+    // MARK: - Evaluation
+
+    private func evaluate(input: [String: JSON], featureKey: String) -> FeatureResult {
+        let testData = FeaturesTest(json: input)
+
+        let context = Context(
+            apiHost: nil,
+            streamingHost: nil,
+            clientKey: nil,
+            encryptionKey: nil,
+            isEnabled: input["enabled"]?.bool ?? true,
+            attributes: testData.attributes,
+            forcedVariations: testData.forcedVariations,
+            isQaMode: input["qaMode"]?.bool ?? false,
+            trackingClosure: { _, _ in },
+            backgroundSync: false,
+            savedGroups: testData.savedGroups,
+            contextualBandits: input["contextualBandits"],
+            url: input["url"]?.string
+        )
+        if let features = testData.features {
+            context.features = features
+        }
+
+        let evalContext = Utils.initializeEvalContext(context: context)
+        return FeatureEvaluator(context: evalContext, featureKey: featureKey).evaluateFeature()
+    }
+
+    // MARK: - Comparison
+
+    private func compare(result: FeatureResult, expected: [String: JSON]) -> [String] {
+        var mismatches: [String] = []
+
+        func check<T: Equatable>(_ field: String, _ actual: T?, _ expectedValue: T?) {
+            if actual != expectedValue {
+                mismatches.append("\(field): expected \(describe(expectedValue)), got \(describe(actual))")
+            }
+        }
+
+        if let value = expected["value"] { check("value", result.value, value) }
+        if let on = expected["on"] { check("on", result.isOn, on.boolValue) }
+        if let off = expected["off"] { check("off", result.isOff, off.boolValue) }
+        if let source = expected["source"] { check("source", result.source, source.stringValue) }
+        if let ruleId = expected["ruleId"] { check("ruleId", result.ruleId ?? "", ruleId.stringValue) }
+
+        // The experiment is only asserted for its key and the bandit selection attached to it; the
+        // rest of its fields are echoes of the rule and are already covered by the feature section.
+        if let experiment = expected["experiment"]?.dictionary {
+            check("experiment.key", result.experiment?.key, experiment["key"]?.stringValue)
+            check("experiment.weights", result.experiment?.weights,
+                  experiment["weights"].map { JSON.convertToArrayFloat(jsonArray: $0.arrayValue) })
+
+            if let bandit = experiment["contextualBandit"]?.dictionary {
+                let actual = result.experiment?.contextualBandit
+                check("experiment.contextualBandit.leafId", actual?.leafId, bandit["leafId"]?.int)
+                check("experiment.contextualBandit.variationWeights", actual?.variationWeights,
+                      bandit["variationWeights"].map { JSON.convertToArrayFloat(jsonArray: $0.arrayValue) })
+                check("experiment.contextualBandit.banditVersion", actual?.banditVersion, bandit["banditVersion"]?.int)
+            } else if result.experiment?.contextualBandit != nil {
+                mismatches.append("experiment.contextualBandit: expected none, got a selection")
+            }
+        }
+
+        if let expectedResult = expected["experimentResult"]?.dictionary {
+            let actual = result.experimentResult
+            check("experimentResult.variationId", actual?.variationId, expectedResult["variationId"]?.int)
+            check("experimentResult.key", actual?.key, expectedResult["key"]?.stringValue)
+            check("experimentResult.value", actual?.value, expectedResult["value"])
+            check("experimentResult.inExperiment", actual?.inExperiment, expectedResult["inExperiment"]?.bool)
+            check("experimentResult.hashUsed", actual?.hashUsed, expectedResult["hashUsed"]?.bool)
+            check("experimentResult.hashAttribute", actual?.hashAttribute, expectedResult["hashAttribute"]?.string)
+            check("experimentResult.hashValue", actual?.valueHash, expectedResult["hashValue"]?.string)
+            check("experimentResult.featureId", actual?.featureId, expectedResult["featureId"]?.string)
+            check("experimentResult.stickyBucketUsed", actual?.stickyBucketUsed, expectedResult["stickyBucketUsed"]?.bool)
+            if let bucket = expectedResult["bucket"]?.float {
+                check("experimentResult.bucket", actual?.bucket, bucket)
+            }
+            // Declared explicitly so an omitted field asserts absence.
+            check("experimentResult.leafId", actual?.leafId, expectedResult["leafId"]?.int)
+            check("experimentResult.variationWeights", actual?.variationWeights,
+                  expectedResult["variationWeights"].map { JSON.convertToArrayFloat(jsonArray: $0.arrayValue) })
+            check("experimentResult.banditVersion", actual?.banditVersion, expectedResult["banditVersion"]?.int)
+        } else if result.experimentResult != nil, expected["experiment"] == nil {
+            mismatches.append("experimentResult: expected none, got one")
+        }
+
+        return mismatches
+    }
+
+    private func describe<T>(_ value: T?) -> String {
+        guard let value else { return "nil" }
+        return "\(value)"
+    }
+}

--- a/GrowthBookTests/ContextualBanditTests.swift
+++ b/GrowthBookTests/ContextualBanditTests.swift
@@ -740,6 +740,33 @@ class ContextualBanditTests: XCTestCase {
         XCTAssertFalse(Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil).contains("shouldNotAppear"))
     }
 
+    // MARK: - Legacy Context bridge
+
+    /// `Utils.initializeEvalContext` builds an `EvalContext` from the legacy `Context`. It must carry
+    /// the bandits across, otherwise anything going through that bridge evaluates bandit rules with
+    /// no definitions and silently falls back to aggregate weights.
+    func testLegacyContextBridgeCarriesContextualBandits() {
+        let context = Context(
+            apiHost: nil, streamingHost: nil, clientKey: nil, encryptionKey: nil,
+            isEnabled: true,
+            attributes: JSON(["id": "user-1", "country": "CA"]),
+            forcedVariations: nil,
+            isQaMode: false,
+            trackingClosure: { _, _ in },
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            contextualBandits: twoLeafBandits()
+        )
+
+        let evalContext = Utils.initializeEvalContext(context: context)
+
+        XCTAssertEqual(evalContext.globalContext.contextualBandits?["bandit-1"]["banditVersion"].intValue, 7)
+
+        // And end to end through that context: the leaf must actually be applied.
+        let result = FeatureEvaluator(context: evalContext, featureKey: "my-feature").evaluateFeature()
+        XCTAssertEqual(result.experimentResult?.leafId, 2)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
     // MARK: - Context plumbing
 
     func testContextManagerPropagatesContextualBanditsToEvalContext() {

--- a/GrowthBookTests/ContextualBanditTests.swift
+++ b/GrowthBookTests/ContextualBanditTests.swift
@@ -1,0 +1,724 @@
+import XCTest
+@testable import GrowthBook
+
+/// Covers consumption of the contextual bandit payload: leaf selection by condition, weight
+/// application before bucketing, fallback behaviour, and enrichment of the experiment result.
+///
+/// All weight recomputation happens on the GrowthBook backend — the SDK only picks the matching
+/// leaf and applies its ready weights, so these tests assert selection and application, not any
+/// optimisation behaviour.
+class ContextualBanditTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeContext(
+        features: Features = [:],
+        attributes: JSON = JSON(["id": "user-1"]),
+        contextualBandits: JSON? = nil,
+        savedGroups: JSON? = nil,
+        forcedVariations: JSON? = nil,
+        isQaMode: Bool = false
+    ) -> EvalContext {
+        let globalContext = GlobalContext(
+            features: features,
+            savedGroups: savedGroups,
+            contextualBandits: contextualBandits
+        )
+        let userContext = UserContext(attributes: attributes, forcedVariations: forcedVariations)
+        let options = ClientOptions(isEnabled: true, stickyBucketService: nil, isQaMode: isQaMode, trackingClosure: { _, _ in })
+        return EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
+    }
+
+    private func makeFeature(_ raw: [String: Any]) -> Feature {
+        Feature(json: JSON(raw).dictionaryValue)
+    }
+
+    private func evaluate(_ featureKey: String, in context: EvalContext) -> FeatureResult {
+        FeatureEvaluator(context: context, featureKey: featureKey).evaluateFeature()
+    }
+
+    /// A rule whose variations live under `contextualVariations` and which points at `bandit-1`.
+    /// `weights` on the rule act as the aggregate fallback when no leaf matches.
+    private func banditRule(ref: String? = "bandit-1", weights: [Float]? = nil) -> [String: Any] {
+        var rule: [String: Any] = [
+            "id": "rule-1",
+            "key": "my-experiment",
+            "contextualVariations": ["control", "treatment"]
+        ]
+        if let ref { rule["contextualBanditRef"] = ref }
+        if let weights { rule["weights"] = weights }
+        return rule
+    }
+
+    /// A bandit definition with two leaves: leaf 1 targets US, leaf 2 targets CA.
+    /// Leaf 1's weights force variation 0, leaf 2's force variation 1.
+    private func twoLeafBandits(banditVersion: Int = 7) -> JSON {
+        JSON([
+            "bandit-1": [
+                "banditVersion": banditVersion,
+                "contexts": [
+                    ["leafId": 1, "condition": ["country": "US"], "weights": [1.0, 0.0]],
+                    ["leafId": 2, "condition": ["country": "CA"], "weights": [0.0, 1.0]]
+                ]
+            ]
+        ])
+    }
+
+    // MARK: - Leaf selection
+
+    func testMatchingLeafAppliesItsWeightsAndIsReportedOnResult() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1", "country": "CA"]),
+            contextualBandits: twoLeafBandits()
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.source, FeatureSource.experiment.rawValue)
+        // Leaf 2's weights are [0, 1] — every user lands in variation 1 regardless of hash.
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+        XCTAssertEqual(result.experimentResult?.variationId, 1)
+        XCTAssertEqual(result.experimentResult?.leafId, 2)
+        XCTAssertEqual(result.experimentResult?.variationWeights, [0.0, 1.0])
+        XCTAssertEqual(result.experimentResult?.banditVersion, 7)
+    }
+
+    func testFirstMatchingLeafWinsWhenSeveralConditionsMatch() {
+        // Both leaves match a US user; the first one listed must win.
+        let bandits = JSON([
+            "bandit-1": [
+                "banditVersion": 2,
+                "contexts": [
+                    ["leafId": 10, "condition": ["country": "US"], "weights": [1.0, 0.0]],
+                    ["leafId": 20, "condition": ["country": "US"], "weights": [0.0, 1.0]]
+                ]
+            ]
+        ])
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1", "country": "US"]),
+            contextualBandits: bandits
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, 10)
+        XCTAssertEqual(result.experimentResult?.variationWeights, [1.0, 0.0])
+        XCTAssertEqual(result.value?.stringValue, "control")
+    }
+
+    func testLeafWithoutConditionMatchesEveryUser() {
+        let bandits = JSON([
+            "bandit-1": [
+                "banditVersion": 1,
+                "contexts": [
+                    ["leafId": 5, "weights": [0.0, 1.0]]
+                ]
+            ]
+        ])
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1"]),
+            contextualBandits: bandits
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, 5)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
+    func testLeafConditionCanReferenceSavedGroups() {
+        let bandits = JSON([
+            "bandit-1": [
+                "banditVersion": 4,
+                "contexts": [
+                    ["leafId": 9, "condition": ["id": ["$inGroup": "vips"]], "weights": [0.0, 1.0]]
+                ]
+            ]
+        ])
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1"]),
+            contextualBandits: bandits,
+            savedGroups: JSON(["vips": ["user-1", "user-2"]])
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, 9)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
+    // MARK: - Fallback: no leaf matches
+
+    func testNoMatchingLeafFallsBackToRuleWeightsWithFallbackLeafId() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature([
+                "defaultValue": "off",
+                "rules": [banditRule(weights: [1.0, 0.0])]
+            ])],
+            // Matches neither the US nor the CA leaf.
+            attributes: JSON(["id": "user-1", "country": "UA"]),
+            contextualBandits: twoLeafBandits()
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, ContextualBandit.fallbackLeafId)
+        XCTAssertEqual(result.experimentResult?.leafId, -1)
+        // The rule's own aggregate weights survive — [1, 0] forces variation 0.
+        XCTAssertEqual(result.experimentResult?.variationWeights, [1.0, 0.0])
+        XCTAssertEqual(result.value?.stringValue, "control")
+        XCTAssertEqual(result.experimentResult?.banditVersion, 7)
+    }
+
+    func testNoMatchingLeafAndNoRuleWeightsFallsBackToEqualWeights() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1", "country": "UA"]),
+            contextualBandits: twoLeafBandits()
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, -1)
+        XCTAssertEqual(result.experimentResult?.variationWeights, [0.5, 0.5])
+    }
+
+    func testEmptyContextsListFallsBack() {
+        let bandits = JSON(["bandit-1": ["banditVersion": 3, "contexts": [] as [Any]]])
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule(weights: [0.0, 1.0])]])],
+            contextualBandits: bandits
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, -1)
+        XCTAssertEqual(result.experimentResult?.variationWeights, [0.0, 1.0])
+        XCTAssertEqual(result.experimentResult?.banditVersion, 3)
+    }
+
+    // MARK: - Fallback: missing ref / missing payload
+
+    func testUnknownRefLeavesExperimentUntouched() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature([
+                "defaultValue": "off",
+                "rules": [banditRule(ref: "does-not-exist", weights: [0.0, 1.0])]
+            ])],
+            attributes: JSON(["id": "user-1", "country": "US"]),
+            contextualBandits: twoLeafBandits()
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        // No definition found → no bandit metadata at all, rule weights apply as usual.
+        XCTAssertNil(result.experimentResult?.leafId)
+        XCTAssertNil(result.experimentResult?.variationWeights)
+        XCTAssertNil(result.experimentResult?.banditVersion)
+        XCTAssertNil(result.experiment?.contextualBandit)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
+    func testRefWithNoBanditsPayloadStillEvaluatesAsExperiment() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature([
+                "defaultValue": "off",
+                "rules": [banditRule(weights: [0.0, 1.0])]
+            ])],
+            contextualBandits: nil
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.source, FeatureSource.experiment.rawValue)
+        XCTAssertNil(result.experimentResult?.leafId)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
+    // MARK: - contextualVariations
+
+    func testContextualVariationsAreUsedWithoutARef() {
+        // A rule can carry contextualVariations with no ref; the variations must still be read
+        // rather than the rule being skipped for having no `variations`.
+        let context = makeContext(
+            features: ["my-feature": makeFeature([
+                "defaultValue": "off",
+                "rules": [banditRule(ref: nil, weights: [0.0, 1.0])]
+            ])]
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.source, FeatureSource.experiment.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+        XCTAssertNil(result.experimentResult?.leafId)
+    }
+
+    func testContextualVariationsTakePrecedenceOverVariations() {
+        let rule: [String: Any] = [
+            "id": "rule-1",
+            "key": "my-experiment",
+            "variations": ["legacy-a", "legacy-b"],
+            "contextualVariations": ["control", "treatment"],
+            "weights": [0.0, 1.0]
+        ]
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])]
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
+    func testBanditRefWorksWithPlainVariationsKey() {
+        let rule: [String: Any] = [
+            "id": "rule-1",
+            "key": "my-experiment",
+            "variations": ["control", "treatment"],
+            "contextualBanditRef": "bandit-1"
+        ]
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])],
+            attributes: JSON(["id": "user-1", "country": "CA"]),
+            contextualBandits: twoLeafBandits()
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.experimentResult?.leafId, 2)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+    }
+
+    // MARK: - Only reported for a real exposure
+
+    func testForcedVariationClearsBanditSelection() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1", "country": "CA"]),
+            contextualBandits: twoLeafBandits(),
+            forcedVariations: JSON(["my-experiment": 0])
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        // The user was force-assigned, not hash-bucketed — the bandit weights did not decide
+        // anything, so no selection may be reported.
+        XCTAssertEqual(result.experimentResult?.hashUsed, false)
+        XCTAssertNil(result.experimentResult?.leafId)
+        XCTAssertNil(result.experimentResult?.variationWeights)
+        XCTAssertNil(result.experimentResult?.banditVersion)
+        XCTAssertNil(result.experiment?.contextualBandit)
+    }
+
+    func testQaModeYieldsNoBanditSelection() {
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [banditRule()]])],
+            attributes: JSON(["id": "user-1", "country": "CA"]),
+            contextualBandits: twoLeafBandits(),
+            isQaMode: true
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        // QA mode never puts the user in the experiment, so the rule is skipped entirely.
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+        XCTAssertNil(result.experimentResult?.leafId)
+    }
+
+    func testUserExcludedByCoverageGetsNoBanditSelection() {
+        var rule = banditRule()
+        rule["coverage"] = 0.0
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])],
+            attributes: JSON(["id": "user-1", "country": "CA"]),
+            contextualBandits: twoLeafBandits()
+        )
+
+        let result = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(result.source, FeatureSource.defaultValue.rawValue)
+        XCTAssertNil(result.experimentResult?.leafId)
+    }
+
+    // MARK: - Tracking callback
+
+    func testTrackingCallbackReceivesBanditEnrichedResult() {
+        var tracked: [(Experiment, ExperimentResult)] = []
+        // `ExperimentHelper.shared` dedupes tracking per
+        // (hashAttribute, hashValue, experimentKey, variationId) for the lifetime of the process,
+        // so this test needs an experiment key and user id no other test in the suite uses.
+        let rule: [String: Any] = [
+            "id": "rule-1",
+            "key": "bandit-tracking-experiment",
+            "contextualVariations": ["control", "treatment"],
+            "contextualBanditRef": "bandit-1"
+        ]
+        let globalContext = GlobalContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])],
+            savedGroups: nil,
+            contextualBandits: twoLeafBandits()
+        )
+        let userContext = UserContext(attributes: JSON(["id": "bandit-tracking-user", "country": "CA"]))
+        let options = ClientOptions(isEnabled: true, stickyBucketService: nil, isQaMode: false) { experiment, result in
+            tracked.append((experiment, result))
+        }
+        let context = EvalContext(globalContext: globalContext, userContext: userContext, stackContext: StackContext(), options: options)
+
+        _ = evaluate("my-feature", in: context)
+
+        XCTAssertEqual(tracked.count, 1)
+        XCTAssertEqual(tracked.first?.1.leafId, 2)
+        XCTAssertEqual(tracked.first?.1.banditVersion, 7)
+        XCTAssertEqual(tracked.first?.0.contextualBandit?.leafId, 2)
+        XCTAssertEqual(tracked.first?.0.weights, [0.0, 1.0])
+    }
+
+    // MARK: - Model parsing
+
+    func testFeatureRuleParsesBanditFields() {
+        let rule = FeatureRule(json: JSON([
+            "id": "rule-1",
+            "contextualBanditRef": "bandit-1",
+            "contextualVariations": ["a", "b"]
+        ]).dictionaryValue)
+
+        XCTAssertEqual(rule.contextualBanditRef, "bandit-1")
+        XCTAssertEqual(rule.contextualVariations?.count, 2)
+        XCTAssertEqual(rule.contextualVariations?.first?.stringValue, "a")
+        XCTAssertNil(rule.variations)
+    }
+
+    func testFeatureRuleWithoutBanditFieldsHasNilBanditProperties() {
+        let rule = FeatureRule(json: JSON(["id": "rule-1", "variations": ["a", "b"]]).dictionaryValue)
+
+        XCTAssertNil(rule.contextualBanditRef)
+        XCTAssertNil(rule.contextualVariations)
+        XCTAssertEqual(rule.variations?.count, 2)
+    }
+
+    func testContextualBanditDefinitionParsing() {
+        let definition = ContextualBanditDefinition(json: JSON([
+            "banditVersion": 12,
+            "contexts": [
+                ["leafId": 0, "condition": ["country": "US"], "weights": [0.25, 0.75]],
+                ["leafId": 1]
+            ]
+        ]).dictionaryValue)
+
+        XCTAssertEqual(definition.banditVersion, 12)
+        XCTAssertEqual(definition.contexts?.count, 2)
+        XCTAssertEqual(definition.contexts?[0].leafId, 0)
+        XCTAssertEqual(definition.contexts?[0].weights, [0.25, 0.75])
+        XCTAssertEqual(definition.contexts?[0].condition?["country"].stringValue, "US")
+        XCTAssertEqual(definition.contexts?[1].leafId, 1)
+        XCTAssertNil(definition.contexts?[1].weights)
+        XCTAssertNil(definition.contexts?[1].condition)
+    }
+
+    func testContextualBanditDefinitionParsingWithMissingFields() {
+        let definition = ContextualBanditDefinition(json: JSON([:] as [String: Any]).dictionaryValue)
+
+        XCTAssertNil(definition.banditVersion)
+        XCTAssertNil(definition.contexts)
+    }
+
+    func testExperimentResultParsesBanditFieldsFromJson() {
+        let result = ExperimentResult(json: JSON([
+            "inExperiment": true,
+            "variationId": 1,
+            "leafId": 3,
+            "banditVersion": 8,
+            "variationWeights": [0.3, 0.7]
+        ]).dictionaryValue)
+
+        XCTAssertEqual(result.leafId, 3)
+        XCTAssertEqual(result.banditVersion, 8)
+        XCTAssertEqual(result.variationWeights, [0.3, 0.7])
+    }
+
+    // MARK: - Payload parsing
+
+    func testFeaturesDataModelDecodesContextualBandits() throws {
+        let json = """
+        {
+          "features": {},
+          "contextualBandits": {
+            "bandit-1": {
+              "banditVersion": 5,
+              "contexts": [{"leafId": 0, "condition": {"country": "US"}, "weights": [0.4, 0.6]}]
+            }
+          }
+        }
+        """
+        let model = try JSONDecoder().decode(FeaturesDataModel.self, from: Data(json.utf8))
+
+        XCTAssertNil(model.encryptedContextualBandits)
+        let definition = model.contextualBandits?["bandit-1"]
+        XCTAssertEqual(definition?["banditVersion"].intValue, 5)
+        XCTAssertEqual(definition?["contexts"].arrayValue.count, 1)
+    }
+
+    func testFeaturesDataModelDecodesEncryptedContextualBandits() throws {
+        let json = """
+        {"features": {}, "encryptedContextualBandits": "iv.cipher"}
+        """
+        let model = try JSONDecoder().decode(FeaturesDataModel.self, from: Data(json.utf8))
+
+        XCTAssertEqual(model.encryptedContextualBandits, "iv.cipher")
+        XCTAssertNil(model.contextualBandits)
+    }
+
+    func testPayloadWithoutBanditsKeepsBanditFieldsNil() throws {
+        let json = """
+        {"features": {}, "savedGroups": {"vips": ["a"]}}
+        """
+        let model = try JSONDecoder().decode(FeaturesDataModel.self, from: Data(json.utf8))
+
+        XCTAssertNil(model.contextualBandits)
+        XCTAssertNil(model.encryptedContextualBandits)
+        XCTAssertNotNil(model.savedGroups)
+    }
+
+    // MARK: - End-to-end through the SDK
+
+    private let testApiHost = "https://host.com"
+
+    /// A full API payload whose single feature is a contextual bandit rule. Leaf 1 forces
+    /// variation 0 ("control"), leaf 2 forces variation 1 ("treatment").
+    private func payload(banditVersion: Int, usWeights: [Float], caWeights: [Float]) -> String {
+        """
+        {
+          "features": {
+            "my-feature": {
+              "defaultValue": "off",
+              "rules": [{
+                "id": "rule-1",
+                "key": "e2e-experiment",
+                "contextualBanditRef": "bandit-1",
+                "contextualVariations": ["control", "treatment"]
+              }]
+            }
+          },
+          "contextualBandits": {
+            "bandit-1": {
+              "banditVersion": \(banditVersion),
+              "contexts": [
+                {"leafId": 1, "condition": {"country": "US"}, "weights": [\(usWeights[0]), \(usWeights[1])]},
+                {"leafId": 2, "condition": {"country": "CA"}, "weights": [\(caWeights[0]), \(caWeights[1])]}
+              ]
+            }
+          }
+        }
+        """
+    }
+
+    func testBanditsFromPreloadedPayloadAreApplied() {
+        let clientKey = "bandit-offline-key"
+        let manager = CachingManager(apiKey: clientKey)
+        manager.clearCache()
+
+        let sdk = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "CA"],
+            features: Data(payload(banditVersion: 1, usWeights: [1.0, 0.0], caWeights: [0.0, 1.0]).utf8),
+            trackingCallback: { _, _ in },
+            backgroundSync: false
+        )
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: nil))
+        .initializer()
+
+        let result = sdk.evalFeature(id: "my-feature")
+
+        XCTAssertEqual(result.source, FeatureSource.experiment.rawValue)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+        XCTAssertEqual(result.experimentResult?.leafId, 2)
+        XCTAssertEqual(result.experimentResult?.banditVersion, 1)
+        manager.clearCache()
+    }
+
+    func testBanditsFromNetworkPayloadAreApplied() {
+        let clientKey = "bandit-network-key"
+        let manager = CachingManager(apiKey: clientKey)
+        manager.clearCache()
+
+        let refreshed = XCTestExpectation(description: "refreshHandler called")
+        let sdk = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "US"],
+            trackingCallback: { _, _ in },
+            backgroundSync: false,
+            ttlSeconds: 0
+        )
+        .setRefreshHandler(refreshHandler: { _ in DispatchQueue.main.async { refreshed.fulfill() } })
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(
+            successResponse: payload(banditVersion: 4, usWeights: [1.0, 0.0], caWeights: [0.0, 1.0]),
+            error: nil
+        ))
+        .initializer()
+
+        wait(for: [refreshed], timeout: 2.0)
+
+        let result = sdk.evalFeature(id: "my-feature")
+
+        XCTAssertEqual(result.value?.stringValue, "control")
+        XCTAssertEqual(result.experimentResult?.leafId, 1)
+        XCTAssertEqual(result.experimentResult?.banditVersion, 4)
+        manager.clearCache()
+    }
+
+    func testStableSessionDoesNotApplyRefreshedBandits() {
+        let clientKey = "bandit-stable-key"
+        let manager = CachingManager(apiKey: clientKey)
+        manager.clearCache()
+
+        // Session starts with bandits that send a CA user to "treatment".
+        let initialPayload = payload(banditVersion: 1, usWeights: [1.0, 0.0], caWeights: [0.0, 1.0])
+        // The refresh flips CA to "control" and bumps the version — it must not take effect now.
+        let refreshedPayload = payload(banditVersion: 2, usWeights: [0.0, 1.0], caWeights: [1.0, 0.0])
+
+        let refreshed = XCTestExpectation(description: "refreshHandler called")
+        let sdk = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "CA"],
+            features: Data(initialPayload.utf8),
+            trackingCallback: { _, _ in },
+            backgroundSync: false,
+            ttlSeconds: 0
+        )
+        .setStableSession(true)
+        .setRefreshHandler(refreshHandler: { _ in DispatchQueue.main.async { refreshed.fulfill() } })
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: refreshedPayload, error: nil))
+        .initializer()
+
+        sdk.refreshCache()
+        wait(for: [refreshed], timeout: 2.0)
+
+        let result = sdk.evalFeature(id: "my-feature")
+
+        XCTAssertEqual(result.value?.stringValue, "treatment", "Session bandit weights must survive the refresh")
+        XCTAssertEqual(result.experimentResult?.leafId, 2)
+        XCTAssertEqual(result.experimentResult?.banditVersion, 1, "banditVersion must still be the session's, not the refreshed one")
+        manager.clearCache()
+    }
+
+    func testBanditsAreAppliedOnFirstFetchInStableSessionMode() {
+        let clientKey = "bandit-stable-first-key"
+        let manager = CachingManager(apiKey: clientKey)
+        manager.clearCache()
+
+        // No preloaded payload: the first network fetch establishes the session, and the bandits
+        // riding along in that same payload must be applied rather than blocked by the latch.
+        let refreshed = XCTestExpectation(description: "refreshHandler called")
+        let sdk = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "CA"],
+            trackingCallback: { _, _ in },
+            backgroundSync: false,
+            ttlSeconds: 0
+        )
+        .setStableSession(true)
+        .setRefreshHandler(refreshHandler: { _ in DispatchQueue.main.async { refreshed.fulfill() } })
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(
+            successResponse: payload(banditVersion: 9, usWeights: [1.0, 0.0], caWeights: [0.0, 1.0]),
+            error: nil
+        ))
+        .initializer()
+
+        wait(for: [refreshed], timeout: 2.0)
+
+        let result = sdk.evalFeature(id: "my-feature")
+
+        XCTAssertEqual(result.experimentResult?.leafId, 2)
+        XCTAssertEqual(result.experimentResult?.banditVersion, 9)
+        XCTAssertEqual(result.value?.stringValue, "treatment")
+        manager.clearCache()
+    }
+
+    func testContextualBanditsSurviveCacheRoundTrip() {
+        let clientKey = "bandit-cache-key"
+        let manager = CachingManager(apiKey: clientKey)
+        manager.clearCache()
+
+        // First SDK writes features + bandits to disk from the network response.
+        let firstRefresh = XCTestExpectation(description: "first refresh")
+        _ = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "CA"],
+            trackingCallback: { _, _ in },
+            backgroundSync: false,
+            ttlSeconds: 0
+        )
+        .setRefreshHandler(refreshHandler: { _ in DispatchQueue.main.async { firstRefresh.fulfill() } })
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(
+            successResponse: payload(banditVersion: 6, usWeights: [1.0, 0.0], caWeights: [0.0, 1.0]),
+            error: nil
+        ))
+        .initializer()
+        wait(for: [firstRefresh], timeout: 2.0)
+
+        // A second SDK with a failing network must recover both from the cache.
+        let secondRefresh = XCTestExpectation(description: "second refresh")
+        let sdk = GrowthBookBuilder(
+            apiHost: testApiHost,
+            clientKey: clientKey,
+            attributes: ["id": "user-1", "country": "CA"],
+            trackingCallback: { _, _ in },
+            backgroundSync: false,
+            ttlSeconds: 0
+        )
+        .setRefreshHandler(refreshHandler: { _ in DispatchQueue.main.async { secondRefresh.fulfill() } })
+        .setNetworkDispatcher(networkDispatcher: MockNetworkClient(successResponse: nil, error: SDKError.failedToLoadData))
+        .initializer()
+        wait(for: [secondRefresh], timeout: 2.0)
+
+        let result = sdk.evalFeature(id: "my-feature")
+
+        XCTAssertEqual(result.experimentResult?.leafId, 2, "Bandits must be restored from the on-disk cache")
+        XCTAssertEqual(result.experimentResult?.banditVersion, 6)
+        manager.clearCache()
+    }
+
+    // MARK: - Context plumbing
+
+    func testContextManagerPropagatesContextualBanditsToEvalContext() {
+        let evalData = EvaluationData(
+            streamingHost: nil,
+            attributes: JSON(["id": "user-1"]),
+            forcedVariations: nil,
+            features: [:],
+            savedGroups: nil,
+            contextualBandits: twoLeafBandits()
+        )
+        let globalConfig = GlobalConfig(
+            apiHost: nil, clientKey: nil, encryptionKey: nil,
+            isEnabled: true, isQaMode: false, backgroundSync: false,
+            remoteEval: false, trackingClosure: { _, _ in }
+        )
+        let manager = ContextManager(globalConfig: globalConfig, evalData: evalData)
+
+        XCTAssertEqual(
+            manager.getEvalContext().globalContext.contextualBandits?["bandit-1"]["banditVersion"].intValue,
+            7
+        )
+
+        // Cache invalidation: an update must be visible on the next context build.
+        manager.updateEvalData { data in
+            data.contextualBandits = JSON(["bandit-2": ["banditVersion": 99]])
+        }
+        XCTAssertNil(manager.getEvalContext().globalContext.contextualBandits?["bandit-1"].dictionary)
+        XCTAssertEqual(
+            manager.getEvalContext().globalContext.contextualBandits?["bandit-2"]["banditVersion"].intValue,
+            99
+        )
+    }
+}

--- a/GrowthBookTests/ContextualBanditTests.swift
+++ b/GrowthBookTests/ContextualBanditTests.swift
@@ -688,6 +688,58 @@ class ContextualBanditTests: XCTestCase {
         manager.clearCache()
     }
 
+    // MARK: - Sticky bucket identifier attributes
+
+    /// The identifier attributes drive which assignment documents are fetched from the sticky bucket
+    /// service. A contextual bandit rule carries its variations under `contextualVariations`, so a
+    /// check for `variations` alone leaves its hash and fallback attributes unregistered and sticky
+    /// bucketing silently never loads that experiment's documents.
+    func testStickyBucketIdentifierAttributesIncludeContextualBanditRules() {
+        let rule: [String: Any] = [
+            "id": "rule-1",
+            "key": "my-experiment",
+            "contextualBanditRef": "bandit-1",
+            "contextualVariations": ["control", "treatment"],
+            "hashAttribute": "deviceId",
+            "fallbackAttribute": "anonymousId"
+        ]
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])],
+            contextualBandits: twoLeafBandits()
+        )
+
+        let attributes = Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil)
+
+        XCTAssertTrue(attributes.contains("deviceId"),
+                      "A bandit rule's hashAttribute must be registered for sticky bucketing")
+        XCTAssertTrue(attributes.contains("anonymousId"),
+                      "A bandit rule's fallbackAttribute must be registered for sticky bucketing")
+    }
+
+    func testStickyBucketIdentifierAttributesStillIncludePlainRules() {
+        let rule: [String: Any] = [
+            "id": "rule-1",
+            "key": "plain-experiment",
+            "variations": ["a", "b"],
+            "hashAttribute": "userId"
+        ]
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])]
+        )
+
+        XCTAssertTrue(Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil).contains("userId"))
+    }
+
+    func testStickyBucketIdentifierAttributesIgnoreNonExperimentRules() {
+        // A pure force rule has neither variations nor contextualVariations and must not contribute.
+        let rule: [String: Any] = ["id": "rule-1", "force": "on", "hashAttribute": "shouldNotAppear"]
+        let context = makeContext(
+            features: ["my-feature": makeFeature(["defaultValue": "off", "rules": [rule]])]
+        )
+
+        XCTAssertFalse(Utils.deriveStickyBucketIdentifierAttributes(context: context, data: nil).contains("shouldNotAppear"))
+    }
+
     // MARK: - Context plumbing
 
     func testContextManagerPropagatesContextualBanditsToEvalContext() {

--- a/GrowthBookTests/FeaturesViewModelExtendedTests.swift
+++ b/GrowthBookTests/FeaturesViewModelExtendedTests.swift
@@ -10,9 +10,11 @@ class FeaturesViewModelExtendedTests: XCTestCase {
         var successCount = 0
         var failCount = 0
         var savedGroupsCount = 0
+        var contextualBanditsCount = 0
         var lastError: SDKError?
         var lastFeatures: Features?
         var lastSavedGroups: JSON?
+        var lastContextualBandits: JSON?
 
         func featuresFetchedSuccessfully(features: Features, isRemote: Bool) {
             successCount += 1
@@ -27,6 +29,11 @@ class FeaturesViewModelExtendedTests: XCTestCase {
             lastSavedGroups = savedGroups
         }
         func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) { failCount += 1 }
+        func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool) {
+            contextualBanditsCount += 1
+            lastContextualBandits = contextualBandits
+        }
+        func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool) { failCount += 1 }
         func featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
 
         // featuresUpdateIsComplete

--- a/GrowthBookTests/FeaturesViewModelTests.swift
+++ b/GrowthBookTests/FeaturesViewModelTests.swift
@@ -397,7 +397,17 @@ class FeaturesViewModelTests: XCTestCase, FeaturesFlowDelegate {
         isSuccess = true
         isError = false
     }
-    
+
+    func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool) {
+        isSuccess = false
+        isError = true
+    }
+
+    func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool) {
+        isSuccess = true
+        isError = false
+    }
+
     func featuresAPIModelSuccessfully(model: FeaturesDataModel) {
 
     }
@@ -427,6 +437,8 @@ private class SavedGroupsCapture: FeaturesFlowDelegate {
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {
         onSavedGroups(savedGroups)
     }
+    func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool) {}
 
     // featuresUpdateIsComplete
 
@@ -451,6 +463,8 @@ private class RemoteCallCapture: FeaturesFlowDelegate {
     func featuresFetchFailed(error: SDKError, isRemote: Bool) { onFailure(isRemote) }
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
+    func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool) {}
     func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {}
 }
 
@@ -462,5 +476,7 @@ private class ErrorCapture: FeaturesFlowDelegate {
     func featuresFetchFailed(error: SDKError, isRemote: Bool) { onError(error) }
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool) {}
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool) {}
+    func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool) {}
+    func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool) {}
     func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool) {}
 }

--- a/GrowthBookTests/Source/json.json
+++ b/GrowthBookTests/Source/json.json
@@ -1,9016 +1,13987 @@
 {
-    "specVersion": "0.7.1",
-    "evalCondition": [
-        [
-            "$not - pass",
-            {
-                "$not": {
-                    "name": "hello"
-                }
-            },
-            {
-                "name": "world"
-            },
-            true
-        ],
-        [
-            "$not - fail",
-            {
-                "$not": {
-                    "name": "hello"
-                }
-            },
-            {
-                "name": "hello"
-            },
-            false
-        ],
-        [
-            "$and/$or - all true",
-            {
-                "$and": [
-                    {
-                        "father.age": {
-                            "$gt": 65
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "bday": {
-                                    "$regex": "-12-25$"
-                                }
-                            },
-                            {
-                                "name": "santa"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "name": "santa",
-                "bday": "1980-12-25",
-                "father": {
-                    "age": 70
-                }
-            },
-            true
-        ],
-        [
-            "$groups - match",
-            {
-                "$and": [
-                    {
-                        "$groups": {
-                            "$elemMatch": {
-                                "$eq": "a"
-                            }
-                        }
-                    },
-                    {
-                        "$groups": {
-                            "$elemMatch": {
-                                "$eq": "b"
-                            }
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "$groups": {
-                                    "$elemMatch": {
-                                        "$eq": "c"
-                                    }
-                                }
-                            },
-                            {
-                                "$groups": {
-                                    "$elemMatch": {
-                                        "$eq": "e"
-                                    }
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "$not": {
-                            "$groups": {
-                                "$elemMatch": {
-                                    "$eq": "f"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "$not": {
-                            "$groups": {
-                                "$elemMatch": {
-                                    "$eq": "g"
-                                }
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "$groups": [
-                    "a",
-                    "b",
-                    "c",
-                    "d"
-                ]
-            },
-            true
-        ],
-        [
-            "$groups - no match",
-            {
-                "$and": [
-                    {
-                        "$groups": {
-                            "$elemMatch": {
-                                "$eq": "a"
-                            }
-                        }
-                    },
-                    {
-                        "$groups": {
-                            "$elemMatch": {
-                                "$eq": "b"
-                            }
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "$groups": {
-                                    "$elemMatch": {
-                                        "$eq": "c"
-                                    }
-                                }
-                            },
-                            {
-                                "$groups": {
-                                    "$elemMatch": {
-                                        "$eq": "e"
-                                    }
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "$not": {
-                            "$groups": {
-                                "$elemMatch": {
-                                    "$eq": "d"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "$not": {
-                            "$groups": {
-                                "$elemMatch": {
-                                    "$eq": "g"
-                                }
-                            }
-                        }
-                    }
-                ]
-            },
-            {
-                "$groups": [
-                    "a",
-                    "b",
-                    "c",
-                    "d"
-                ]
-            },
-            false
-        ],
-        [
-            "$and/$or - first or true",
-            {
-                "$and": [
-                    {
-                        "father.age": {
-                            "$gt": 65
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "bday": {
-                                    "$regex": "-12-25$"
-                                }
-                            },
-                            {
-                                "name": "santa"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "name": "santa",
-                "bday": "1980-12-20",
-                "father": {
-                    "age": 70
-                }
-            },
-            true
-        ],
-        [
-            "$and/$or - second or true",
-            {
-                "$and": [
-                    {
-                        "father.age": {
-                            "$gt": 65
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "bday": {
-                                    "$regex": "-12-25$"
-                                }
-                            },
-                            {
-                                "name": "santa"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "name": "barbara",
-                "bday": "1980-12-25",
-                "father": {
-                    "age": 70
-                }
-            },
-            true
-        ],
-        [
-            "$and/$or - first and false",
-            {
-                "$and": [
-                    {
-                        "father.age": {
-                            "$gt": 65
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "bday": {
-                                    "$regex": "-12-25$"
-                                }
-                            },
-                            {
-                                "name": "santa"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "name": "santa",
-                "bday": "1980-12-25",
-                "father": {
-                    "age": 65
-                }
-            },
-            false
-        ],
-        [
-            "$and/$or - both or false",
-            {
-                "$and": [
-                    {
-                        "father.age": {
-                            "$gt": 65
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "bday": {
-                                    "$regex": "-12-25$"
-                                }
-                            },
-                            {
-                                "name": "santa"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "name": "barbara",
-                "bday": "1980-11-25",
-                "father": {
-                    "age": 70
-                }
-            },
-            false
-        ],
-        [
-            "$and/$or - both and false",
-            {
-                "$and": [
-                    {
-                        "father.age": {
-                            "$gt": 65
-                        }
-                    },
-                    {
-                        "$or": [
-                            {
-                                "bday": {
-                                    "$regex": "-12-25$"
-                                }
-                            },
-                            {
-                                "name": "santa"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "name": "john smith",
-                "bday": "1956-12-20",
-                "father": {
-                    "age": 40
-                }
-            },
-            false
-        ],
-        [
-            "$exists - false pass",
-            {
-                "pets.dog.name": {
-                    "$exists": false
-                }
-            },
-            {
-                "hello": "world"
-            },
-            true
-        ],
-        [
-            "$exists - false fail",
-            {
-                "pets.dog.name": {
-                    "$exists": false
-                }
-            },
-            {
-                "pets": {
-                    "dog": {
-                        "name": "fido"
-                    }
-                }
-            },
-            false
-        ],
-        [
-            "$exists - true fail",
-            {
-                "pets.dog.name": {
-                    "$exists": true
-                }
-            },
-            {
-                "hello": "world"
-            },
-            false
-        ],
-        [
-            "$exists - true pass",
-            {
-                "pets.dog.name": {
-                    "$exists": true
-                }
-            },
-            {
-                "pets": {
-                    "dog": {
-                        "name": "fido"
-                    }
-                }
-            },
-            true
-        ],
-        [
-            "equals - multiple datatypes",
-            {
-                "str": "str",
-                "num": 10,
-                "flag": false
-            },
-            {
-                "str": "str",
-                "num": 10,
-                "flag": false
-            },
-            true
-        ],
-        [
-            "$in - pass",
-            {
-                "num": {
-                    "$in": [
-                        1,
-                        2,
-                        3
-                    ]
-                }
-            },
-            {
-                "num": 2
-            },
-            true
-        ],
-        [
-            "$in - fail",
-            {
-                "num": {
-                    "$in": [
-                        1,
-                        2,
-                        3
-                    ]
-                }
-            },
-            {
-                "num": 4
-            },
-            false
-        ],
-        [
-            "$in - not array",
-            {
-                "num": {
-                    "$in": 1
-                }
-            },
-            {
-                "num": 1
-            },
-            false
-        ],
-        [
-            "$in - array pass 1",
-            {
-                "tags": {
-                    "$in": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "e",
-                    "a"
-                ]
-            },
-            true
-        ],
-        [
-            "$in - array pass 2",
-            {
-                "tags": {
-                    "$in": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "b",
-                    "f"
-                ]
-            },
-            true
-        ],
-        [
-            "$in - array pass 3",
-            {
-                "tags": {
-                    "$in": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "b",
-                    "a"
-                ]
-            },
-            true
-        ],
-        [
-            "$in - array fail 1",
-            {
-                "tags": {
-                    "$in": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "e",
-                    "f"
-                ]
-            },
-            false
-        ],
-        [
-            "$in - array fail 2",
-            {
-                "tags": {
-                    "$in": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": []
-            },
-            false
-        ],
-        [
-            "$nin - pass",
-            {
-                "num": {
-                    "$nin": [
-                        1,
-                        2,
-                        3
-                    ]
-                }
-            },
-            {
-                "num": 4
-            },
-            true
-        ],
-        [
-            "$nin - fail",
-            {
-                "num": {
-                    "$nin": [
-                        1,
-                        2,
-                        3
-                    ]
-                }
-            },
-            {
-                "num": 2
-            },
-            false
-        ],
-        [
-            "$nin - not array",
-            {
-                "num": {
-                    "$nin": 1
-                }
-            },
-            {
-                "num": 1
-            },
-            false
-        ],
-        [
-            "$nin - array fail 1",
-            {
-                "tags": {
-                    "$nin": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "e",
-                    "a"
-                ]
-            },
-            false
-        ],
-        [
-            "$nin - array fail 2",
-            {
-                "tags": {
-                    "$nin": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "b",
-                    "f"
-                ]
-            },
-            false
-        ],
-        [
-            "$nin - array fail 3",
-            {
-                "tags": {
-                    "$nin": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "b",
-                    "a"
-                ]
-            },
-            false
-        ],
-        [
-            "$nin - array pass 1",
-            {
-                "tags": {
-                    "$nin": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "e",
-                    "f"
-                ]
-            },
-            true
-        ],
-        [
-            "$nin - array pass 2",
-            {
-                "tags": {
-                    "$nin": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": []
-            },
-            true
-        ],
-        [
-            "$elemMatch - pass - flat arrays",
-            {
-                "nums": {
-                    "$elemMatch": {
-                        "$gt": 10
-                    }
-                }
-            },
-            {
-                "nums": [
-                    0,
-                    5,
-                    -20,
-                    15
-                ]
-            },
-            true
-        ],
-        [
-            "$elemMatch - fail - flat arrays",
-            {
-                "nums": {
-                    "$elemMatch": {
-                        "$gt": 10
-                    }
-                }
-            },
-            {
-                "nums": [
-                    0,
-                    5,
-                    -20,
-                    8
-                ]
-            },
-            false
-        ],
-        [
-            "missing attribute - fail",
-            {
-                "pets.dog.name": {
-                    "$in": [
-                        "fido"
-                    ]
-                }
-            },
-            {
-                "hello": "world"
-            },
-            false
-        ],
-        [
-            "missing attribute with comparison operators",
-            {
-                "age": {
-                    "$gt": -10,
-                    "$lt": 10,
-                    "$gte": -9,
-                    "$lte": 9,
-                    "$ne": 10
-                }
-            },
-            {},
-            true
-        ],
-        [
-            "comparing numbers and strings",
-            {
-                "n": {
-                    "$gt": 5,
-                    "$lt": 10
-                }
-            },
-            {
-                "n": "8"
-            },
-            true
-        ],
-        [
-            "comparing numbers and strings - v2",
-            {
-                "n": {
-                    "$gt": "5",
-                    "$lt": "10"
-                }
-            },
-            {
-                "n": 8
-            },
-            true
-        ],
-        [
-            "empty $or - pass",
-            {
-                "$or": []
-            },
-            {
-                "hello": "world"
-            },
-            true
-        ],
-        [
-            "empty $and - pass",
-            {
-                "$and": []
-            },
-            {
-                "hello": "world"
-            },
-            true
-        ],
-        [
-            "empty - pass",
-            {},
-            {
-                "hello": "world"
-            },
-            true
-        ],
-        [
-            "$eq - pass",
-            {
-                "occupation": {
-                    "$eq": "engineer"
-                }
-            },
-            {
-                "occupation": "engineer"
-            },
-            true
-        ],
-        [
-            "$eq - fail",
-            {
-                "occupation": {
-                    "$eq": "engineer"
-                }
-            },
-            {
-                "occupation": "civil engineer"
-            },
-            false
-        ],
-        [
-            "$ne - pass",
-            {
-                "level": {
-                    "$ne": "senior"
-                }
-            },
-            {
-                "level": "junior"
-            },
-            true
-        ],
-        [
-            "$ne - fail",
-            {
-                "level": {
-                    "$ne": "senior"
-                }
-            },
-            {
-                "level": "senior"
-            },
-            false
-        ],
-        [
-            "$regexi - pass (case insensitive match)",
-            {
-                "userAgent": {
-                    "$regexi": "(mobile|tablet)"
-                }
-            },
-            {
-                "userAgent": "Android Mobile Browser"
-            },
-            true
-        ],
-        [
-            "$regexi - pass (uppercase pattern, lowercase value)",
-            {
-                "userAgent": {
-                    "$regexi": "(MOBILE|TABLET)"
-                }
-            },
-            {
-                "userAgent": "android mobile browser"
-            },
-            true
-        ],
-        [
-            "$regexi - fail",
-            {
-                "userAgent": {
-                    "$regexi": "(mobile|tablet)"
-                }
-            },
-            {
-                "userAgent": "Chrome Desktop Browser"
-            },
-            false
-        ],
-        [
-            "$notRegex - pass",
-            {
-                "userAgent": {
-                    "$notRegex": "(Mobile|Tablet)"
-                }
-            },
-            {
-                "userAgent": "Chrome Desktop Browser"
-            },
-            true
-        ],
-        [
-            "$notRegex - fail",
-            {
-                "userAgent": {
-                    "$notRegex": "(Mobile|Tablet)"
-                }
-            },
-            {
-                "userAgent": "Android Mobile Browser"
-            },
-            false
-        ],
-        [
-            "$notRegexi - pass",
-            {
-                "userAgent": {
-                    "$notRegexi": "(mobile|tablet)"
-                }
-            },
-            {
-                "userAgent": "Chrome Desktop Browser"
-            },
-            true
-        ],
-        [
-            "$notRegexi - fail",
-            {
-                "userAgent": {
-                    "$notRegexi": "(mobile|tablet)"
-                }
-            },
-            {
-                "userAgent": "Android Mobile Browser"
-            },
-            false
-        ],
-        [
-            "$ini - pass",
-            {
-                "tags": {
-                    "$ini": [
-                        "A",
-                        "B"
-                    ]
-                }
-            },
-            {
-                "tags": "a"
-            },
-            true
-        ],
-        [
-            "$ini - fail",
-            {
-                "tags": {
-                    "$ini": [
-                        "a",
-                        "b"
-                    ]
-                }
-            },
-            {
-                "tags": "c"
-            },
-            false
-        ],
-        [
-            "$ini - array pass",
-            {
-                "tags": {
-                    "$ini": [
-                        "A",
-                        "B"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "a"
-                ]
-            },
-            true
-        ],
-        [
-            "$nini - pass",
-            {
-                "tags": {
-                    "$nini": [
-                        "A",
-                        "B"
-                    ]
-                }
-            },
-            {
-                "tags": "c"
-            },
-            true
-        ],
-        [
-            "$nini - fail",
-            {
-                "tags": {
-                    "$nini": [
-                        "A",
-                        "B"
-                    ]
-                }
-            },
-            {
-                "tags": "a"
-            },
-            false
-        ],
-        [
-            "$alli - pass",
-            {
-                "tags": {
-                    "$alli": [
-                        "A",
-                        "B"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "a",
-                    "b",
-                    "c"
-                ]
-            },
-            true
-        ],
-        [
-            "$alli - fail",
-            {
-                "tags": {
-                    "$alli": [
-                        "A",
-                        "B"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "a",
-                    "c"
-                ]
-            },
-            false
-        ],
-        [
-            "$gt/$lt numbers - pass",
-            {
-                "age": {
-                    "$gt": 30,
-                    "$lt": 60
-                }
-            },
-            {
-                "age": 50
-            },
-            true
-        ],
-        [
-            "$gt/$lt numbers - fail $lt",
-            {
-                "age": {
-                    "$gt": 30,
-                    "$lt": 60
-                }
-            },
-            {
-                "age": 60
-            },
-            false
-        ],
-        [
-            "$gt/$lt numbers - fail $gt",
-            {
-                "age": {
-                    "$gt": 30,
-                    "$lt": 60
-                }
-            },
-            {
-                "age": 30
-            },
-            false
-        ],
-        [
-            "$gte/$lte numbers - pass",
-            {
-                "age": {
-                    "$gte": 30,
-                    "$lte": 60
-                }
-            },
-            {
-                "age": 50
-            },
-            true
-        ],
-        [
-            "$gte/$lte numbers - pass $gte",
-            {
-                "age": {
-                    "$gte": 30,
-                    "$lte": 60
-                }
-            },
-            {
-                "age": 30
-            },
-            true
-        ],
-        [
-            "$gte/$lte numbers - pass $lte",
-            {
-                "age": {
-                    "$gte": 30,
-                    "$lte": 60
-                }
-            },
-            {
-                "age": 60
-            },
-            true
-        ],
-        [
-            "$gte/$lte numbers - fail $lte",
-            {
-                "age": {
-                    "$gte": 30,
-                    "$lte": 60
-                }
-            },
-            {
-                "age": 61
-            },
-            false
-        ],
-        [
-            "$gte/$lte numbers - fail $gte",
-            {
-                "age": {
-                    "$gt": 30,
-                    "$lt": 60
-                }
-            },
-            {
-                "age": 29
-            },
-            false
-        ],
-        [
-            "$gt/$lt strings - fail $gt",
-            {
-                "word": {
-                    "$gt": "alphabet",
-                    "$lt": "zebra"
-                }
-            },
-            {
-                "word": "alphabet"
-            },
-            false
-        ],
-        [
-            "$gt/$lt strings - fail $lt",
-            {
-                "word": {
-                    "$gt": "alphabet",
-                    "$lt": "zebra"
-                }
-            },
-            {
-                "word": "zebra"
-            },
-            false
-        ],
-        [
-            "$gt/$lt strings - pass",
-            {
-                "word": {
-                    "$gt": "alphabet",
-                    "$lt": "zebra"
-                }
-            },
-            {
-                "word": "always"
-            },
-            true
-        ],
-        [
-            "$gt/$lt strings - fail uppercase",
-            {
-                "word": {
-                    "$gt": "alphabet",
-                    "$lt": "zebra"
-                }
-            },
-            {
-                "word": "AZL"
-            },
-            false
-        ],
-        [
-            "nested value is null",
-            {
-                "address.state": "CA"
-            },
-            {
-                "address": null
-            },
-            false
-        ],
-        [
-            "nested value is integer",
-            {
-                "address.state": "CA"
-            },
-            {
-                "address": 123
-            },
-            false
-        ],
-        [
-            "$type string - pass",
-            {
-                "a": {
-                    "$type": "string"
-                }
-            },
-            {
-                "a": "a"
-            },
-            true
-        ],
-        [
-            "$type string - fail",
-            {
-                "a": {
-                    "$type": "string"
-                }
-            },
-            {
-                "a": 1
-            },
-            false
-        ],
-        [
-            "$type null - pass",
-            {
-                "a": {
-                    "$type": "null"
-                }
-            },
-            {
-                "a": null
-            },
-            true
-        ],
-        [
-            "$type null - fail",
-            {
-                "a": {
-                    "$type": "null"
-                }
-            },
-            {
-                "a": 1
-            },
-            false
-        ],
-        [
-            "$type boolean - pass",
-            {
-                "a": {
-                    "$type": "boolean"
-                }
-            },
-            {
-                "a": false
-            },
-            true
-        ],
-        [
-            "$type boolean - fail",
-            {
-                "a": {
-                    "$type": "boolean"
-                }
-            },
-            {
-                "a": 1
-            },
-            false
-        ],
-        [
-            "$type number - pass",
-            {
-                "a": {
-                    "$type": "number"
-                }
-            },
-            {
-                "a": 1
-            },
-            true
-        ],
-        [
-            "$type number - fail",
-            {
-                "a": {
-                    "$type": "number"
-                }
-            },
-            {
-                "a": "a"
-            },
-            false
-        ],
-        [
-            "$type object - pass",
-            {
-                "a": {
-                    "$type": "object"
-                }
-            },
-            {
-                "a": {
-                    "a": "b"
-                }
-            },
-            true
-        ],
-        [
-            "$type object - fail",
-            {
-                "a": {
-                    "$type": "object"
-                }
-            },
-            {
-                "a": 1
-            },
-            false
-        ],
-        [
-            "$type array - pass",
-            {
-                "a": {
-                    "$type": "array"
-                }
-            },
-            {
-                "a": [
-                    1,
-                    2
-                ]
-            },
-            true
-        ],
-        [
-            "$type array - fail",
-            {
-                "a": {
-                    "$type": "array"
-                }
-            },
-            {
-                "a": 1
-            },
-            false
-        ],
-        [
-            "unknown operator - pass",
-            {
-                "name": {
-                    "$regx": "hello"
-                }
-            },
-            {
-                "name": "hello"
-            },
-            false
-        ],
-        [
-            "$regex invalid - pass",
-            {
-                "name": {
-                    "$regex": "/???***[)"
-                }
-            },
-            {
-                "name": "hello"
-            },
-            false
-        ],
-        [
-            "$regex invalid - fail",
-            {
-                "name": {
-                    "$regex": "/???***[)"
-                }
-            },
-            {
-                "hello": "hello"
-            },
-            false
-        ],
-        [
-            "$size empty - pass",
-            {
-                "tags": {
-                    "$size": 0
-                }
-            },
-            {
-                "tags": []
-            },
-            true
-        ],
-        [
-            "$size empty - fail",
-            {
-                "tags": {
-                    "$size": 0
-                }
-            },
-            {
-                "tags": [
-                    10
-                ]
-            },
-            false
-        ],
-        [
-            "$size number - pass",
-            {
-                "tags": {
-                    "$size": 3
-                }
-            },
-            {
-                "tags": [
-                    "a",
-                    "b",
-                    "c"
-                ]
-            },
-            true
-        ],
-        [
-            "$size number - fail small",
-            {
-                "tags": {
-                    "$size": 3
-                }
-            },
-            {
-                "tags": [
-                    "a",
-                    "b"
-                ]
-            },
-            false
-        ],
-        [
-            "$size number - fail large",
-            {
-                "tags": {
-                    "$size": 3
-                }
-            },
-            {
-                "tags": [
-                    "a",
-                    "b",
-                    "c",
-                    "d"
-                ]
-            },
-            false
-        ],
-        [
-            "$size number - fail not array",
-            {
-                "tags": {
-                    "$size": 3
-                }
-            },
-            {
-                "tags": "abc"
-            },
-            false
-        ],
-        [
-            "$size nested - pass",
-            {
-                "tags": {
-                    "$size": {
-                        "$gt": 2
-                    }
-                }
-            },
-            {
-                "tags": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            true
-        ],
-        [
-            "$size nested - fail equal",
-            {
-                "tags": {
-                    "$size": {
-                        "$gt": 2
-                    }
-                }
-            },
-            {
-                "tags": [
-                    0,
-                    1
-                ]
-            },
-            false
-        ],
-        [
-            "$size nested - fail less than",
-            {
-                "tags": {
-                    "$size": {
-                        "$gt": 2
-                    }
-                }
-            },
-            {
-                "tags": [
-                    0
-                ]
-            },
-            false
-        ],
-        [
-            "$elemMatch contains - pass",
-            {
-                "tags": {
-                    "$elemMatch": {
-                        "$eq": "bar"
-                    }
-                }
-            },
-            {
-                "tags": [
-                    "foo",
-                    "bar",
-                    "baz"
-                ]
-            },
-            true
-        ],
-        [
-            "$elemMatch contains - false",
-            {
-                "tags": {
-                    "$elemMatch": {
-                        "$eq": "bar"
-                    }
-                }
-            },
-            {
-                "tags": [
-                    "foo",
-                    "baz"
-                ]
-            },
-            false
-        ],
-        [
-            "$elemMatch intersection - pass",
-            {
-                "tags": {
-                    "$elemMatch": {
-                        "$in": [
-                            "a",
-                            "b"
-                        ]
-                    }
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "e",
-                    "b"
-                ]
-            },
-            true
-        ],
-        [
-            "$elemMatch intersection - fail",
-            {
-                "tags": {
-                    "$elemMatch": {
-                        "$in": [
-                            "a",
-                            "b"
-                        ]
-                    }
-                }
-            },
-            {
-                "tags": [
-                    "d",
-                    "e",
-                    "f"
-                ]
-            },
-            false
-        ],
-        [
-            "$elemMatch not contains - pass",
-            {
-                "tags": {
-                    "$not": {
-                        "$elemMatch": {
-                            "$eq": "bar"
-                        }
-                    }
-                }
-            },
-            {
-                "tags": [
-                    "foo",
-                    "baz"
-                ]
-            },
-            true
-        ],
-        [
-            "$elemMatch not contains - fail",
-            {
-                "tags": {
-                    "$not": {
-                        "$elemMatch": {
-                            "$eq": "bar"
-                        }
-                    }
-                }
-            },
-            {
-                "tags": [
-                    "foo",
-                    "bar",
-                    "baz"
-                ]
-            },
-            false
-        ],
-        [
-            "$elemMatch nested - pass",
-            {
-                "hobbies": {
-                    "$elemMatch": {
-                        "name": {
-                            "$regex": "^ping"
-                        }
-                    }
-                }
-            },
-            {
-                "hobbies": [
-                    {
-                        "name": "bowling"
-                    },
-                    {
-                        "name": "pingpong"
-                    },
-                    {
-                        "name": "tennis"
-                    }
-                ]
-            },
-            true
-        ],
-        [
-            "$elemMatch nested - fail",
-            {
-                "hobbies": {
-                    "$elemMatch": {
-                        "name": {
-                            "$regex": "^ping"
-                        }
-                    }
-                }
-            },
-            {
-                "hobbies": [
-                    {
-                        "name": "bowling"
-                    },
-                    {
-                        "name": "tennis"
-                    }
-                ]
-            },
-            false
-        ],
-        [
-            "$elemMatch nested - fail not array",
-            {
-                "hobbies": {
-                    "$elemMatch": {
-                        "name": {
-                            "$regex": "^ping"
-                        }
-                    }
-                }
-            },
-            {
-                "hobbies": "all"
-            },
-            false
-        ],
-        [
-            "$not - pass",
-            {
-                "name": {
-                    "$not": {
-                        "$regex": "^hello"
-                    }
-                }
-            },
-            {
-                "name": "world"
-            },
-            true
-        ],
-        [
-            "$not - fail",
-            {
-                "name": {
-                    "$not": {
-                        "$regex": "^hello"
-                    }
-                }
-            },
-            {
-                "name": "hello world"
-            },
-            false
-        ],
-        [
-            "$all - pass",
-            {
-                "tags": {
-                    "$all": [
-                        "one",
-                        "three"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "one",
-                    "two",
-                    "three"
-                ]
-            },
-            true
-        ],
-        [
-            "$all - fail",
-            {
-                "tags": {
-                    "$all": [
-                        "one",
-                        "three"
-                    ]
-                }
-            },
-            {
-                "tags": [
-                    "one",
-                    "two",
-                    "four"
-                ]
-            },
-            false
-        ],
-        [
-            "$all - fail not array",
-            {
-                "tags": {
-                    "$all": [
-                        "one",
-                        "three"
-                    ]
-                }
-            },
-            {
-                "tags": "hello"
-            },
-            false
-        ],
-        [
-            "$nor - pass",
-            {
-                "$nor": [
-                    {
-                        "name": "john"
-                    },
-                    {
-                        "age": {
-                            "$lt": 30
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "jim",
-                "age": 40
-            },
-            true
-        ],
-        [
-            "$nor - fail both",
-            {
-                "$nor": [
-                    {
-                        "name": "john"
-                    },
-                    {
-                        "age": {
-                            "$lt": 30
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "john",
-                "age": 20
-            },
-            false
-        ],
-        [
-            "$nor - fail first",
-            {
-                "$nor": [
-                    {
-                        "name": "john"
-                    },
-                    {
-                        "age": {
-                            "$lt": 30
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "john",
-                "age": 40
-            },
-            false
-        ],
-        [
-            "$nor - fail second",
-            {
-                "$nor": [
-                    {
-                        "name": "john"
-                    },
-                    {
-                        "age": {
-                            "$lt": 30
-                        }
-                    }
-                ]
-            },
-            {
-                "name": "jim",
-                "age": 20
-            },
-            false
-        ],
-        [
-            "equals array - pass",
-            {
-                "tags": [
-                    "hello",
-                    "world"
-                ]
-            },
-            {
-                "tags": [
-                    "hello",
-                    "world"
-                ]
-            },
-            true
-        ],
-        [
-            "equals array - fail order",
-            {
-                "tags": [
-                    "hello",
-                    "world"
-                ]
-            },
-            {
-                "tags": [
-                    "world",
-                    "hello"
-                ]
-            },
-            false
-        ],
-        [
-            "equals array - fail missing item",
-            {
-                "tags": [
-                    "hello",
-                    "world"
-                ]
-            },
-            {
-                "tags": [
-                    "hello"
-                ]
-            },
-            false
-        ],
-        [
-            "equals array - fail extra item",
-            {
-                "tags": [
-                    "hello",
-                    "world"
-                ]
-            },
-            {
-                "tags": [
-                    "hello",
-                    "world",
-                    "foo"
-                ]
-            },
-            false
-        ],
-        [
-            "equals array - fail type mismatch",
-            {
-                "tags": [
-                    "hello",
-                    "world"
-                ]
-            },
-            {
-                "tags": "hello world"
-            },
-            false
-        ],
-        [
-            "equals object - pass",
-            {
-                "tags": {
-                    "hello": "world"
-                }
-            },
-            {
-                "tags": {
-                    "hello": "world"
-                }
-            },
-            true
-        ],
-        [
-            "equals object - fail extra property",
-            {
-                "tags": {
-                    "hello": "world"
-                }
-            },
-            {
-                "tags": {
-                    "hello": "world",
-                    "yes": "please"
-                }
-            },
-            false
-        ],
-        [
-            "equals object - fail missing property",
-            {
-                "tags": {
-                    "hello": "world"
-                }
-            },
-            {
-                "tags": {}
-            },
-            false
-        ],
-        [
-            "equals object - fail type mismatch",
-            {
-                "tags": {
-                    "hello": "world"
-                }
-            },
-            {
-                "tags": "hello world"
-            },
-            false
-        ],
-        [
-            "null condition - null attribute",
-            {
-                "userId": null
-            },
-            {
-                "userId": null
-            },
-            true
-        ],
-        [
-            "null condition - missing attribute",
-            {
-                "userId": null
-            },
-            {},
-            true
-        ],
-        [
-            "null condition - string attribute",
-            {
-                "userId": null
-            },
-            {
-                "userId": "123"
-            },
-            false
-        ],
-        [
-            "null condition - zero attribute",
-            {
-                "userId": null
-            },
-            {
-                "userId": 0
-            },
-            false
-        ],
-        [
-            "null condition - empty string attribute",
-            {
-                "userId": null
-            },
-            {
-                "userId": ""
-            },
-            false
-        ],
-        [
-            "null condition - false attribute",
-            {
-                "userId": null
-            },
-            {
-                "userId": false
-            },
-            false
-        ],
-        [
-            "false condition - missing attribute",
-            {
-                "userId": false
-            },
-            {},
-            false
-        ],
-        [
-            "false strict condition - missing attribute",
-            {
-                "userId": {
-                    "$eq": false
-                }
-            },
-            {},
-            false
-        ],
-        [
-            "$vgt/$vlt - pass - major",
-            {
-                "version": {
-                    "$vgt": "9.99.8",
-                    "$vlt": "11.0.1"
-                }
-            },
-            {
-                "version": "10.12.13"
-            },
-            true
-        ],
-        [
-            "$vgt/$vlt - pass - minor",
-            {
-                "version": {
-                    "$vgt": "10.2.11",
-                    "$vlt": "10.20.11"
-                }
-            },
-            {
-                "version": "10.12.11"
-            },
-            true
-        ],
-        [
-            "$vgt/$vlt - pass - patch",
-            {
-                "version": {
-                    "$vgt": "10.0.2",
-                    "$vlt": "10.0.20"
-                }
-            },
-            {
-                "version": "10.0.12"
-            },
-            true
-        ],
-        [
-            "$vgt/$vlt - fail $vlt - major",
-            {
-                "version": {
-                    "$vgt": "30.0.0",
-                    "$vlt": "50.0.0"
-                }
-            },
-            {
-                "version": "60.0.0"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt - fail $vlt - minor",
-            {
-                "version": {
-                    "$vgt": "10.30.0",
-                    "$vlt": "10.50.0"
-                }
-            },
-            {
-                "version": "10.60.0"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt - fail $vlt - patch",
-            {
-                "version": {
-                    "$vgt": "10.2.30",
-                    "$vlt": "10.2.50"
-                }
-            },
-            {
-                "version": "10.2.60"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt - fail $vgt - major",
-            {
-                "version": {
-                    "$vgt": "30.0.16",
-                    "$vlt": "50.0.16"
-                }
-            },
-            {
-                "version": "20.0.16"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt - fail $vgt - minor",
-            {
-                "version": {
-                    "$vgt": "10.30.0",
-                    "$vlt": "10.50.0"
-                }
-            },
-            {
-                "version": "10.20.0"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt - fail $vgt - patch",
-            {
-                "version": {
-                    "$vgt": "10.30.10",
-                    "$vlt": "10.30.20"
-                }
-            },
-            {
-                "version": "10.30.2"
-            },
-            false
-        ],
-        [
-            "$vgte/$vlte - pass $vgte - major",
-            {
-                "version": {
-                    "$vgte": "30.1.2",
-                    "$vlte": "60.1.2"
-                }
-            },
-            {
-                "version": "30.1.2"
-            },
-            true
-        ],
-        [
-            "$vgte/$vlte - pass $vgte - minor",
-            {
-                "version": {
-                    "$vgte": "5.30.2",
-                    "$vlte": "5.60.2"
-                }
-            },
-            {
-                "version": "5.30.2"
-            },
-            true
-        ],
-        [
-            "$vgte/$vlte - pass $vgte - patch",
-            {
-                "version": {
-                    "$vgte": "5.10.30",
-                    "$vlte": "5.10.60"
-                }
-            },
-            {
-                "version": "5.10.30"
-            },
-            true
-        ],
-        [
-            "$vgte/$vlte - pass $vlte - major",
-            {
-                "version": {
-                    "$vgte": "30.1.2",
-                    "$vlte": "60.1.2"
-                }
-            },
-            {
-                "version": "60.1.2"
-            },
-            true
-        ],
-        [
-            "$vgte/$vlte - pass $vlte - minor",
-            {
-                "version": {
-                    "$vgte": "1.30.2",
-                    "$vlte": "1.60.2"
-                }
-            },
-            {
-                "version": "1.60.2"
-            },
-            true
-        ],
-        [
-            "$vgte/$vlte - pass $vlte - patch",
-            {
-                "version": {
-                    "$vgte": "1.2.30",
-                    "$vlte": "1.2.60"
-                }
-            },
-            {
-                "version": "1.2.60"
-            },
-            true
-        ],
-        [
-            "$vgte/$vlte - fail $vlte - major",
-            {
-                "version": {
-                    "$vgte": "30.1.2",
-                    "$vlte": "60.1.2"
-                }
-            },
-            {
-                "version": "61.1.2"
-            },
-            false
-        ],
-        [
-            "$vgte/$vlte - fail $vgt - minor",
-            {
-                "version": {
-                    "$vgte": "30.1.2",
-                    "$vlte": "60.1.2"
-                }
-            },
-            {
-                "version": "29.1.2"
-            },
-            false
-        ],
-        [
-            "$vgte/$vlte - fail $vgt - patch",
-            {
-                "version": {
-                    "$vgte": "1.2.30",
-                    "$vlte": "1.2.60"
-                }
-            },
-            {
-                "version": "1.2.29"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt prerelease - fail $vgt",
-            {
-                "v": {
-                    "$vgt": "1.0.0-alpha",
-                    "$vlt": "1.0.0-beta"
-                }
-            },
-            {
-                "v": "1.0.0-alpha"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt prerelease  w/ multiple fields - fail $vgt",
-            {
-                "v": {
-                    "$vgt": "1.0.0-alpha.2",
-                    "$vlt": "1.0.0-beta.1"
-                }
-            },
-            {
-                "v": "1.0.0-alpha.1"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt prerelease - fail $vlt",
-            {
-                "v": {
-                    "$vgt": "1.0.0-alpha",
-                    "$vlt": "1.0.0-beta"
-                }
-            },
-            {
-                "v": "1.0.0-beta"
-            },
-            false
-        ],
-        [
-            "$vgt/$vlt prerelease - pass",
-            {
-                "v": {
-                    "$vgt": "1.0.0-alpha",
-                    "$vlt": "1.0.0-beta"
-                }
-            },
-            {
-                "v": "1.0.0-alpha.10"
-            },
-            true
-        ],
-        [
-            "$vgt/$vlt prerelease - fail uppercase",
-            {
-                "v": {
-                    "$vgt": "1.0.0-alpha",
-                    "$vlt": "1.0.0-beta"
-                }
-            },
-            {
-                "v": "1.0.0-ALPHA"
-            },
-            false
-        ],
-        [
-            "$veq - pass",
-            {
-                "v": {
-                    "$veq": "1.2.3"
-                }
-            },
-            {
-                "v": "1.2.3"
-            },
-            true
-        ],
-        [
-            "$veq - pass (with build)",
-            {
-                "v": {
-                    "$veq": "1.2.3"
-                }
-            },
-            {
-                "v": "1.2.3+build.abc.123"
-            },
-            true
-        ],
-        [
-            "$vne - pass",
-            {
-                "v": {
-                    "$vne": "1.2.3"
-                }
-            },
-            {
-                "v": "2.2.3"
-            },
-            true
-        ],
-        [
-            "$vne - pass (prerelease)",
-            {
-                "v": {
-                    "$vne": "1.2.3"
-                }
-            },
-            {
-                "v": "1.2.3-alpha"
-            },
-            true
-        ],
-        [
-            "version 0.9.99 < 1.0.0",
-            {
-                "version": {
-                    "$vlt": "1.0.0"
-                }
-            },
-            {
-                "version": "0.9.99"
-            },
-            true
-        ],
-        [
-            "version 0.9.0 < 0.10.0",
-            {
-                "version": {
-                    "$vlt": "0.10.0"
-                }
-            },
-            {
-                "version": "0.9.0"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-0.0 < 1.0.0-0.0.0",
-            {
-                "version": {
-                    "$vlt": "1.0.0-0.0.0"
-                }
-            },
-            {
-                "version": "1.0.0-0.0"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-9999 < 1.0.0--",
-            {
-                "version": {
-                    "$vlt": "1.0.0--"
-                }
-            },
-            {
-                "version": "1.0.0-9999"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-99 < 1.0.0-100",
-            {
-                "version": {
-                    "$vlt": "1.0.0-100"
-                }
-            },
-            {
-                "version": "1.0.0-99"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-alpha < 1.0.0-alpha.1",
-            {
-                "version": {
-                    "$vlt": "1.0.0-alpha.1"
-                }
-            },
-            {
-                "version": "1.0.0-alpha"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-alpha.1 < 1.0.0-alpha.beta",
-            {
-                "version": {
-                    "$vlt": "1.0.0-alpha.beta"
-                }
-            },
-            {
-                "version": "1.0.0-alpha.1"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-alpha.beta < 1.0.0-beta",
-            {
-                "version": {
-                    "$vlt": "1.0.0-beta"
-                }
-            },
-            {
-                "version": "1.0.0-alpha.beta"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-beta < 1.0.0-beta.2",
-            {
-                "version": {
-                    "$vlt": "1.0.0-beta.2"
-                }
-            },
-            {
-                "version": "1.0.0-beta"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-beta.2 < 1.0.0-beta.11",
-            {
-                "version": {
-                    "$vlt": "1.0.0-beta.11"
-                }
-            },
-            {
-                "version": "1.0.0-beta.2"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-beta.11 < 1.0.0-rc.1",
-            {
-                "version": {
-                    "$vlt": "1.0.0-rc.1"
-                }
-            },
-            {
-                "version": "1.0.0-beta.11"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-rc.1 < 1.0.0",
-            {
-                "version": {
-                    "$vlt": "1.0.0"
-                }
-            },
-            {
-                "version": "1.0.0-rc.1"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-0 < 1.0.0--1",
-            {
-                "version": {
-                    "$vlt": "1.0.0--1"
-                }
-            },
-            {
-                "version": "1.0.0-0"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-0 < 1.0.0-1",
-            {
-                "version": {
-                    "$vlt": "1.0.0-1"
-                }
-            },
-            {
-                "version": "1.0.0-0"
-            },
-            true
-        ],
-        [
-            "version 1.0.0-1.0 < 1.0.0-1.-1",
-            {
-                "version": {
-                    "$vlt": "1.0.0-1.-1"
-                }
-            },
-            {
-                "version": "1.0.0-1.0"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-a.b.c < 1.2.3-a.b.c.d",
-            {
-                "version": {
-                    "$vlt": "1.2.3-a.b.c.d"
-                }
-            },
-            {
-                "version": "1.2.3-a.b.c"
-            },
-            true
-        ],
-        [
-            "version 0.0.0 > 0.0.0-foo",
-            {
-                "version": {
-                    "$vgt": "0.0.0-foo"
-                }
-            },
-            {
-                "version": "0.0.0"
-            },
-            true
-        ],
-        [
-            "version 0.0.1 > 0.0.0",
-            {
-                "version": {
-                    "$vgt": "0.0.0"
-                }
-            },
-            {
-                "version": "0.0.1"
-            },
-            true
-        ],
-        [
-            "version 1.0.0 > 0.9.9",
-            {
-                "version": {
-                    "$vgt": "0.9.9"
-                }
-            },
-            {
-                "version": "1.0.0"
-            },
-            true
-        ],
-        [
-            "version 0.10.0 > 0.9.0",
-            {
-                "version": {
-                    "$vgt": "0.9.0"
-                }
-            },
-            {
-                "version": "0.10.0"
-            },
-            true
-        ],
-        [
-            "version 0.99.0 > 0.10.0",
-            {
-                "version": {
-                    "$vgt": "0.10.0"
-                }
-            },
-            {
-                "version": "0.99.0"
-            },
-            true
-        ],
-        [
-            "version 2.0.0 > 1.2.3",
-            {
-                "version": {
-                    "$vgt": "1.2.3"
-                }
-            },
-            {
-                "version": "2.0.0"
-            },
-            true
-        ],
-        [
-            "version v0.0.0 > 0.0.0-foo",
-            {
-                "version": {
-                    "$vgt": "0.0.0-foo"
-                }
-            },
-            {
-                "version": "v0.0.0"
-            },
-            true
-        ],
-        [
-            "version v0.0.1 > 0.0.0",
-            {
-                "version": {
-                    "$vgt": "0.0.0"
-                }
-            },
-            {
-                "version": "v0.0.1"
-            },
-            true
-        ],
-        [
-            "version v1.0.0 > 0.9.9",
-            {
-                "version": {
-                    "$vgt": "0.9.9"
-                }
-            },
-            {
-                "version": "v1.0.0"
-            },
-            true
-        ],
-        [
-            "version v0.10.0 > 0.9.0",
-            {
-                "version": {
-                    "$vgt": "0.9.0"
-                }
-            },
-            {
-                "version": "v0.10.0"
-            },
-            true
-        ],
-        [
-            "version v0.99.0 > 0.10.0",
-            {
-                "version": {
-                    "$vgt": "0.10.0"
-                }
-            },
-            {
-                "version": "v0.99.0"
-            },
-            true
-        ],
-        [
-            "version v2.0.0 > 1.2.3",
-            {
-                "version": {
-                    "$vgt": "1.2.3"
-                }
-            },
-            {
-                "version": "v2.0.0"
-            },
-            true
-        ],
-        [
-            "version 0.0.0 > v0.0.0-foo",
-            {
-                "version": {
-                    "$vgt": "v0.0.0-foo"
-                }
-            },
-            {
-                "version": "0.0.0"
-            },
-            true
-        ],
-        [
-            "version 0.0.1 > v0.0.0",
-            {
-                "version": {
-                    "$vgt": "v0.0.0"
-                }
-            },
-            {
-                "version": "0.0.1"
-            },
-            true
-        ],
-        [
-            "version 1.0.0 > v0.9.9",
-            {
-                "version": {
-                    "$vgt": "v0.9.9"
-                }
-            },
-            {
-                "version": "1.0.0"
-            },
-            true
-        ],
-        [
-            "version 0.10.0 > v0.9.0",
-            {
-                "version": {
-                    "$vgt": "v0.9.0"
-                }
-            },
-            {
-                "version": "0.10.0"
-            },
-            true
-        ],
-        [
-            "version 0.99.0 > v0.10.0",
-            {
-                "version": {
-                    "$vgt": "v0.10.0"
-                }
-            },
-            {
-                "version": "0.99.0"
-            },
-            true
-        ],
-        [
-            "version 2.0.0 > v1.2.3",
-            {
-                "version": {
-                    "$vgt": "v1.2.3"
-                }
-            },
-            {
-                "version": "2.0.0"
-            },
-            true
-        ],
-        [
-            "version 1.2.3 > 1.2.3-asdf",
-            {
-                "version": {
-                    "$vgt": "1.2.3-asdf"
-                }
-            },
-            {
-                "version": "1.2.3"
-            },
-            true
-        ],
-        [
-            "version 1.2.3 > 1.2.3-4",
-            {
-                "version": {
-                    "$vgt": "1.2.3-4"
-                }
-            },
-            {
-                "version": "1.2.3"
-            },
-            true
-        ],
-        [
-            "version 1.2.3 > 1.2.3-4-foo",
-            {
-                "version": {
-                    "$vgt": "1.2.3-4-foo"
-                }
-            },
-            {
-                "version": "1.2.3"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-5-foo > 1.2.3-5",
-            {
-                "version": {
-                    "$vgt": "1.2.3-5"
-                }
-            },
-            {
-                "version": "1.2.3-5-foo"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-5 > 1.2.3-4",
-            {
-                "version": {
-                    "$vgt": "1.2.3-4"
-                }
-            },
-            {
-                "version": "1.2.3-5"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-5-foo > 1.2.3-5-Foo",
-            {
-                "version": {
-                    "$vgt": "1.2.3-5-Foo"
-                }
-            },
-            {
-                "version": "1.2.3-5-foo"
-            },
-            true
-        ],
-        [
-            "version 3.0.0 > 2.7.2+asdf",
-            {
-                "version": {
-                    "$vgt": "2.7.2+asdf"
-                }
-            },
-            {
-                "version": "3.0.0"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-a.10 > 1.2.3-a.5",
-            {
-                "version": {
-                    "$vgt": "1.2.3-a.5"
-                }
-            },
-            {
-                "version": "1.2.3-a.10"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-a.b > 1.2.3-a.5",
-            {
-                "version": {
-                    "$vgt": "1.2.3-a.5"
-                }
-            },
-            {
-                "version": "1.2.3-a.b"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-a.b > 1.2.3-a",
-            {
-                "version": {
-                    "$vgt": "1.2.3-a"
-                }
-            },
-            {
-                "version": "1.2.3-a.b"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-a.b.c.10.d.5 > 1.2.3-a.b.c.5.d.100",
-            {
-                "version": {
-                    "$vgt": "1.2.3-a.b.c.5.d.100"
-                }
-            },
-            {
-                "version": "1.2.3-a.b.c.10.d.5"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-r2 > 1.2.3-r100",
-            {
-                "version": {
-                    "$vgt": "1.2.3-r100"
-                }
-            },
-            {
-                "version": "1.2.3-r2"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-r100 > 1.2.3-R2",
-            {
-                "version": {
-                    "$vgt": "1.2.3-R2"
-                }
-            },
-            {
-                "version": "1.2.3-r100"
-            },
-            true
-        ],
-        [
-            "version a.b.c.d.e.f > 1.2.3",
-            {
-                "version": {
-                    "$vgt": "1.2.3"
-                }
-            },
-            {
-                "version": "a.b.c.d.e.f"
-            },
-            true
-        ],
-        [
-            "version 10.0.0 > 9.0.0",
-            {
-                "version": {
-                    "$vgt": "9.0.0"
-                }
-            },
-            {
-                "version": "10.0.0"
-            },
-            true
-        ],
-        [
-            "version 10000.0.0 > 9999.0.0",
-            {
-                "version": {
-                    "$vgt": "9999.0.0"
-                }
-            },
-            {
-                "version": "10000.0.0"
-            },
-            true
-        ],
-        [
-            "version 1.2.3 == 1.2.3",
-            {
-                "version": {
-                    "$veq": "1.2.3"
-                }
-            },
-            {
-                "version": "1.2.3"
-            },
-            true
-        ],
-        [
-            "version 1.2.3 == v1.2.3",
-            {
-                "version": {
-                    "$veq": "v1.2.3"
-                }
-            },
-            {
-                "version": "1.2.3"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-0 == v1.2.3-0",
-            {
-                "version": {
-                    "$veq": "v1.2.3-0"
-                }
-            },
-            {
-                "version": "1.2.3-0"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-1 == 1.2.3-1",
-            {
-                "version": {
-                    "$veq": "1.2.3-1"
-                }
-            },
-            {
-                "version": "1.2.3-1"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-1 == v1.2.3-1",
-            {
-                "version": {
-                    "$veq": "v1.2.3-1"
-                }
-            },
-            {
-                "version": "1.2.3-1"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-beta == 1.2.3-beta",
-            {
-                "version": {
-                    "$veq": "1.2.3-beta"
-                }
-            },
-            {
-                "version": "1.2.3-beta"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-beta == v1.2.3-beta",
-            {
-                "version": {
-                    "$veq": "v1.2.3-beta"
-                }
-            },
-            {
-                "version": "1.2.3-beta"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-beta+build == 1.2.3-beta+otherbuild",
-            {
-                "version": {
-                    "$veq": "1.2.3-beta+otherbuild"
-                }
-            },
-            {
-                "version": "1.2.3-beta+build"
-            },
-            true
-        ],
-        [
-            "version 1.2.3-beta+build == v1.2.3-beta+otherbuild",
-            {
-                "version": {
-                    "$veq": "v1.2.3-beta+otherbuild"
-                }
-            },
-            {
-                "version": "1.2.3-beta+build"
-            },
-            true
-        ],
-        [
-            "version 1-2-3 == 1.2.3",
-            {
-                "version": {
-                    "$veq": "1.2.3"
-                }
-            },
-            {
-                "version": "1-2-3"
-            },
-            true
-        ],
-        [
-            "version 1-2-3 == 1-2.3+build99",
-            {
-                "version": {
-                    "$veq": "1-2.3+build99"
-                }
-            },
-            {
-                "version": "1-2-3"
-            },
-            true
-        ],
-        [
-            "version 1-2-3 == v1.2.3",
-            {
-                "version": {
-                    "$veq": "v1.2.3"
-                }
-            },
-            {
-                "version": "1-2-3"
-            },
-            true
-        ],
-        [
-            "version 1.2.3.4 == 1.2.3-4",
-            {
-                "version": {
-                    "$veq": "1.2.3-4"
-                }
-            },
-            {
-                "version": "1.2.3.4"
-            },
-            true
-        ],
-        [
-            "$or pass but second condition fail",
-            {
-                "$or": [
-                    {
-                        "foo": 1
-                    },
-                    {
-                        "bar": 1
-                    }
-                ],
-                "baz": 2
-            },
-            {
-                "foo": 1,
-                "bar": 2,
-                "baz": 1
-            },
-            false
-        ],
-        [
-            "$or and second condition both pass",
-            {
-                "$or": [
-                    {
-                        "foo": 1
-                    },
-                    {
-                        "bar": 1
-                    }
-                ],
-                "baz": 2
-            },
-            {
-                "foo": 1,
-                "bar": 2,
-                "baz": 2
-            },
-            true
-        ],
-        [
-            "$and condition pass but $or fail",
-            {
-                "$and": [
-                    {
-                        "foo": 1
-                    },
-                    {
-                        "bar": 1
-                    }
-                ],
-                "$or": [
-                    {
-                        "baz": 1
-                    },
-                    {
-                        "empty": 1
-                    }
-                ]
-            },
-            {
-                "foo": 1,
-                "bar": 1,
-                "baz": 2
-            },
-            false
-        ],
-        [
-            "$and and $or both pass",
-            {
-                "$and": [
-                    {
-                        "foo": 1
-                    },
-                    {
-                        "bar": 1
-                    }
-                ],
-                "$or": [
-                    {
-                        "baz": 1
-                    },
-                    {
-                        "empty": 1
-                    }
-                ]
-            },
-            {
-                "foo": 1,
-                "bar": 1,
-                "baz": 2,
-                "empty": 1
-            },
-            true
-        ],
-        [
-            "$inGroup passes for member of known group id",
-            {
-                "id": {
-                    "$inGroup": "group_id"
-                }
-            },
-            {
-                "id": 1
-            },
-            true,
-            {
-                "group_id": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        [
-            "$inGroup fails for non-member of known group id",
-            {
-                "id": {
-                    "$inGroup": "group_id"
-                }
-            },
-            {
-                "id": 5
-            },
-            false,
-            {
-                "group_id": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        [
-            "$inGroup fails for unknown group id",
-            {
-                "id": {
-                    "$inGroup": "unknowngroup_id"
-                }
-            },
-            {
-                "id": 1
-            },
-            false,
-            {
-                "group_id": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        [
-            "$notInGroup fails for member of known group id",
-            {
-                "id": {
-                    "$notInGroup": "group_id"
-                }
-            },
-            {
-                "id": 1
-            },
-            false,
-            {
-                "group_id": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        [
-            "$notInGroup passes for non-member of known group id",
-            {
-                "id": {
-                    "$notInGroup": "group_id"
-                }
-            },
-            {
-                "id": 5
-            },
-            true,
-            {
-                "group_id": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        [
-            "$notInGroup passes for unknown group id",
-            {
-                "id": {
-                    "$notInGroup": "unknowngroup_id"
-                }
-            },
-            {
-                "id": 1
-            },
-            true,
-            {
-                "group_id": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        [
-            "$inGroup passes for properly typed data",
-            {
-                "id": {
-                    "$inGroup": "group_id"
-                }
-            },
-            {
-                "id": "2"
-            },
-            true,
-            {
-                "group_id": [
-                    1,
-                    "2",
-                    3
-                ]
-            }
-        ],
-        [
-            "$inGroup fails for improperly typed data",
-            {
-                "id": {
-                    "$inGroup": "group_id"
-                }
-            },
-            {
-                "id": "3"
-            },
-            false,
-            {
-                "group_id": [
-                    1,
-                    "2",
-                    3
-                ]
-            }
-        ]
+  "specVersion": "0.8.0",
+  "evalCondition": [
+    [
+      "$not - pass",
+      {
+        "$not": {
+          "name": "hello"
+        }
+      },
+      {
+        "name": "world"
+      },
+      true
     ],
-    "hash": [
-        [
-            "",
+    [
+      "$not - fail",
+      {
+        "$not": {
+          "name": "hello"
+        }
+      },
+      {
+        "name": "hello"
+      },
+      false
+    ],
+    [
+      "$and/$or - all true",
+      {
+        "$and": [
+          {
+            "father.age": {
+              "$gt": 65
+            }
+          },
+          {
+            "$or": [
+              {
+                "bday": {
+                  "$regex": "-12-25$"
+                }
+              },
+              {
+                "name": "santa"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "santa",
+        "bday": "1980-12-25",
+        "father": {
+          "age": 70
+        }
+      },
+      true
+    ],
+    [
+      "$groups - match",
+      {
+        "$and": [
+          {
+            "$groups": {
+              "$elemMatch": {
+                "$eq": "a"
+              }
+            }
+          },
+          {
+            "$groups": {
+              "$elemMatch": {
+                "$eq": "b"
+              }
+            }
+          },
+          {
+            "$or": [
+              {
+                "$groups": {
+                  "$elemMatch": {
+                    "$eq": "c"
+                  }
+                }
+              },
+              {
+                "$groups": {
+                  "$elemMatch": {
+                    "$eq": "e"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "$not": {
+              "$groups": {
+                "$elemMatch": {
+                  "$eq": "f"
+                }
+              }
+            }
+          },
+          {
+            "$not": {
+              "$groups": {
+                "$elemMatch": {
+                  "$eq": "g"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "$groups": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
+      },
+      true
+    ],
+    [
+      "$groups - no match",
+      {
+        "$and": [
+          {
+            "$groups": {
+              "$elemMatch": {
+                "$eq": "a"
+              }
+            }
+          },
+          {
+            "$groups": {
+              "$elemMatch": {
+                "$eq": "b"
+              }
+            }
+          },
+          {
+            "$or": [
+              {
+                "$groups": {
+                  "$elemMatch": {
+                    "$eq": "c"
+                  }
+                }
+              },
+              {
+                "$groups": {
+                  "$elemMatch": {
+                    "$eq": "e"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "$not": {
+              "$groups": {
+                "$elemMatch": {
+                  "$eq": "d"
+                }
+              }
+            }
+          },
+          {
+            "$not": {
+              "$groups": {
+                "$elemMatch": {
+                  "$eq": "g"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "$groups": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
+      },
+      false
+    ],
+    [
+      "$and/$or - first or true",
+      {
+        "$and": [
+          {
+            "father.age": {
+              "$gt": 65
+            }
+          },
+          {
+            "$or": [
+              {
+                "bday": {
+                  "$regex": "-12-25$"
+                }
+              },
+              {
+                "name": "santa"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "santa",
+        "bday": "1980-12-20",
+        "father": {
+          "age": 70
+        }
+      },
+      true
+    ],
+    [
+      "$and/$or - second or true",
+      {
+        "$and": [
+          {
+            "father.age": {
+              "$gt": 65
+            }
+          },
+          {
+            "$or": [
+              {
+                "bday": {
+                  "$regex": "-12-25$"
+                }
+              },
+              {
+                "name": "santa"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "barbara",
+        "bday": "1980-12-25",
+        "father": {
+          "age": 70
+        }
+      },
+      true
+    ],
+    [
+      "$and/$or - first and false",
+      {
+        "$and": [
+          {
+            "father.age": {
+              "$gt": 65
+            }
+          },
+          {
+            "$or": [
+              {
+                "bday": {
+                  "$regex": "-12-25$"
+                }
+              },
+              {
+                "name": "santa"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "santa",
+        "bday": "1980-12-25",
+        "father": {
+          "age": 65
+        }
+      },
+      false
+    ],
+    [
+      "$and/$or - both or false",
+      {
+        "$and": [
+          {
+            "father.age": {
+              "$gt": 65
+            }
+          },
+          {
+            "$or": [
+              {
+                "bday": {
+                  "$regex": "-12-25$"
+                }
+              },
+              {
+                "name": "santa"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "barbara",
+        "bday": "1980-11-25",
+        "father": {
+          "age": 70
+        }
+      },
+      false
+    ],
+    [
+      "$and/$or - both and false",
+      {
+        "$and": [
+          {
+            "father.age": {
+              "$gt": 65
+            }
+          },
+          {
+            "$or": [
+              {
+                "bday": {
+                  "$regex": "-12-25$"
+                }
+              },
+              {
+                "name": "santa"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "john smith",
+        "bday": "1956-12-20",
+        "father": {
+          "age": 40
+        }
+      },
+      false
+    ],
+    [
+      "$exists - false pass",
+      {
+        "pets.dog.name": {
+          "$exists": false
+        }
+      },
+      {
+        "hello": "world"
+      },
+      true
+    ],
+    [
+      "$exists - false fail",
+      {
+        "pets.dog.name": {
+          "$exists": false
+        }
+      },
+      {
+        "pets": {
+          "dog": {
+            "name": "fido"
+          }
+        }
+      },
+      false
+    ],
+    [
+      "$exists - true fail",
+      {
+        "pets.dog.name": {
+          "$exists": true
+        }
+      },
+      {
+        "hello": "world"
+      },
+      false
+    ],
+    [
+      "$exists - true pass",
+      {
+        "pets.dog.name": {
+          "$exists": true
+        }
+      },
+      {
+        "pets": {
+          "dog": {
+            "name": "fido"
+          }
+        }
+      },
+      true
+    ],
+    [
+      "equals - multiple datatypes",
+      {
+        "str": "str",
+        "num": 10,
+        "flag": false
+      },
+      {
+        "str": "str",
+        "num": 10,
+        "flag": false
+      },
+      true
+    ],
+    [
+      "$in - pass",
+      {
+        "num": {
+          "$in": [
+            1,
+            2,
+            3
+          ]
+        }
+      },
+      {
+        "num": 2
+      },
+      true
+    ],
+    [
+      "$in - fail",
+      {
+        "num": {
+          "$in": [
+            1,
+            2,
+            3
+          ]
+        }
+      },
+      {
+        "num": 4
+      },
+      false
+    ],
+    [
+      "$in - not array",
+      {
+        "num": {
+          "$in": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$in - array pass 1",
+      {
+        "tags": {
+          "$in": [
             "a",
-            1,
-            0.22
-        ],
-        [
-            "",
-            "b",
-            1,
-            0.077
-        ],
-        [
-            "b",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "a"
+        ]
+      },
+      true
+    ],
+    [
+      "$in - array pass 2",
+      {
+        "tags": {
+          "$in": [
             "a",
-            1,
-            0.946
-        ],
-        [
-            "ef",
-            "d",
-            1,
-            0.652
-        ],
-        [
-            "asdf",
-            "8952klfjas09ujk",
-            1,
-            0.549
-        ],
-        [
-            "",
-            "123",
-            1,
-            0.011
-        ],
-        [
-            "",
-            "___)((*\":&",
-            1,
-            0.563
-        ],
-        [
-            "seed",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
+      },
+      true
+    ],
+    [
+      "$in - array pass 3",
+      {
+        "tags": {
+          "$in": [
             "a",
-            2,
-            0.0505
-        ],
-        [
-            "seed",
-            "b",
-            2,
-            0.2696
-        ],
-        [
-            "foo",
-            "ab",
-            2,
-            0.2575
-        ],
-        [
-            "foo",
-            "def",
-            2,
-            0.2019
-        ],
-        [
-            "89123klj",
-            "8952klfjas09ujkasdf",
-            2,
-            0.124
-        ],
-        [
-            "90850943850283058242805",
-            "123",
-            2,
-            0.7516
-        ],
-        [
-            "()**(%$##$%#$#",
-            "___)((*\":&",
-            2,
-            0.0128
-        ],
-        [
-            "abc",
-            "def",
-            99,
-            null
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "a"
         ]
+      },
+      true
     ],
-    "getBucketRange": [
-        [
-            "normal 50/50",
-            [
-                2,
-                1,
-                null
-            ],
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ]
-        ],
-        [
-            "reduced coverage",
-            [
-                2,
-                0.5,
-                null
-            ],
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ]
-        ],
-        [
-            "zero coverage",
-            [
-                2,
-                0,
-                null
-            ],
-            [
-                [
-                    0,
-                    0
-                ],
-                [
-                    0.5,
-                    0.5
-                ]
-            ]
-        ],
-        [
-            "4 variations",
-            [
-                4,
-                1,
-                null
-            ],
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.25,
-                    0.5
-                ],
-                [
-                    0.5,
-                    0.75
-                ],
-                [
-                    0.75,
-                    1
-                ]
-            ]
-        ],
-        [
-            "uneven weights",
-            [
-                2,
-                1,
-                [
-                    0.4,
-                    0.6
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.4
-                ],
-                [
-                    0.4,
-                    1
-                ]
-            ]
-        ],
-        [
-            "uneven weights, 3 variations",
-            [
-                3,
-                1,
-                [
-                    0.2,
-                    0.3,
-                    0.5
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.2
-                ],
-                [
-                    0.2,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ]
-        ],
-        [
-            "uneven weights, reduced coverage, 3 variations",
-            [
-                3,
-                0.2,
-                [
-                    0.2,
-                    0.3,
-                    0.5
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.04
-                ],
-                [
-                    0.2,
-                    0.26
-                ],
-                [
-                    0.5,
-                    0.6
-                ]
-            ]
-        ],
-        [
-            "negative coverage",
-            [
-                2,
-                -0.2,
-                null
-            ],
-            [
-                [
-                    0,
-                    0
-                ],
-                [
-                    0.5,
-                    0.5
-                ]
-            ]
-        ],
-        [
-            "coverage above 1",
-            [
-                2,
-                1.5,
-                null
-            ],
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ]
-        ],
-        [
-            "weights sum below 1",
-            [
-                2,
-                1,
-                [
-                    0.4,
-                    0.1
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ]
-        ],
-        [
-            "weights sum above 1",
-            [
-                2,
-                1,
-                [
-                    0.7,
-                    0.6
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ]
-        ],
-        [
-            "weights.length not equal to num variations",
-            [
-                4,
-                1,
-                [
-                    0.4,
-                    0.4,
-                    0.2
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.25,
-                    0.5
-                ],
-                [
-                    0.5,
-                    0.75
-                ],
-                [
-                    0.75,
-                    1
-                ]
-            ]
-        ],
-        [
-            "weights sum almost equals 1",
-            [
-                2,
-                1,
-                [
-                    0.4,
-                    0.5999
-                ]
-            ],
-            [
-                [
-                    0,
-                    0.4
-                ],
-                [
-                    0.4,
-                    0.9999
-                ]
-            ]
+    [
+      "$in - array fail 1",
+      {
+        "tags": {
+          "$in": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
         ]
+      },
+      false
     ],
-    "feature": [
-        [
-            "unknown feature key",
-            {},
-            "my-feature",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "unknownFeature",
-                "ruleId": ""
-            }
-        ],
-        [
-            "defaults when empty",
-            {
-                "features": {
-                    "feature": {}
-                }
-            },
-            "feature",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "uses defaultValue - number",
-            {
-                "features": {
-                    "feature": {
-                        "defaultValue": 1
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "uses custom values - string",
-            {
-                "features": {
-                    "feature": {
-                        "defaultValue": "yes"
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": "yes",
-                "on": true,
-                "off": false,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules",
-            {
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rule with rule id",
-            {
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "id": "a",
-                                "force": 1
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": "a"
-            }
-        ],
-        [
-            "force rules - force false",
-            {
-                "features": {
-                    "feature": {
-                        "defaultValue": true,
-                        "rules": [
-                            {
-                                "force": false
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": false,
-                "on": false,
-                "off": true,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - coverage included",
-            {
-                "attributes": {
-                    "id": "3"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "coverage": 0.5
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rule - coverage with integer hash attribute",
-            {
-                "attributes": {
-                    "id": 3
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "coverage": 0.5
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - coverage excluded",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "id": "a",
-                                "force": 1,
-                                "coverage": 0.5
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - coverage missing hashAttribute",
-            {
-                "attributes": {},
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "coverage": 0.5
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - coverage 0",
-            {
-                "attributes": {
-                    "id": "d0bc0a5a"
-                },
-                "features": {
-                    "8d156": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "coverage": 0,
-                                "hashVersion": 2
-                            }
-                        ]
-                    }
-                }
-            },
-            "8d156",
-            {
-                "value": 0,
-                "on": false,
-                "off": true,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - condition pass",
-            {
-                "attributes": {
-                    "country": "US",
-                    "browser": "firefox"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "condition": {
-                                    "country": {
-                                        "$in": [
-                                            "US",
-                                            "CA"
-                                        ]
-                                    },
-                                    "browser": "firefox"
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - condition fail",
-            {
-                "attributes": {
-                    "country": "US",
-                    "browser": "chrome"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "condition": {
-                                    "country": {
-                                        "$in": [
-                                            "US",
-                                            "CA"
-                                        ]
-                                    },
-                                    "browser": "firefox"
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "force rules - coverage with bad hash version",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 2,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "coverage": 1.0,
-                                "hashVersion": 99
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "ignores empty rules",
-            {
-                "features": {
-                    "feature": {
-                        "rules": [
-                            {}
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "empty experiment rule - c",
-            {
-                "attributes": {
-                    "id": "123"
-                },
-                "features": {
-                    "feature": {
-                        "rules": [
-                            {
-                                "variations": [
-                                    "a",
-                                    "b",
-                                    "c"
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": "c",
-                "on": true,
-                "off": false,
-                "experiment": {
-                    "key": "feature",
-                    "variations": [
-                        "a",
-                        "b",
-                        "c"
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "value": "c",
-                    "variationId": 2,
-                    "inExperiment": true,
-                    "hashUsed": true,
-                    "hashAttribute": "id",
-                    "hashValue": "123",
-                    "bucket": 0.863,
-                    "key": "2",
-                    "stickyBucketUsed": false
-                },
-                "source": "experiment",
-                "ruleId": ""
-            }
-        ],
-        [
-            "empty experiment rule - a",
-            {
-                "attributes": {
-                    "id": "456"
-                },
-                "features": {
-                    "feature": {
-                        "rules": [
-                            {
-                                "id": "id",
-                                "variations": [
-                                    "a",
-                                    "b",
-                                    "c"
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": "a",
-                "on": true,
-                "off": false,
-                "experiment": {
-                    "key": "feature",
-                    "variations": [
-                        "a",
-                        "b",
-                        "c"
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "value": "a",
-                    "variationId": 0,
-                    "inExperiment": true,
-                    "hashUsed": true,
-                    "hashAttribute": "id",
-                    "hashValue": "456",
-                    "bucket": 0.178,
-                    "key": "0",
-                    "stickyBucketUsed": false
-                },
-                "source": "experiment",
-                "ruleId": "id"
-            }
-        ],
-        [
-            "empty experiment rule - b",
-            {
-                "attributes": {
-                    "id": "fds"
-                },
-                "features": {
-                    "feature": {
-                        "rules": [
-                            {
-                                "variations": [
-                                    "a",
-                                    "b",
-                                    "c"
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": "b",
-                "on": true,
-                "off": false,
-                "experiment": {
-                    "key": "feature",
-                    "variations": [
-                        "a",
-                        "b",
-                        "c"
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "value": "b",
-                    "variationId": 1,
-                    "inExperiment": true,
-                    "hashUsed": true,
-                    "hashAttribute": "id",
-                    "hashValue": "fds",
-                    "bucket": 0.514,
-                    "key": "1",
-                    "stickyBucketUsed": false
-                },
-                "source": "experiment",
-                "ruleId": ""
-            }
-        ],
-        [
-            "creates experiments properly",
-            {
-                "attributes": {
-                    "anonId": "123",
-                    "premium": true
-                },
-                "features": {
-                    "feature": {
-                        "rules": [
-                            {
-                                "coverage": 0.99,
-                                "hashAttribute": "anonId",
-                                "seed": "feature",
-                                "hashVersion": 2,
-                                "name": "Test",
-                                "phase": "1",
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.1
-                                    ],
-                                    [
-                                        0.1,
-                                        1.0
-                                    ]
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "v0",
-                                        "name": "variation 0"
-                                    },
-                                    {
-                                        "key": "v1",
-                                        "name": "variation 1"
-                                    }
-                                ],
-                                "filters": [
-                                    {
-                                        "attribute": "anonId",
-                                        "seed": "pricing",
-                                        "ranges": [
-                                            [
-                                                0,
-                                                1
-                                            ]
-                                        ]
-                                    }
-                                ],
-                                "namespace": [
-                                    "pricing",
-                                    0,
-                                    1
-                                ],
-                                "key": "hello",
-                                "variations": [
-                                    true,
-                                    false
-                                ],
-                                "weights": [
-                                    0.1,
-                                    0.9
-                                ],
-                                "condition": {
-                                    "premium": true
-                                },
-                                "foo": "bar"
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": false,
-                "on": false,
-                "off": true,
-                "source": "experiment",
-                "experiment": {
-                    "coverage": 0.99,
-                    "ranges": [
-                        [
-                            0,
-                            0.1
-                        ],
-                        [
-                            0.1,
-                            1.0
-                        ]
-                    ],
-                    "meta": [
-                        {
-                            "key": "v0",
-                            "name": "variation 0"
-                        },
-                        {
-                            "key": "v1",
-                            "name": "variation 1"
-                        }
-                    ],
-                    "filters": [
-                        {
-                            "attribute": "anonId",
-                            "seed": "pricing",
-                            "ranges": [
-                                [
-                                    0,
-                                    1
-                                ]
-                            ]
-                        }
-                    ],
-                    "name": "Test",
-                    "phase": "1",
-                    "seed": "feature",
-                    "hashVersion": 2,
-                    "hashAttribute": "anonId",
-                    "namespace": [
-                        "pricing",
-                        0,
-                        1
-                    ],
-                    "key": "hello",
-                    "variations": [
-                        true,
-                        false
-                    ],
-                    "weights": [
-                        0.1,
-                        0.9
-                    ],
-                    "condition": {
-                        "premium": true
-                    }
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "value": false,
-                    "variationId": 1,
-                    "inExperiment": true,
-                    "hashUsed": true,
-                    "hashAttribute": "anonId",
-                    "hashValue": "123",
-                    "bucket": 0.5231,
-                    "key": "v1",
-                    "name": "variation 1",
-                    "stickyBucketUsed": false
-                },
-                "ruleId": ""
-            }
-        ],
-        [
-            "rule orders - skip 1",
-            {
-                "attributes": {
-                    "browser": "firefox"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "condition": {
-                                    "browser": "chrome"
-                                }
-                            },
-                            {
-                                "force": 2,
-                                "condition": {
-                                    "browser": "firefox"
-                                }
-                            },
-                            {
-                                "force": 3,
-                                "condition": {
-                                    "browser": "safari"
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "rule orders - skip 1,2",
-            {
-                "attributes": {
-                    "browser": "safari"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "id": "1",
-                                "condition": {
-                                    "browser": "chrome"
-                                }
-                            },
-                            {
-                                "id": "2",
-                                "force": 2,
-                                "condition": {
-                                    "browser": "firefox"
-                                }
-                            },
-                            {
-                                "id": "3",
-                                "force": 3,
-                                "condition": {
-                                    "browser": "safari"
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 3,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": "3"
-            }
-        ],
-        [
-            "rule orders - skip all",
-            {
-                "attributes": {
-                    "browser": "ie"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 1,
-                                "condition": {
-                                    "browser": "chrome"
-                                }
-                            },
-                            {
-                                "force": 2,
-                                "condition": {
-                                    "browser": "firefox"
-                                }
-                            },
-                            {
-                                "force": 3,
-                                "condition": {
-                                    "browser": "safari"
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 0,
-                "on": false,
-                "off": true,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "skips experiment on coverage",
-            {
-                "attributes": {
-                    "id": "123"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "variations": [
-                                    0,
-                                    1,
-                                    2,
-                                    3
-                                ],
-                                "coverage": 0.01
-                            },
-                            {
-                                "force": 3
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 3,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "skips experiment on namespace",
-            {
-                "attributes": {
-                    "id": "123"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "variations": [
-                                    0,
-                                    1,
-                                    2,
-                                    3
-                                ],
-                                "namespace": [
-                                    "pricing",
-                                    0,
-                                    0.01
-                                ]
-                            },
-                            {
-                                "force": 3
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 3,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "handles integer hashAttribute",
-            {
-                "attributes": {
-                    "id": 123
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "variations": [
-                                    0,
-                                    1
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "experiment",
-                "experiment": {
-                    "key": "feature",
-                    "variations": [
-                        0,
-                        1
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "hashAttribute": "id",
-                    "hashValue": 123,
-                    "hashUsed": true,
-                    "inExperiment": true,
-                    "value": 1,
-                    "variationId": 1,
-                    "key": "1",
-                    "bucket": 0.863,
-                    "stickyBucketUsed": false
-                },
-                "ruleId": ""
-            }
-        ],
-        [
-            "skip experiment on missing hashAttribute",
-            {
-                "attributes": {
-                    "id": "123"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "variations": [
-                                    0,
-                                    1,
-                                    2,
-                                    3
-                                ],
-                                "hashAttribute": "company"
-                            },
-                            {
-                                "force": 3
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 3,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "include experiments when forced",
-            {
-                "attributes": {
-                    "id": "123"
-                },
-                "forcedVariations": {
-                    "feature": 1
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "variations": [
-                                    0,
-                                    1,
-                                    2,
-                                    3
-                                ]
-                            },
-                            {
-                                "force": 3
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "experiment",
-                "experiment": {
-                    "key": "feature",
-                    "variations": [
-                        0,
-                        1,
-                        2,
-                        3
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "value": 1,
-                    "variationId": 1,
-                    "inExperiment": true,
-                    "hashUsed": false,
-                    "hashAttribute": "id",
-                    "hashValue": "123",
-                    "key": "1",
-                    "stickyBucketUsed": false
-                },
-                "ruleId": ""
-            }
-        ],
-        [
-            "Force rule with range, ignores coverage",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 2,
-                                "coverage": 0.01,
-                                "range": [
-                                    0,
-                                    0.99
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Force rule, hash version 2",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 2,
-                                "hashVersion": 2,
-                                "range": [
-                                    0.96,
-                                    0.97
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Force rule, skip due to range",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 2,
-                                "range": [
-                                    0,
-                                    0.01
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 0,
-                "on": false,
-                "off": true,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Force rule, skip due to filter",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 2,
-                                "filters": [
-                                    {
-                                        "seed": "seed",
-                                        "ranges": [
-                                            [
-                                                0,
-                                                0.01
-                                            ]
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 0,
-                "on": false,
-                "off": true,
-                "source": "defaultValue",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Force rule, use seed with range",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "force": 2,
-                                "range": [
-                                    0,
-                                    0.5
-                                ],
-                                "seed": "fjdslafdsa",
-                                "hashVersion": 2
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 2,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Support passthrough variations",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "key": "holdout",
-                                "variations": [
-                                    1,
-                                    2
-                                ],
-                                "hashVersion": 2,
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.01
-                                    ],
-                                    [
-                                        0.01,
-                                        1.0
-                                    ]
-                                ],
-                                "meta": [
-                                    {},
-                                    {
-                                        "passthrough": true
-                                    }
-                                ]
-                            },
-                            {
-                                "key": "experiment",
-                                "variations": [
-                                    3,
-                                    4
-                                ],
-                                "hashVersion": 2,
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.5
-                                    ],
-                                    [
-                                        0.5,
-                                        1.0
-                                    ]
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 3,
-                "on": true,
-                "off": false,
-                "source": "experiment",
-                "experiment": {
-                    "key": "experiment",
-                    "hashVersion": 2,
-                    "variations": [
-                        3,
-                        4
-                    ],
-                    "ranges": [
-                        [
-                            0,
-                            0.5
-                        ],
-                        [
-                            0.5,
-                            1.0
-                        ]
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "hashAttribute": "id",
-                    "hashUsed": true,
-                    "hashValue": "1",
-                    "inExperiment": true,
-                    "key": "0",
-                    "value": 3,
-                    "variationId": 0,
-                    "bucket": 0.4413,
-                    "stickyBucketUsed": false
-                },
-                "ruleId": ""
-            }
-        ],
-        [
-            "Support holdout groups",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "key": "holdout",
-                                "hashVersion": 2,
-                                "variations": [
-                                    1,
-                                    2
-                                ],
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.99
-                                    ],
-                                    [
-                                        0.99,
-                                        1.0
-                                    ]
-                                ],
-                                "meta": [
-                                    {},
-                                    {
-                                        "passthrough": true
-                                    }
-                                ]
-                            },
-                            {
-                                "key": "experiment",
-                                "hashVersion": 2,
-                                "variations": [
-                                    3,
-                                    4
-                                ],
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.5
-                                    ],
-                                    [
-                                        0.5,
-                                        1.0
-                                    ]
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "feature",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "experiment",
-                "experiment": {
-                    "hashVersion": 2,
-                    "ranges": [
-                        [
-                            0,
-                            0.99
-                        ],
-                        [
-                            0.99,
-                            1.0
-                        ]
-                    ],
-                    "meta": [
-                        {},
-                        {
-                            "passthrough": true
-                        }
-                    ],
-                    "key": "holdout",
-                    "variations": [
-                        1,
-                        2
-                    ]
-                },
-                "experimentResult": {
-                    "featureId": "feature",
-                    "hashAttribute": "id",
-                    "hashUsed": true,
-                    "hashValue": "1",
-                    "inExperiment": true,
-                    "key": "0",
-                    "value": 1,
-                    "variationId": 0,
-                    "bucket": 0.8043,
-                    "stickyBucketUsed": false
-                },
-                "ruleId": ""
-            }
-        ],
-        [
-            "Prerequisite flag off, block dependent flag",
-            {
-                "attributes": {
-                    "id": "123",
-                    "memberType": "basic",
-                    "country": "Canada"
-                },
-                "features": {
-                    "parentFlag": {
-                        "defaultValue": "silver",
-                        "rules": [
-                            {
-                                "condition": {
-                                    "country": "Canada"
-                                },
-                                "force": "red"
-                            },
-                            {
-                                "condition": {
-                                    "country": {
-                                        "$in": [
-                                            "USA",
-                                            "Mexico"
-                                        ]
-                                    }
-                                },
-                                "force": "green"
-                            }
-                        ]
-                    },
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": "green"
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "prerequisite",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Prerequisite flag missing, block dependent flag",
-            {
-                "attributes": {
-                    "id": "123",
-                    "memberType": "basic",
-                    "country": "Canada"
-                },
-                "features": {
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": "green"
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "prerequisite",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Prerequisite flag on, evaluate dependent flag",
-            {
-                "attributes": {
-                    "id": "123",
-                    "memberType": "basic",
-                    "country": "USA"
-                },
-                "features": {
-                    "parentFlag": {
-                        "defaultValue": "silver",
-                        "rules": [
-                            {
-                                "condition": {
-                                    "country": "Canada"
-                                },
-                                "force": "red"
-                            },
-                            {
-                                "condition": {
-                                    "country": {
-                                        "$in": [
-                                            "USA",
-                                            "Mexico"
-                                        ]
-                                    }
-                                },
-                                "force": "green"
-                            }
-                        ]
-                    },
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": "green"
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": "success",
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Multiple parallel prerequisite flags on, evaluate dependent flag",
-            {
-                "attributes": {
-                    "id": "123",
-                    "memberType": "basic",
-                    "country": "USA"
-                },
-                "features": {
-                    "parentFlag1": {
-                        "defaultValue": "silver",
-                        "rules": [
-                            {
-                                "condition": {
-                                    "country": "Canada"
-                                },
-                                "force": "red"
-                            },
-                            {
-                                "condition": {
-                                    "country": {
-                                        "$in": [
-                                            "USA",
-                                            "Mexico"
-                                        ]
-                                    }
-                                },
-                                "force": "green"
-                            }
-                        ]
-                    },
-                    "parentFlag2": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "condition": {
-                                    "id": "123"
-                                },
-                                "force": 2
-                            }
-                        ]
-                    },
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag1",
-                                        "condition": {
-                                            "value": "green"
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag2",
-                                        "condition": {
-                                            "value": {
-                                                "$gt": 1
-                                            }
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": "success",
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Multiple nested prerequisite flags on, evaluate dependent flag",
-            {
-                "attributes": {
-                    "id": "123",
-                    "memberType": "basic",
-                    "country": "USA"
-                },
-                "features": {
-                    "parentFlag1": {
-                        "defaultValue": "silver",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag2",
-                                        "condition": {
-                                            "value": {
-                                                "$gt": 1
-                                            }
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "country": "Canada"
-                                },
-                                "force": "red"
-                            },
-                            {
-                                "condition": {
-                                    "country": {
-                                        "$in": [
-                                            "USA",
-                                            "Mexico"
-                                        ]
-                                    }
-                                },
-                                "force": "green"
-                            }
-                        ]
-                    },
-                    "parentFlag2": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "condition": {
-                                    "id": "123"
-                                },
-                                "force": 2
-                            }
-                        ]
-                    },
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag1",
-                                        "condition": {
-                                            "value": "green"
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": "success",
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Prerequisite experiment flag in target bucket, evaluate dependent flag",
-            {
-                "attributes": {
-                    "id": "1234",
-                    "memberType": "basic",
-                    "country": "USA"
-                },
-                "features": {
-                    "parentExperimentFlag": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "key": "experiment",
-                                "variations": [
-                                    0,
-                                    1
-                                ],
-                                "hashAttribute": "id",
-                                "hashVersion": 2,
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.5
-                                    ],
-                                    [
-                                        0.5,
-                                        1.0
-                                    ]
-                                ]
-                            }
-                        ]
-                    },
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentExperimentFlag",
-                                        "condition": {
-                                            "value": 1
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": "success",
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
-            {
-                "attributes": {
-                    "id": "1234",
-                    "memberType": "basic",
-                    "country": "USA"
-                },
-                "features": {
-                    "parentExperimentFlag": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "key": "experiment",
-                                "variations": [
-                                    0,
-                                    1
-                                ],
-                                "hashAttribute": "id",
-                                "hashVersion": 2,
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.5
-                                    ],
-                                    [
-                                        0.5,
-                                        1.0
-                                    ]
-                                ]
-                            }
-                        ]
-                    },
-                    "childFlag": {
-                        "defaultValue": "default",
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentExperimentFlag",
-                                        "condition": {
-                                            "value": 0
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "memberType": "basic"
-                                },
-                                "force": "success"
-                            }
-                        ]
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "prerequisite",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Prerequisite cycle detected, break",
-            {
-                "attributes": {
-                    "id": "123"
-                },
-                "features": {
-                    "flag1": {
-                        "defaultValue": true,
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "flag2",
-                                        "condition": {
-                                            "value": true
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "flag2": {
-                        "defaultValue": true,
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "flag1",
-                                        "condition": {
-                                            "value": true
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
-            "flag1",
-            {
-                "value": null,
-                "on": false,
-                "off": true,
-                "source": "cyclicPrerequisite",
-                "ruleId": ""
-            }
-        ],
-        [
-            "Multiple references to same prerequisite, do not break",
-            {
-                "attributes": {
-                    "id": "123",
-                    "browser": "edge"
-                },
-                "features": {
-                    "childFlag": {
-                        "defaultValue": true,
-                        "rules": [
-                            {
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": {
-                                                "$ne": false
-                                            }
-                                        },
-                                        "gate": true
-                                    },
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": true
-                                        },
-                                        "gate": true
-                                    }
-                                ]
-                            },
-                            {
-                                "condition": {
-                                    "browser": "safari"
-                                },
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": true
-                                        }
-                                    }
-                                ],
-                                "force": "C"
-                            },
-                            {
-                                "condition": {
-                                    "browser": {
-                                        "$ne": "safari"
-                                    }
-                                },
-                                "parentConditions": [
-                                    {
-                                        "id": "parentFlag",
-                                        "condition": {
-                                            "value": true
-                                        }
-                                    }
-                                ],
-                                "force": "T"
-                            }
-                        ]
-                    },
-                    "parentFlag": {
-                        "defaultValue": true
-                    }
-                }
-            },
-            "childFlag",
-            {
-                "value": "T",
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "SavedGroups correctly pulled from context for force rule",
-            {
-                "attributes": {
-                    "id": 123
-                },
-                "features": {
-                    "inGroup_force_rule": {
-                        "defaultValue": false,
-                        "rules": [
-                            {
-                                "force": true,
-                                "condition": {
-                                    "id": {
-                                        "$inGroup": "group_id"
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                },
-                "savedGroups": {
-                    "group_id": [
-                        123,
-                        456
-                    ]
-                }
-            },
-            "inGroup_force_rule",
-            {
-                "value": true,
-                "on": true,
-                "off": false,
-                "source": "force",
-                "ruleId": ""
-            }
-        ],
-        [
-            "SavedGroups correctly pulled from context for experiment rule",
-            {
-                "attributes": {
-                    "id": 123
-                },
-                "features": {
-                    "inGroup_experiment_rule": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "key": "experiment",
-                                "condition": {
-                                    "id": {
-                                        "$inGroup": "group_id"
-                                    }
-                                },
-                                "hashVersion": 2,
-                                "variations": [
-                                    1,
-                                    2
-                                ],
-                                "ranges": [
-                                    [
-                                        0,
-                                        0.5
-                                    ],
-                                    [
-                                        0.5,
-                                        1.0
-                                    ]
-                                ]
-                            }
-                        ]
-                    }
-                },
-                "savedGroups": {
-                    "group_id": [
-                        123,
-                        456
-                    ]
-                }
-            },
-            "inGroup_experiment_rule",
-            {
-                "value": 1,
-                "on": true,
-                "off": false,
-                "source": "experiment",
-                "experiment": {
-                    "hashVersion": 2,
-                    "condition": {
-                        "id": {
-                            "$inGroup": "group_id"
-                        }
-                    },
-                    "variations": [
-                        1,
-                        2
-                    ],
-                    "ranges": [
-                        [
-                            0,
-                            0.5
-                        ],
-                        [
-                            0.5,
-                            1.0
-                        ]
-                    ],
-                    "key": "experiment"
-                },
-                "experimentResult": {
-                    "featureId": "inGroup_experiment_rule",
-                    "hashAttribute": "id",
-                    "hashUsed": true,
-                    "hashValue": 123,
-                    "inExperiment": true,
-                    "key": "0",
-                    "value": 1,
-                    "variationId": 0,
-                    "bucket": 0.1736,
-                    "stickyBucketUsed": false
-                },
-                "ruleId": ""
-            }
-        ]
+    [
+      "$in - array fail 2",
+      {
+        "tags": {
+          "$in": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": []
+      },
+      false
     ],
-    "run": [
-        [
-            "default weights - 1",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "default weights - 2",
-            {
-                "attributes": {
-                    "id": "2"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "default weights - 3",
-            {
-                "attributes": {
-                    "id": "3"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "default weights - 4",
-            {
-                "attributes": {
-                    "id": "4"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "default weights - 5",
-            {
-                "attributes": {
-                    "id": "5"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "default weights - 6",
-            {
-                "attributes": {
-                    "id": "6"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "default weights - 7",
-            {
-                "attributes": {
-                    "id": "7"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "default weights - 8",
-            {
-                "attributes": {
-                    "id": "8"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "default weights - 9",
-            {
-                "attributes": {
-                    "id": "9"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 1",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 2",
-            {
-                "attributes": {
-                    "id": "2"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 3",
-            {
-                "attributes": {
-                    "id": "3"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 4",
-            {
-                "attributes": {
-                    "id": "4"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 5",
-            {
-                "attributes": {
-                    "id": "5"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 6",
-            {
-                "attributes": {
-                    "id": "6"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 7",
-            {
-                "attributes": {
-                    "id": "7"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 8",
-            {
-                "attributes": {
-                    "id": "8"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "uneven weights - 9",
-            {
-                "attributes": {
-                    "id": "9"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.1,
-                    0.9
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "coverage - 1",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "coverage - 2",
-            {
-                "attributes": {
-                    "id": "2"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "coverage - 3",
-            {
-                "attributes": {
-                    "id": "3"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "coverage - 4",
-            {
-                "attributes": {
-                    "id": "4"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "coverage - 5",
-            {
-                "attributes": {
-                    "id": "5"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "coverage - 6",
-            {
-                "attributes": {
-                    "id": "6"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "coverage - 7",
-            {
-                "attributes": {
-                    "id": "7"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "coverage - 8",
-            {
-                "attributes": {
-                    "id": "8"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "coverage - 9",
-            {
-                "attributes": {
-                    "id": "9"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0.4
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "three way test - 1",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            2,
-            true,
-            true
-        ],
-        [
-            "three way test - 2",
-            {
-                "attributes": {
-                    "id": "2"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "three way test - 3",
-            {
-                "attributes": {
-                    "id": "3"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "three way test - 4",
-            {
-                "attributes": {
-                    "id": "4"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            2,
-            true,
-            true
-        ],
-        [
-            "three way test - 5",
-            {
-                "attributes": {
-                    "id": "5"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "three way test - 6",
-            {
-                "attributes": {
-                    "id": "6"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            2,
-            true,
-            true
-        ],
-        [
-            "three way test - 7",
-            {
-                "attributes": {
-                    "id": "7"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "three way test - 8",
-            {
-                "attributes": {
-                    "id": "8"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "three way test - 9",
-            {
-                "attributes": {
-                    "id": "9"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "test name - my-test",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "test name - my-test-3",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test-3",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            true,
-            true
-        ],
-        [
-            "empty id",
-            {
-                "attributes": {
-                    "id": ""
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "null id",
-            {
-                "attributes": {
-                    "id": null
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "missing id",
-            {
-                "attributes": {}
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "missing attributes",
-            {},
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "single variation",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "negative forced variation",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "force": -8
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "high forced variation",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "force": 25
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "evaluates conditions - pass",
-            {
-                "attributes": {
-                    "id": "1",
-                    "browser": "firefox"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "condition": {
-                    "browser": "firefox"
-                }
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "evaluates conditions - fail",
-            {
-                "attributes": {
-                    "id": "1",
-                    "browser": "chrome"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "condition": {
-                    "browser": "firefox"
-                }
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "custom hashAttribute",
-            {
-                "attributes": {
-                    "id": "2",
-                    "companyId": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "hashAttribute": "companyId"
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "globally disabled",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "enabled": false
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "querystring force",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "url": "http://example.com?forced-test-qs=1#someanchor"
-            },
-            {
-                "key": "forced-test-qs",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            false
-        ],
-        [
-            "run active experiments",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "active": true,
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "skip inactive experiments",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "active": false,
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "querystring force with inactive",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "url": "http://example.com/?my-test=1"
-            },
-            {
-                "key": "my-test",
-                "active": false,
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            false
-        ],
-        [
-            "coverage take precendence over forced",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "force": 1,
-                "coverage": 0.01,
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "JSON values for experiments",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    {
-                        "color": "blue",
-                        "size": "small"
-                    },
-                    {
-                        "color": "green",
-                        "size": "large"
-                    }
-                ]
-            },
-            {
-                "color": "green",
-                "size": "large"
-            },
-            true,
-            true
-        ],
-        [
-            "Force variation from context",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "forcedVariations": {
-                    "my-test": 0
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            true,
-            false
-        ],
-        [
-            "Skips experiments in QA mode",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "qaMode": true
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "Works in QA mode if forced in context",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "qaMode": true,
-                "forcedVariations": {
-                    "my-test": 1
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            false
-        ],
-        [
-            "Works in QA mode if forced in experiment",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "qaMode": true
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "force": 1
-            },
-            1,
-            true,
-            false
-        ],
-        [
-            "Experiment namespace - pass",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "namespace": [
-                    "namespace",
-                    0.1,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Experiment namespace - fail",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "namespace": [
-                    "namespace",
-                    0,
-                    0.1
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "Experiment coverage - Works when 0",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "no-coverage",
-                "variations": [
-                    0,
-                    1
-                ],
-                "coverage": 0
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "Filtered, included",
-            {
-                "attributes": {
-                    "id": "1",
-                    "anonId": "fsdafsda"
-                }
-            },
-            {
-                "key": "filtered",
-                "variations": [
-                    0,
-                    1
-                ],
-                "filters": [
-                    {
-                        "seed": "seed",
-                        "ranges": [
-                            [
-                                0,
-                                0.1
-                            ],
-                            [
-                                0.2,
-                                0.4
-                            ]
-                        ]
-                    },
-                    {
-                        "seed": "seed",
-                        "attribute": "anonId",
-                        "ranges": [
-                            [
-                                0.8,
-                                1.0
-                            ]
-                        ]
-                    }
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Filtered, excluded",
-            {
-                "attributes": {
-                    "id": "1",
-                    "anonId": "fsdafsda"
-                }
-            },
-            {
-                "key": "filtered",
-                "variations": [
-                    0,
-                    1
-                ],
-                "filters": [
-                    {
-                        "seed": "seed",
-                        "ranges": [
-                            [
-                                0,
-                                0.1
-                            ],
-                            [
-                                0.2,
-                                0.4
-                            ]
-                        ]
-                    },
-                    {
-                        "seed": "seed",
-                        "attribute": "anonId",
-                        "ranges": [
-                            [
-                                0.6,
-                                0.8
-                            ]
-                        ]
-                    }
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "Filtered, ignore namespace",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "filtered",
-                "variations": [
-                    0,
-                    1
-                ],
-                "filters": [
-                    {
-                        "seed": "seed",
-                        "ranges": [
-                            [
-                                0,
-                                0.1
-                            ],
-                            [
-                                0.2,
-                                0.4
-                            ]
-                        ]
-                    }
-                ],
-                "namespace": [
-                    "test",
-                    0,
-                    0.001
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Ranges, ignore coverage and weights",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "ranges",
-                "variations": [
-                    0,
-                    1
-                ],
-                "ranges": [
-                    [
-                        0.99,
-                        1.0
-                    ],
-                    [
-                        0.0,
-                        0.99
-                    ]
-                ],
-                "coverage": 0.01,
-                "weights": [
-                    0.99,
-                    0.01
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Ranges, partial coverage",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "configs",
-                "variations": [
-                    0,
-                    1
-                ],
-                "ranges": [
-                    [
-                        0,
-                        0.1
-                    ],
-                    [
-                        0.9,
-                        1.0
-                    ]
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "Uses seed and hash version",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "key",
-                "seed": "foo",
-                "hashVersion": 2,
-                "variations": [
-                    0,
-                    1
-                ],
-                "ranges": [
-                    [
-                        0,
-                        0.5
-                    ],
-                    [
-                        0.5,
-                        1.0
-                    ]
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Uses seed with default weights/coverage",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "key",
-                "seed": "foo",
-                "hashVersion": 2,
-                "variations": [
-                    0,
-                    1
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Uses seed with weights/coverage",
-            {
-                "attributes": {
-                    "id": "1"
-                }
-            },
-            {
-                "key": "key",
-                "seed": "foo",
-                "hashVersion": 2,
-                "variations": [
-                    0,
-                    1
-                ],
-                "weights": [
-                    0.5,
-                    0.5
-                ],
-                "coverage": 0.99
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Prerequisite condition passes",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "parentFlag": {
-                        "defaultValue": true
-                    }
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "parentConditions": [
-                    {
-                        "id": "parentFlag",
-                        "condition": {
-                            "value": true
-                        }
-                    }
-                ]
-            },
-            1,
-            true,
-            true
-        ],
-        [
-            "Prerequisite condition fails",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "features": {
-                    "parentFlag": {
-                        "defaultValue": false
-                    }
-                }
-            },
-            {
-                "key": "my-test",
-                "variations": [
-                    0,
-                    1
-                ],
-                "parentConditions": [
-                    {
-                        "id": "parentFlag",
-                        "condition": {
-                            "value": true
-                        }
-                    }
-                ]
-            },
-            0,
-            false,
-            false
-        ],
-        [
-            "SavedGroups correctly pulled from context for experiment",
-            {
-                "attributes": {
-                    "id": "4"
-                },
-                "savedGroups": {
-                    "group_id": [
-                        "4",
-                        "5",
-                        "6"
-                    ]
-                }
-            },
-            {
-                "key": "group-filtered-test",
-                "condition": {
-                    "id": {
-                        "$inGroup": "group_id"
-                    }
-                },
-                "variations": [
-                    0,
-                    1,
-                    2
-                ]
-            },
-            0,
-            true,
-            true
-        ]
+    [
+      "$in - fail (case sensitive mismatch)",
+      {
+        "country": {
+          "$in": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
     ],
-    "chooseVariation": [
-        [
-            "even range, 0.2",
-            0.2,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            0
-        ],
-        [
-            "even range, 0.4",
-            0.4,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            0
-        ],
-        [
-            "even range, 0.6",
-            0.6,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            1
-        ],
-        [
-            "even range, 0.8",
-            0.8,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            1
-        ],
-        [
-            "even range, 0",
-            0,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            0
-        ],
-        [
-            "even range, 0.5",
-            0.5,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            1
-        ],
-        [
-            "reduced range, 0.2",
-            0.2,
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ],
-            0
-        ],
-        [
-            "reduced range, 0.4",
-            0.4,
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ],
-            -1
-        ],
-        [
-            "reduced range, 0.6",
-            0.6,
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ],
-            1
-        ],
-        [
-            "reduced range, 0.8",
-            0.8,
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ],
-            -1
-        ],
-        [
-            "reduced range, 0.25",
-            0.25,
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ],
-            -1
-        ],
-        [
-            "reduced range, 0.5",
-            0.5,
-            [
-                [
-                    0,
-                    0.25
-                ],
-                [
-                    0.5,
-                    0.75
-                ]
-            ],
-            1
-        ],
-        [
-            "zero range",
-            0.5,
-            [
-                [
-                    0,
-                    0.5
-                ],
-                [
-                    0.5,
-                    0.5
-                ],
-                [
-                    0.5,
-                    1
-                ]
-            ],
-            2
-        ]
-    ],
-    "getQueryStringOverride": [
-        [
-            "empty url",
-            "my-test",
-            "",
-            2,
-            null
-        ],
-        [
-            "no query string",
-            "my-test",
-            "http://example.com",
-            2,
-            null
-        ],
-        [
-            "empty query string",
-            "my-test",
-            "http://example.com?",
-            2,
-            null
-        ],
-        [
-            "no query string match",
-            "my-test",
-            "http://example.com?somequery",
-            2,
-            null
-        ],
-        [
-            "invalid query string",
-            "my-test",
-            "http://example.com??&&&?#",
-            2,
-            null
-        ],
-        [
-            "simple match 0",
-            "my-test",
-            "http://example.com?my-test=0",
-            2,
-            0
-        ],
-        [
-            "simple match 1",
-            "my-test",
-            "http://example.com?my-test=1",
-            2,
-            1
-        ],
-        [
-            "negative variation",
-            "my-test",
-            "http://example.com?my-test=-1",
-            2,
-            null
-        ],
-        [
-            "float",
-            "my-test",
-            "http://example.com?my-test=2.054",
-            2,
-            null
-        ],
-        [
-            "string",
-            "my-test",
-            "http://example.com?my-test=foo",
-            2,
-            null
-        ],
-        [
-            "variation too high",
-            "my-test",
-            "http://example.com?my-test=5",
-            2,
-            null
-        ],
-        [
-            "high numVariations",
-            "my-test",
-            "http://example.com?my-test=5",
-            6,
-            5
-        ],
-        [
-            "equal to numVariations",
-            "my-test",
-            "http://example.com?my-test=5",
-            5,
-            null
-        ],
-        [
-            "other query string before",
-            "my-test",
-            "http://example.com?foo=bar&my-test=1",
-            2,
-            1
-        ],
-        [
-            "other query string after",
-            "my-test",
-            "http://example.com?foo=bar&my-test=1&bar=baz",
-            2,
-            1
-        ],
-        [
-            "anchor",
-            "my-test",
-            "http://example.com?my-test=1#foo",
-            2,
-            1
-        ]
-    ],
-    "inNamespace": [
-        [
-            "user 1, namespace1, 1",
-            "1",
-            [
-                "namespace1",
-                0,
-                0.4
-            ],
-            false
-        ],
-        [
-            "user 1, namespace1, 2",
-            "1",
-            [
-                "namespace1",
-                0.4,
-                1
-            ],
-            true
-        ],
-        [
-            "user 1, namespace2, 1",
-            "1",
-            [
-                "namespace2",
-                0,
-                0.4
-            ],
-            false
-        ],
-        [
-            "user 1, namespace2, 2",
-            "1",
-            [
-                "namespace2",
-                0.4,
-                1
-            ],
-            true
-        ],
-        [
-            "user 2, namespace1, 1",
-            "2",
-            [
-                "namespace1",
-                0,
-                0.4
-            ],
-            false
-        ],
-        [
-            "user 2, namespace1, 2",
-            "2",
-            [
-                "namespace1",
-                0.4,
-                1
-            ],
-            true
-        ],
-        [
-            "user 2, namespace2, 1",
-            "2",
-            [
-                "namespace2",
-                0,
-                0.4
-            ],
-            false
-        ],
-        [
-            "user 2, namespace2, 2",
-            "2",
-            [
-                "namespace2",
-                0.4,
-                1
-            ],
-            true
-        ],
-        [
-            "user 3, namespace1, 1",
-            "3",
-            [
-                "namespace1",
-                0,
-                0.4
-            ],
-            false
-        ],
-        [
-            "user 3, namespace1, 2",
-            "3",
-            [
-                "namespace1",
-                0.4,
-                1
-            ],
-            true
-        ],
-        [
-            "user 3, namespace2, 1",
-            "3",
-            [
-                "namespace2",
-                0,
-                0.4
-            ],
-            true
-        ],
-        [
-            "user 3, namespace2, 2",
-            "3",
-            [
-                "namespace2",
-                0.4,
-                1
-            ],
-            false
-        ],
-        [
-            "user 4, namespace1, 1",
-            "4",
-            [
-                "namespace1",
-                0,
-                0.4
-            ],
-            false
-        ],
-        [
-            "user 4, namespace1, 2",
-            "4",
-            [
-                "namespace1",
-                0.4,
-                1
-            ],
-            true
-        ],
-        [
-            "user 4, namespace2, 1",
-            "4",
-            [
-                "namespace2",
-                0,
-                0.4
-            ],
-            true
-        ],
-        [
-            "user 4, namespace2, 2",
-            "4",
-            [
-                "namespace2",
-                0.4,
-                1
-            ],
-            false
-        ]
-    ],
-    "getEqualWeights": [
-        [
-            -1,
-            []
-        ],
-        [
-            0,
-            []
-        ],
-        [
+    [
+      "$nin - pass",
+      {
+        "num": {
+          "$nin": [
             1,
-            [
-                1
-            ]
-        ],
-        [
             2,
-            [
-                0.5,
-                0.5
-            ]
-        ],
-        [
-            3,
-            [
-                0.33333333,
-                0.33333333,
-                0.33333333
-            ]
-        ],
-        [
-            4,
-            [
-                0.25,
-                0.25,
-                0.25,
-                0.25
-            ]
-        ]
+            3
+          ]
+        }
+      },
+      {
+        "num": 4
+      },
+      true
     ],
-    "decrypt": [
-        [
-            "Valid feature",
-            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznZ6SX28Yjg==",
-            "{\"feature\":{\"defaultValue\":true}}"
-        ],
-        [
-            "Broken JSON",
-            "SVZIM2oKD1JoHNIeeoW3Uw==.AGbRiGAHf2f6/ziVr9UTIy+bVFmVli6+bHZ2jnCm9N991ITv1ROvOEjxjLSmgEpv",
-            "UQD0Qqw7fM1bhfKKPH8TGw==",
-            "{\"feature\":{\"defaultValue\":true?5%"
-        ],
-        [
-            "Wrong key",
-            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznZ6SX39Yjg==",
-            null
-        ],
-        [
-            "Invalid key length",
-            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznSX39Yjg==",
-            null
-        ],
-        [
-            "Invalid key characters",
-            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/%!(pFDznZ6SX39Yjg==",
-            null
-        ],
-        [
-            "Invalid body",
-            "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q0!*&()f3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznZ6SX28Yjg==",
-            null
-        ],
-        [
-            "Invalid iv length",
-            "m5ylFM6ndyOPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznZ6SX28Yjg==",
-            null
-        ],
-        [
-            "Invalid iv",
-            "m5ylFM6*&(OJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznZ6SX28Yjg==",
-            null
-        ],
-        [
-            "Missing delimiter",
-            "m5ylFM6ndyOJA2OPadubkw==Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
-            "Zvwv/+uhpFDznZ6SX28Yjg==",
-            null
-        ],
-        [
-            "Corrupted payload",
-            "fsa*(&(SF*&F&SF^SD&*FS&*6fsdkajfd",
-            "Zvwv/+uhpFDznZ6SX28Yjg==",
-            null
-        ]
+    [
+      "$nin - fail",
+      {
+        "num": {
+          "$nin": [
+            1,
+            2,
+            3
+          ]
+        }
+      },
+      {
+        "num": 2
+      },
+      false
     ],
-    "stickyBucket": [
-        [
-            "use fallbackAttribute when missing hashAttribute",
-            {
-                "attributes": {
-                    "anonymousId": "123"
-                },
-                "features": {
-                    "feature": {
-                        "defaultValue": 0,
-                        "rules": [
-                            {
-                                "variations": [
-                                    0,
-                                    1,
-                                    2,
-                                    3
-                                ],
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "anonymousId"
-                            }
-                        ]
-                    }
-                }
-            },
-            [],
-            "feature",
-            {
-                "bucket": 0.863,
-                "featureId": "feature",
-                "hashAttribute": "anonymousId",
-                "hashUsed": true,
-                "hashValue": "123",
-                "inExperiment": true,
-                "key": "3",
-                "stickyBucketUsed": false,
-                "value": 3,
-                "variationId": 3
-            },
-            {
-                "anonymousId||123": {
-                    "assignments": {
-                        "feature__0": "3"
-                    },
-                    "attributeName": "anonymousId",
-                    "attributeValue": "123"
-                }
-            }
-        ],
-        [
-            "performs evaluation without sticky bucket",
-            {
-                "attributes": {
-                    "deviceId": "d123",
-                    "anonymousId": "ses123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "deviceId",
-                                "hashVersion": 2,
-                                "bucketVersion": 0,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                },
-                "stickyBucketAssignmentDocs": {}
-            },
-            [],
-            "exp1",
-            {
-                "bucket": 0.6468,
-                "featureId": "exp1",
-                "hashAttribute": "deviceId",
-                "hashUsed": true,
-                "hashValue": "d123",
-                "inExperiment": true,
-                "key": "1",
-                "stickyBucketUsed": false,
-                "value": "red",
-                "variationId": 1
-            },
-            {
-                "deviceId||d123": {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "deviceId",
-                    "attributeValue": "d123"
-                }
-            }
-        ],
-        [
-            "evaluates based on stored sticky bucket",
-            {
-                "attributes": {
-                    "deviceId": "d123",
-                    "anonymousId": "ses123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "deviceId",
-                                "hashVersion": 2,
-                                "bucketVersion": 0,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "attributeName": "deviceId",
-                    "attributeValue": "d123",
-                    "assignments": {
-                        "feature-exp__0": "2"
-                    }
-                }
-            ],
-            "exp1",
-            {
-                "bucket": 0.6468,
-                "featureId": "exp1",
-                "hashAttribute": "deviceId",
-                "hashUsed": true,
-                "hashValue": "d123",
-                "inExperiment": true,
-                "key": "2",
-                "stickyBucketUsed": true,
-                "value": "blue",
-                "variationId": 2
-            },
-            {
-                "deviceId||d123": {
-                    "assignments": {
-                        "feature-exp__0": "2"
-                    },
-                    "attributeName": "deviceId",
-                    "attributeValue": "d123"
-                }
-            }
-        ],
-        [
-            "does not consume a sticky bucket not belonging to the user",
-            {
-                "attributes": {
-                    "deviceId": "d123",
-                    "anonymousId": "ses123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "deviceId",
-                                "hashVersion": 2,
-                                "bucketVersion": 0,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "attributeName": "deviceId",
-                    "attributeValue": "d456",
-                    "assignments": {
-                        "feature-exp__0": "2"
-                    }
-                }
-            ],
-            "exp1",
-            {
-                "bucket": 0.6468,
-                "featureId": "exp1",
-                "hashAttribute": "deviceId",
-                "hashUsed": true,
-                "hashValue": "d123",
-                "inExperiment": true,
-                "key": "1",
-                "stickyBucketUsed": false,
-                "value": "red",
-                "variationId": 1
-            },
-            {
-                "deviceId||d123": {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "deviceId",
-                    "attributeValue": "d123"
-                }
-            }
-        ],
-        [
-            "upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute",
-            {
-                "attributes": {
-                    "id": "i123",
-                    "anonymousId": "ses123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "anonymousId",
-                                "hashVersion": 2,
-                                "bucketVersion": 0,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "attributeName": "anonymousId",
-                    "attributeValue": "ses123",
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    }
-                }
-            ],
-            "exp1",
-            {
-                "bucket": 0.9943,
-                "featureId": "exp1",
-                "hashAttribute": "id",
-                "hashUsed": true,
-                "hashValue": "i123",
-                "inExperiment": true,
-                "key": "1",
-                "stickyBucketUsed": true,
-                "value": "red",
-                "variationId": 1
-            },
-            {
-                "anonymousId||ses123": {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "anonymousId",
-                    "attributeValue": "ses123"
-                },
-                "id||i123": {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "id",
-                    "attributeValue": "i123"
-                }
-            }
-        ],
-        [
-            "favors a sticky bucket doc based on hashAttribute over fallbackAttribute",
-            {
-                "attributes": {
-                    "id": "i123",
-                    "anonymousId": "ses123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "anonymousId",
-                                "hashVersion": 2,
-                                "bucketVersion": 0,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "attributeName": "anonymousId",
-                    "attributeValue": "ses123",
-                    "assignments": {
-                        "feature-exp__0": "2"
-                    }
-                },
-                {
-                    "attributeName": "id",
-                    "attributeValue": "i123",
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    }
-                }
-            ],
-            "exp1",
-            {
-                "bucket": 0.9943,
-                "featureId": "exp1",
-                "hashAttribute": "id",
-                "hashUsed": true,
-                "hashValue": "i123",
-                "inExperiment": true,
-                "key": "1",
-                "stickyBucketUsed": true,
-                "value": "red",
-                "variationId": 1
-            },
-            {
-                "anonymousId||ses123": {
-                    "assignments": {
-                        "feature-exp__0": "2"
-                    },
-                    "attributeName": "anonymousId",
-                    "attributeValue": "ses123"
-                },
-                "id||i123": {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "id",
-                    "attributeValue": "i123"
-                }
-            }
-        ],
-        [
-            "resets sticky bucketing when the bucketVersion changes",
-            {
-                "attributes": {
-                    "id": "i123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "deviceId",
-                                "hashVersion": 2,
-                                "bucketVersion": 3,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "id",
-                    "attributeValue": "i123"
-                }
-            ],
-            "exp1",
-            {
-                "bucket": 0.9943,
-                "featureId": "exp1",
-                "hashAttribute": "id",
-                "hashUsed": true,
-                "hashValue": "i123",
-                "inExperiment": true,
-                "key": "2",
-                "stickyBucketUsed": false,
-                "value": "blue",
-                "variationId": 2
-            },
-            {
-                "id||i123": {
-                    "assignments": {
-                        "feature-exp__0": "1",
-                        "feature-exp__3": "2"
-                    },
-                    "attributeName": "id",
-                    "attributeValue": "i123"
-                }
-            }
-        ],
-        [
-            "stops test enrollment when and existing sticky bucket is blocked by version",
-            {
-                "attributes": {
-                    "id": "i123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "deviceId",
-                                "hashVersion": 2,
-                                "bucketVersion": 3,
-                                "minBucketVersion": 3,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "id",
-                    "attributeValue": "i123"
-                }
-            ],
-            "exp1",
-            null,
-            {
-                "id||i123": {
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    },
-                    "attributeName": "id",
-                    "attributeValue": "i123"
-                }
-            }
-        ],
-        [
-            "disables sticky bucketing when disabled by experiment",
-            {
-                "attributes": {
-                    "id": "i123",
-                    "foo": "bar",
-                    "country": "USA"
-                },
-                "features": {
-                    "exp1": {
-                        "defaultValue": "control",
-                        "rules": [
-                            {
-                                "key": "feature-exp",
-                                "seed": "feature-exp",
-                                "hashAttribute": "id",
-                                "fallbackAttribute": "deviceId",
-                                "hashVersion": 2,
-                                "bucketVersion": 1,
-                                "disableStickyBucketing": true,
-                                "condition": {
-                                    "country": "USA"
-                                },
-                                "variations": [
-                                    "control",
-                                    "red",
-                                    "blue"
-                                ],
-                                "meta": [
-                                    {
-                                        "key": "0"
-                                    },
-                                    {
-                                        "key": "1"
-                                    },
-                                    {
-                                        "key": "2"
-                                    }
-                                ],
-                                "coverage": 1,
-                                "weights": [
-                                    0.3334,
-                                    0.3333,
-                                    0.3333
-                                ],
-                                "phase": "0"
-                            }
-                        ]
-                    }
-                }
-            },
-            [
-                {
-                    "attributeName": "id",
-                    "attributeValue": "i123",
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    }
-                }
-            ],
-            "exp1",
-            {
-                "bucket": 0.9943,
-                "featureId": "exp1",
-                "hashAttribute": "id",
-                "hashUsed": true,
-                "hashValue": "i123",
-                "inExperiment": true,
-                "key": "2",
-                "stickyBucketUsed": false,
-                "value": "blue",
-                "variationId": 2
-            },
-            {
-                "id||i123": {
-                    "attributeName": "id",
-                    "attributeValue": "i123",
-                    "assignments": {
-                        "feature-exp__0": "1"
-                    }
-                }
-            }
-        ]
+    [
+      "$nin - not array",
+      {
+        "num": {
+          "$nin": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
     ],
-    "urlRedirect": [
-        [
-            "redirects correctly without query strings",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "url": "http://www.example.com/home",
-                "experiments": [
-                    {
-                        "key": "my-experiment",
-                        "urlPatterns": [
-                            {
-                                "type": "simple",
-                                "include": true,
-                                "pattern": "http://www.example.com/home"
-                            }
-                        ],
-                        "weights": [
-                            0.1,
-                            0.9
-                        ],
-                        "variations": [
-                            {},
-                            {
-                                "urlRedirect": "http://www.example.com/home-new"
-                            }
-                        ]
-                    }
-                ]
-            },
-            [
-                {
-                    "inExperiment": true,
-                    "urlRedirect": "http://www.example.com/home-new",
-                    "urlWithParams": "http://www.example.com/home-new"
-                }
-            ]
-        ],
-        [
-            "redirects with query string on original url and persistQueryString enabled",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "url": "http://www.example.com/home?color=blue&food=sushi",
-                "experiments": [
-                    {
-                        "key": "my-experiment",
-                        "urlPatterns": [
-                            {
-                                "type": "simple",
-                                "include": true,
-                                "pattern": "http://www.example.com/home"
-                            }
-                        ],
-                        "weights": [
-                            0.1,
-                            0.9
-                        ],
-                        "variations": [
-                            {},
-                            {
-                                "urlRedirect": "http://www.example.com/home-new"
-                            }
-                        ],
-                        "persistQueryString": true
-                    }
-                ]
-            },
-            [
-                {
-                    "inExperiment": true,
-                    "urlRedirect": "http://www.example.com/home-new",
-                    "urlWithParams":
-                        "http://www.example.com/home-new?color=blue&food=sushi"
-                }
-            ]
-        ],
-        [
-            "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "url":
-                    "http://www.example.com/home?color=blue&food=sushi&title=original",
-                "experiments": [
-                    {
-                        "key": "my-experiment",
-                        "urlPatterns": [
-                            {
-                                "type": "simple",
-                                "include": true,
-                                "pattern": "http://www.example.com/home"
-                            }
-                        ],
-                        "weights": [
-                            0.1,
-                            0.9
-                        ],
-                        "variations": [
-                            {},
-                            {
-                                "urlRedirect":
-                                    "http://www.example.com/home-new?name=test&color=red&food=lasagna"
-                            }
-                        ],
-                        "persistQueryString": true
-                    }
-                ]
-            },
-            [
-                {
-                    "inExperiment": true,
-                    "urlRedirect":
-                        "http://www.example.com/home-new?name=test&color=red&food=lasagna",
-                    "urlWithParams":
-                        "http://www.example.com/home-new?name=test&color=red&food=lasagna&title=original"
-                }
-            ]
-        ],
-        [
-            "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
-            {
-                "attributes": {
-                    "id": "1"
-                },
-                "url": "http://www.example.com/home",
-                "experiments": [
-                    {
-                        "key": "my-experiment",
-                        "urlPatterns": [
-                            {
-                                "type": "simple",
-                                "include": true,
-                                "pattern": "http://www.example.com/"
-                            }
-                        ],
-                        "weights": [
-                            0.1,
-                            0.9
-                        ],
-                        "variations": [
-                            {},
-                            {
-                                "urlRedirect": "http://www.example.com/home-new"
-                            }
-                        ]
-                    },
-                    {
-                        "key": "my-experiment-2",
-                        "urlPatterns": [
-                            {
-                                "type": "simple",
-                                "include": true,
-                                "pattern": "http://www.example.com/home"
-                            }
-                        ],
-                        "weights": [
-                            0.1,
-                            0.9
-                        ],
-                        "variations": [
-                            {},
-                            {
-                                "urlRedirect":
-                                    "http://www.example.com/home-new-new"
-                            }
-                        ]
-                    },
-                    {
-                        "key": "my-experiment-3",
-                        "urlPatterns": [
-                            {
-                                "type": "simple",
-                                "include": true,
-                                "pattern": "http://www.example.com/home"
-                            }
-                        ],
-                        "weights": [
-                            0.1,
-                            0.9
-                        ],
-                        "variations": [
-                            {},
-                            {
-                                "urlRedirect": "http://www.example.com/home-es"
-                            }
-                        ]
-                    }
-                ]
-            },
-            [
-                {
-                    "inExperiment": true,
-                    "urlRedirect": "http://www.example.com/home-new-new",
-                    "urlWithParams": "http://www.example.com/home-new-new"
-                }
-            ]
+    [
+      "$nin - array fail 1",
+      {
+        "tags": {
+          "$nin": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "a"
         ]
+      },
+      false
+    ],
+    [
+      "$nin - array fail 2",
+      {
+        "tags": {
+          "$nin": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
+      },
+      false
+    ],
+    [
+      "$nin - array fail 3",
+      {
+        "tags": {
+          "$nin": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "a"
+        ]
+      },
+      false
+    ],
+    [
+      "$nin - array pass 1",
+      {
+        "tags": {
+          "$nin": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
+      },
+      true
+    ],
+    [
+      "$nin - array pass 2",
+      {
+        "tags": {
+          "$nin": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": []
+      },
+      true
+    ],
+    [
+      "$nin - pass (case sensitive mismatch)",
+      {
+        "country": {
+          "$nin": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (case insensitive match)",
+      {
+        "country": {
+          "$ini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$ini": [
+            "US",
+            "UK"
+          ]
+        }
+      },
+      {
+        "country": "us"
+      },
+      true
+    ],
+    [
+      "$ini - pass (mixed case)",
+      {
+        "country": {
+          "$ini": [
+            "Us",
+            "Uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - fail (no match)",
+      {
+        "country": {
+          "$ini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      false
+    ],
+    [
+      "$ini - array pass 1",
+      {
+        "tags": {
+          "$ini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "A"
+        ]
+      },
+      true
+    ],
+    [
+      "$ini - array pass 2",
+      {
+        "tags": {
+          "$ini": [
+            "A",
+            "B"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
+      },
+      true
+    ],
+    [
+      "$ini - array fail",
+      {
+        "tags": {
+          "$ini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
+      },
+      false
+    ],
+    [
+      "$ini - not array",
+      {
+        "num": {
+          "$ini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$nini - pass (case insensitive match)",
+      {
+        "country": {
+          "$nini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      true
+    ],
+    [
+      "$nini - fail (case insensitive match)",
+      {
+        "country": {
+          "$nini": [
+            "us",
+            "uk"
+          ]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
+      "$nini - fail (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$nini": [
+            "US",
+            "UK"
+          ]
+        }
+      },
+      {
+        "country": "us"
+      },
+      false
+    ],
+    [
+      "$nini - array pass",
+      {
+        "tags": {
+          "$nini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
+      },
+      true
+    ],
+    [
+      "$nini - array fail 1",
+      {
+        "tags": {
+          "$nini": [
+            "a",
+            "b"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "A"
+        ]
+      },
+      false
+    ],
+    [
+      "$nini - array fail 2",
+      {
+        "tags": {
+          "$nini": [
+            "A",
+            "B"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "b",
+          "f"
+        ]
+      },
+      false
+    ],
+    [
+      "$nini - not array",
+      {
+        "num": {
+          "$nini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$elemMatch - pass - flat arrays",
+      {
+        "nums": {
+          "$elemMatch": {
+            "$gt": 10
+          }
+        }
+      },
+      {
+        "nums": [
+          0,
+          5,
+          -20,
+          15
+        ]
+      },
+      true
+    ],
+    [
+      "$elemMatch - fail - flat arrays",
+      {
+        "nums": {
+          "$elemMatch": {
+            "$gt": 10
+          }
+        }
+      },
+      {
+        "nums": [
+          0,
+          5,
+          -20,
+          8
+        ]
+      },
+      false
+    ],
+    [
+      "missing attribute - fail",
+      {
+        "pets.dog.name": {
+          "$in": [
+            "fido"
+          ]
+        }
+      },
+      {
+        "hello": "world"
+      },
+      false
+    ],
+    [
+      "missing attribute with comparison operators",
+      {
+        "age": {
+          "$gt": -10,
+          "$lt": 10,
+          "$gte": -9,
+          "$lte": 9,
+          "$ne": 10
+        }
+      },
+      {},
+      true
+    ],
+    [
+      "comparing numbers and strings",
+      {
+        "n": {
+          "$gt": 5,
+          "$lt": 10
+        }
+      },
+      {
+        "n": "8"
+      },
+      true
+    ],
+    [
+      "comparing numbers and strings - v2",
+      {
+        "n": {
+          "$gt": "5",
+          "$lt": "10"
+        }
+      },
+      {
+        "n": 8
+      },
+      true
+    ],
+    [
+      "empty $or - pass",
+      {
+        "$or": []
+      },
+      {
+        "hello": "world"
+      },
+      true
+    ],
+    [
+      "empty $and - pass",
+      {
+        "$and": []
+      },
+      {
+        "hello": "world"
+      },
+      true
+    ],
+    [
+      "empty - pass",
+      {},
+      {
+        "hello": "world"
+      },
+      true
+    ],
+    [
+      "$eq - pass",
+      {
+        "occupation": {
+          "$eq": "engineer"
+        }
+      },
+      {
+        "occupation": "engineer"
+      },
+      true
+    ],
+    [
+      "$eq - fail",
+      {
+        "occupation": {
+          "$eq": "engineer"
+        }
+      },
+      {
+        "occupation": "civil engineer"
+      },
+      false
+    ],
+    [
+      "$ne - pass",
+      {
+        "level": {
+          "$ne": "senior"
+        }
+      },
+      {
+        "level": "junior"
+      },
+      true
+    ],
+    [
+      "$ne - fail",
+      {
+        "level": {
+          "$ne": "senior"
+        }
+      },
+      {
+        "level": "senior"
+      },
+      false
+    ],
+    [
+      "$regex - pass",
+      {
+        "userAgent": {
+          "$regex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regex - fail",
+      {
+        "userAgent": {
+          "$regex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$regex - fail (case sensitive mismatch)",
+      {
+        "userAgent": {
+          "$regex": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$regexi - pass (case insensitive match)",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regexi - pass (uppercase pattern, lowercase value)",
+      {
+        "userAgent": {
+          "$regexi": "(MOBILE|TABLET)"
+        }
+      },
+      {
+        "userAgent": "android mobile browser"
+      },
+      true
+    ],
+    [
+      "$regexi - fail",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$gt/$lt numbers - pass",
+      {
+        "age": {
+          "$gt": 30,
+          "$lt": 60
+        }
+      },
+      {
+        "age": 50
+      },
+      true
+    ],
+    [
+      "$gt/$lt numbers - fail $lt",
+      {
+        "age": {
+          "$gt": 30,
+          "$lt": 60
+        }
+      },
+      {
+        "age": 60
+      },
+      false
+    ],
+    [
+      "$gt/$lt numbers - fail $gt",
+      {
+        "age": {
+          "$gt": 30,
+          "$lt": 60
+        }
+      },
+      {
+        "age": 30
+      },
+      false
+    ],
+    [
+      "$gte/$lte numbers - pass",
+      {
+        "age": {
+          "$gte": 30,
+          "$lte": 60
+        }
+      },
+      {
+        "age": 50
+      },
+      true
+    ],
+    [
+      "$gte/$lte numbers - pass $gte",
+      {
+        "age": {
+          "$gte": 30,
+          "$lte": 60
+        }
+      },
+      {
+        "age": 30
+      },
+      true
+    ],
+    [
+      "$gte/$lte numbers - pass $lte",
+      {
+        "age": {
+          "$gte": 30,
+          "$lte": 60
+        }
+      },
+      {
+        "age": 60
+      },
+      true
+    ],
+    [
+      "$gte/$lte numbers - fail $lte",
+      {
+        "age": {
+          "$gte": 30,
+          "$lte": 60
+        }
+      },
+      {
+        "age": 61
+      },
+      false
+    ],
+    [
+      "$gte/$lte numbers - fail $gte",
+      {
+        "age": {
+          "$gt": 30,
+          "$lt": 60
+        }
+      },
+      {
+        "age": 29
+      },
+      false
+    ],
+    [
+      "$gt/$lt strings - fail $gt",
+      {
+        "word": {
+          "$gt": "alphabet",
+          "$lt": "zebra"
+        }
+      },
+      {
+        "word": "alphabet"
+      },
+      false
+    ],
+    [
+      "$gt/$lt strings - fail $lt",
+      {
+        "word": {
+          "$gt": "alphabet",
+          "$lt": "zebra"
+        }
+      },
+      {
+        "word": "zebra"
+      },
+      false
+    ],
+    [
+      "$gt/$lt strings - pass",
+      {
+        "word": {
+          "$gt": "alphabet",
+          "$lt": "zebra"
+        }
+      },
+      {
+        "word": "always"
+      },
+      true
+    ],
+    [
+      "$gt/$lt strings - fail uppercase",
+      {
+        "word": {
+          "$gt": "alphabet",
+          "$lt": "zebra"
+        }
+      },
+      {
+        "word": "AZL"
+      },
+      false
+    ],
+    [
+      "nested value is null",
+      {
+        "address.state": "CA"
+      },
+      {
+        "address": null
+      },
+      false
+    ],
+    [
+      "nested value is integer",
+      {
+        "address.state": "CA"
+      },
+      {
+        "address": 123
+      },
+      false
+    ],
+    [
+      "$type string - pass",
+      {
+        "a": {
+          "$type": "string"
+        }
+      },
+      {
+        "a": "a"
+      },
+      true
+    ],
+    [
+      "$type string - fail",
+      {
+        "a": {
+          "$type": "string"
+        }
+      },
+      {
+        "a": 1
+      },
+      false
+    ],
+    [
+      "$type null - pass",
+      {
+        "a": {
+          "$type": "null"
+        }
+      },
+      {
+        "a": null
+      },
+      true
+    ],
+    [
+      "$type null - fail",
+      {
+        "a": {
+          "$type": "null"
+        }
+      },
+      {
+        "a": 1
+      },
+      false
+    ],
+    [
+      "$type boolean - pass",
+      {
+        "a": {
+          "$type": "boolean"
+        }
+      },
+      {
+        "a": false
+      },
+      true
+    ],
+    [
+      "$type boolean - fail",
+      {
+        "a": {
+          "$type": "boolean"
+        }
+      },
+      {
+        "a": 1
+      },
+      false
+    ],
+    [
+      "$type number - pass",
+      {
+        "a": {
+          "$type": "number"
+        }
+      },
+      {
+        "a": 1
+      },
+      true
+    ],
+    [
+      "$type number - fail",
+      {
+        "a": {
+          "$type": "number"
+        }
+      },
+      {
+        "a": "a"
+      },
+      false
+    ],
+    [
+      "$type object - pass",
+      {
+        "a": {
+          "$type": "object"
+        }
+      },
+      {
+        "a": {
+          "a": "b"
+        }
+      },
+      true
+    ],
+    [
+      "$type object - fail",
+      {
+        "a": {
+          "$type": "object"
+        }
+      },
+      {
+        "a": 1
+      },
+      false
+    ],
+    [
+      "$type array - pass",
+      {
+        "a": {
+          "$type": "array"
+        }
+      },
+      {
+        "a": [
+          1,
+          2
+        ]
+      },
+      true
+    ],
+    [
+      "$type array - fail",
+      {
+        "a": {
+          "$type": "array"
+        }
+      },
+      {
+        "a": 1
+      },
+      false
+    ],
+    [
+      "unknown operator - pass",
+      {
+        "name": {
+          "$regx": "hello"
+        }
+      },
+      {
+        "name": "hello"
+      },
+      false
+    ],
+    [
+      "$regex invalid - pass",
+      {
+        "name": {
+          "$regex": "/???***[)"
+        }
+      },
+      {
+        "name": "hello"
+      },
+      false
+    ],
+    [
+      "$regex invalid - fail",
+      {
+        "name": {
+          "$regex": "/???***[)"
+        }
+      },
+      {
+        "hello": "hello"
+      },
+      false
+    ],
+    [
+      "$size empty - pass",
+      {
+        "tags": {
+          "$size": 0
+        }
+      },
+      {
+        "tags": []
+      },
+      true
+    ],
+    [
+      "$size empty - fail",
+      {
+        "tags": {
+          "$size": 0
+        }
+      },
+      {
+        "tags": [
+          10
+        ]
+      },
+      false
+    ],
+    [
+      "$size number - pass",
+      {
+        "tags": {
+          "$size": 3
+        }
+      },
+      {
+        "tags": [
+          "a",
+          "b",
+          "c"
+        ]
+      },
+      true
+    ],
+    [
+      "$size number - fail small",
+      {
+        "tags": {
+          "$size": 3
+        }
+      },
+      {
+        "tags": [
+          "a",
+          "b"
+        ]
+      },
+      false
+    ],
+    [
+      "$size number - fail large",
+      {
+        "tags": {
+          "$size": 3
+        }
+      },
+      {
+        "tags": [
+          "a",
+          "b",
+          "c",
+          "d"
+        ]
+      },
+      false
+    ],
+    [
+      "$size number - fail not array",
+      {
+        "tags": {
+          "$size": 3
+        }
+      },
+      {
+        "tags": "abc"
+      },
+      false
+    ],
+    [
+      "$size nested - pass",
+      {
+        "tags": {
+          "$size": {
+            "$gt": 2
+          }
+        }
+      },
+      {
+        "tags": [
+          0,
+          1,
+          2
+        ]
+      },
+      true
+    ],
+    [
+      "$size nested - fail equal",
+      {
+        "tags": {
+          "$size": {
+            "$gt": 2
+          }
+        }
+      },
+      {
+        "tags": [
+          0,
+          1
+        ]
+      },
+      false
+    ],
+    [
+      "$size nested - fail less than",
+      {
+        "tags": {
+          "$size": {
+            "$gt": 2
+          }
+        }
+      },
+      {
+        "tags": [
+          0
+        ]
+      },
+      false
+    ],
+    [
+      "$elemMatch contains - pass",
+      {
+        "tags": {
+          "$elemMatch": {
+            "$eq": "bar"
+          }
+        }
+      },
+      {
+        "tags": [
+          "foo",
+          "bar",
+          "baz"
+        ]
+      },
+      true
+    ],
+    [
+      "$elemMatch contains - false",
+      {
+        "tags": {
+          "$elemMatch": {
+            "$eq": "bar"
+          }
+        }
+      },
+      {
+        "tags": [
+          "foo",
+          "baz"
+        ]
+      },
+      false
+    ],
+    [
+      "$elemMatch intersection - pass",
+      {
+        "tags": {
+          "$elemMatch": {
+            "$in": [
+              "a",
+              "b"
+            ]
+          }
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "b"
+        ]
+      },
+      true
+    ],
+    [
+      "$elemMatch intersection - fail",
+      {
+        "tags": {
+          "$elemMatch": {
+            "$in": [
+              "a",
+              "b"
+            ]
+          }
+        }
+      },
+      {
+        "tags": [
+          "d",
+          "e",
+          "f"
+        ]
+      },
+      false
+    ],
+    [
+      "$elemMatch not contains - pass",
+      {
+        "tags": {
+          "$not": {
+            "$elemMatch": {
+              "$eq": "bar"
+            }
+          }
+        }
+      },
+      {
+        "tags": [
+          "foo",
+          "baz"
+        ]
+      },
+      true
+    ],
+    [
+      "$elemMatch not contains - fail",
+      {
+        "tags": {
+          "$not": {
+            "$elemMatch": {
+              "$eq": "bar"
+            }
+          }
+        }
+      },
+      {
+        "tags": [
+          "foo",
+          "bar",
+          "baz"
+        ]
+      },
+      false
+    ],
+    [
+      "$elemMatch nested - pass",
+      {
+        "hobbies": {
+          "$elemMatch": {
+            "name": {
+              "$regex": "^ping"
+            }
+          }
+        }
+      },
+      {
+        "hobbies": [
+          {
+            "name": "bowling"
+          },
+          {
+            "name": "pingpong"
+          },
+          {
+            "name": "tennis"
+          }
+        ]
+      },
+      true
+    ],
+    [
+      "$elemMatch nested - fail",
+      {
+        "hobbies": {
+          "$elemMatch": {
+            "name": {
+              "$regex": "^ping"
+            }
+          }
+        }
+      },
+      {
+        "hobbies": [
+          {
+            "name": "bowling"
+          },
+          {
+            "name": "tennis"
+          }
+        ]
+      },
+      false
+    ],
+    [
+      "$elemMatch nested - fail not array",
+      {
+        "hobbies": {
+          "$elemMatch": {
+            "name": {
+              "$regex": "^ping"
+            }
+          }
+        }
+      },
+      {
+        "hobbies": "all"
+      },
+      false
+    ],
+    [
+      "$not - pass",
+      {
+        "name": {
+          "$not": {
+            "$regex": "^hello"
+          }
+        }
+      },
+      {
+        "name": "world"
+      },
+      true
+    ],
+    [
+      "$not - fail",
+      {
+        "name": {
+          "$not": {
+            "$regex": "^hello"
+          }
+        }
+      },
+      {
+        "name": "hello world"
+      },
+      false
+    ],
+    [
+      "$all - pass",
+      {
+        "tags": {
+          "$all": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "one",
+          "two",
+          "three"
+        ]
+      },
+      true
+    ],
+    [
+      "$all - fail",
+      {
+        "tags": {
+          "$all": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "one",
+          "two",
+          "four"
+        ]
+      },
+      false
+    ],
+    [
+      "$all - fail not array",
+      {
+        "tags": {
+          "$all": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": "hello"
+      },
+      false
+    ],
+    [
+      "$all - fail (case sensitive mismatch)",
+      {
+        "tags": {
+          "$all": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "THREE"
+        ]
+      },
+      false
+    ],
+    [
+      "$alli - pass (case insensitive match)",
+      {
+        "tags": {
+          "$alli": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "THREE"
+        ]
+      },
+      true
+    ],
+    [
+      "$alli - pass (uppercase pattern, lowercase value)",
+      {
+        "tags": {
+          "$alli": [
+            "ONE",
+            "THREE"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "one",
+          "two",
+          "three"
+        ]
+      },
+      true
+    ],
+    [
+      "$alli - pass (mixed case)",
+      {
+        "tags": {
+          "$alli": [
+            "One",
+            "Three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "three"
+        ]
+      },
+      true
+    ],
+    [
+      "$alli - fail (case insensitive, missing value)",
+      {
+        "tags": {
+          "$alli": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": [
+          "ONE",
+          "two",
+          "four"
+        ]
+      },
+      false
+    ],
+    [
+      "$alli - fail not array",
+      {
+        "tags": {
+          "$alli": [
+            "one",
+            "three"
+          ]
+        }
+      },
+      {
+        "tags": "hello"
+      },
+      false
+    ],
+    [
+      "$nor - pass",
+      {
+        "$nor": [
+          {
+            "name": "john"
+          },
+          {
+            "age": {
+              "$lt": 30
+            }
+          }
+        ]
+      },
+      {
+        "name": "jim",
+        "age": 40
+      },
+      true
+    ],
+    [
+      "$nor - fail both",
+      {
+        "$nor": [
+          {
+            "name": "john"
+          },
+          {
+            "age": {
+              "$lt": 30
+            }
+          }
+        ]
+      },
+      {
+        "name": "john",
+        "age": 20
+      },
+      false
+    ],
+    [
+      "$nor - fail first",
+      {
+        "$nor": [
+          {
+            "name": "john"
+          },
+          {
+            "age": {
+              "$lt": 30
+            }
+          }
+        ]
+      },
+      {
+        "name": "john",
+        "age": 40
+      },
+      false
+    ],
+    [
+      "$nor - fail second",
+      {
+        "$nor": [
+          {
+            "name": "john"
+          },
+          {
+            "age": {
+              "$lt": 30
+            }
+          }
+        ]
+      },
+      {
+        "name": "jim",
+        "age": 20
+      },
+      false
+    ],
+    [
+      "equals array - pass",
+      {
+        "tags": [
+          "hello",
+          "world"
+        ]
+      },
+      {
+        "tags": [
+          "hello",
+          "world"
+        ]
+      },
+      true
+    ],
+    [
+      "equals array - fail order",
+      {
+        "tags": [
+          "hello",
+          "world"
+        ]
+      },
+      {
+        "tags": [
+          "world",
+          "hello"
+        ]
+      },
+      false
+    ],
+    [
+      "equals array - fail missing item",
+      {
+        "tags": [
+          "hello",
+          "world"
+        ]
+      },
+      {
+        "tags": [
+          "hello"
+        ]
+      },
+      false
+    ],
+    [
+      "equals array - fail extra item",
+      {
+        "tags": [
+          "hello",
+          "world"
+        ]
+      },
+      {
+        "tags": [
+          "hello",
+          "world",
+          "foo"
+        ]
+      },
+      false
+    ],
+    [
+      "equals array - fail type mismatch",
+      {
+        "tags": [
+          "hello",
+          "world"
+        ]
+      },
+      {
+        "tags": "hello world"
+      },
+      false
+    ],
+    [
+      "equals object - pass",
+      {
+        "tags": {
+          "hello": "world"
+        }
+      },
+      {
+        "tags": {
+          "hello": "world"
+        }
+      },
+      true
+    ],
+    [
+      "equals object - fail extra property",
+      {
+        "tags": {
+          "hello": "world"
+        }
+      },
+      {
+        "tags": {
+          "hello": "world",
+          "yes": "please"
+        }
+      },
+      false
+    ],
+    [
+      "equals object - fail missing property",
+      {
+        "tags": {
+          "hello": "world"
+        }
+      },
+      {
+        "tags": {}
+      },
+      false
+    ],
+    [
+      "equals object - fail type mismatch",
+      {
+        "tags": {
+          "hello": "world"
+        }
+      },
+      {
+        "tags": "hello world"
+      },
+      false
+    ],
+    [
+      "null condition - null attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": null
+      },
+      true
+    ],
+    [
+      "null condition - missing attribute",
+      {
+        "userId": null
+      },
+      {},
+      true
+    ],
+    [
+      "null condition - string attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": "123"
+      },
+      false
+    ],
+    [
+      "null condition - zero attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": 0
+      },
+      false
+    ],
+    [
+      "null condition - empty string attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": ""
+      },
+      false
+    ],
+    [
+      "null condition - false attribute",
+      {
+        "userId": null
+      },
+      {
+        "userId": false
+      },
+      false
+    ],
+    [
+      "false condition - missing attribute",
+      {
+        "userId": false
+      },
+      {},
+      false
+    ],
+    [
+      "false strict condition - missing attribute",
+      {
+        "userId": {
+          "$eq": false
+        }
+      },
+      {},
+      false
+    ],
+    [
+      "$vgt/$vlt - pass - major",
+      {
+        "version": {
+          "$vgt": "9.99.8",
+          "$vlt": "11.0.1"
+        }
+      },
+      {
+        "version": "10.12.13"
+      },
+      true
+    ],
+    [
+      "$vgt/$vlt - pass - minor",
+      {
+        "version": {
+          "$vgt": "10.2.11",
+          "$vlt": "10.20.11"
+        }
+      },
+      {
+        "version": "10.12.11"
+      },
+      true
+    ],
+    [
+      "$vgt/$vlt - pass - patch",
+      {
+        "version": {
+          "$vgt": "10.0.2",
+          "$vlt": "10.0.20"
+        }
+      },
+      {
+        "version": "10.0.12"
+      },
+      true
+    ],
+    [
+      "$vgt/$vlt - fail $vlt - major",
+      {
+        "version": {
+          "$vgt": "30.0.0",
+          "$vlt": "50.0.0"
+        }
+      },
+      {
+        "version": "60.0.0"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt - fail $vlt - minor",
+      {
+        "version": {
+          "$vgt": "10.30.0",
+          "$vlt": "10.50.0"
+        }
+      },
+      {
+        "version": "10.60.0"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt - fail $vlt - patch",
+      {
+        "version": {
+          "$vgt": "10.2.30",
+          "$vlt": "10.2.50"
+        }
+      },
+      {
+        "version": "10.2.60"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt - fail $vgt - major",
+      {
+        "version": {
+          "$vgt": "30.0.16",
+          "$vlt": "50.0.16"
+        }
+      },
+      {
+        "version": "20.0.16"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt - fail $vgt - minor",
+      {
+        "version": {
+          "$vgt": "10.30.0",
+          "$vlt": "10.50.0"
+        }
+      },
+      {
+        "version": "10.20.0"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt - fail $vgt - patch",
+      {
+        "version": {
+          "$vgt": "10.30.10",
+          "$vlt": "10.30.20"
+        }
+      },
+      {
+        "version": "10.30.2"
+      },
+      false
+    ],
+    [
+      "$vgte/$vlte - pass $vgte - major",
+      {
+        "version": {
+          "$vgte": "30.1.2",
+          "$vlte": "60.1.2"
+        }
+      },
+      {
+        "version": "30.1.2"
+      },
+      true
+    ],
+    [
+      "$vgte/$vlte - pass $vgte - minor",
+      {
+        "version": {
+          "$vgte": "5.30.2",
+          "$vlte": "5.60.2"
+        }
+      },
+      {
+        "version": "5.30.2"
+      },
+      true
+    ],
+    [
+      "$vgte/$vlte - pass $vgte - patch",
+      {
+        "version": {
+          "$vgte": "5.10.30",
+          "$vlte": "5.10.60"
+        }
+      },
+      {
+        "version": "5.10.30"
+      },
+      true
+    ],
+    [
+      "$vgte/$vlte - pass $vlte - major",
+      {
+        "version": {
+          "$vgte": "30.1.2",
+          "$vlte": "60.1.2"
+        }
+      },
+      {
+        "version": "60.1.2"
+      },
+      true
+    ],
+    [
+      "$vgte/$vlte - pass $vlte - minor",
+      {
+        "version": {
+          "$vgte": "1.30.2",
+          "$vlte": "1.60.2"
+        }
+      },
+      {
+        "version": "1.60.2"
+      },
+      true
+    ],
+    [
+      "$vgte/$vlte - pass $vlte - patch",
+      {
+        "version": {
+          "$vgte": "1.2.30",
+          "$vlte": "1.2.60"
+        }
+      },
+      {
+        "version": "1.2.60"
+      },
+      true
+    ],
+    [
+      "$vgte/$vlte - fail $vlte - major",
+      {
+        "version": {
+          "$vgte": "30.1.2",
+          "$vlte": "60.1.2"
+        }
+      },
+      {
+        "version": "61.1.2"
+      },
+      false
+    ],
+    [
+      "$vgte/$vlte - fail $vgt - minor",
+      {
+        "version": {
+          "$vgte": "30.1.2",
+          "$vlte": "60.1.2"
+        }
+      },
+      {
+        "version": "29.1.2"
+      },
+      false
+    ],
+    [
+      "$vgte/$vlte - fail $vgt - patch",
+      {
+        "version": {
+          "$vgte": "1.2.30",
+          "$vlte": "1.2.60"
+        }
+      },
+      {
+        "version": "1.2.29"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt prerelease - fail $vgt",
+      {
+        "v": {
+          "$vgt": "1.0.0-alpha",
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "v": "1.0.0-alpha"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt prerelease  w/ multiple fields - fail $vgt",
+      {
+        "v": {
+          "$vgt": "1.0.0-alpha.2",
+          "$vlt": "1.0.0-beta.1"
+        }
+      },
+      {
+        "v": "1.0.0-alpha.1"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt prerelease - fail $vlt",
+      {
+        "v": {
+          "$vgt": "1.0.0-alpha",
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "v": "1.0.0-beta"
+      },
+      false
+    ],
+    [
+      "$vgt/$vlt prerelease - pass",
+      {
+        "v": {
+          "$vgt": "1.0.0-alpha",
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "v": "1.0.0-alpha.10"
+      },
+      true
+    ],
+    [
+      "$vgt/$vlt prerelease - fail uppercase",
+      {
+        "v": {
+          "$vgt": "1.0.0-alpha",
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "v": "1.0.0-ALPHA"
+      },
+      false
+    ],
+    [
+      "$veq - pass",
+      {
+        "v": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "v": "1.2.3"
+      },
+      true
+    ],
+    [
+      "$veq - pass (with build)",
+      {
+        "v": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "v": "1.2.3+build.abc.123"
+      },
+      true
+    ],
+    [
+      "$vne - pass",
+      {
+        "v": {
+          "$vne": "1.2.3"
+        }
+      },
+      {
+        "v": "2.2.3"
+      },
+      true
+    ],
+    [
+      "$vne - pass (prerelease)",
+      {
+        "v": {
+          "$vne": "1.2.3"
+        }
+      },
+      {
+        "v": "1.2.3-alpha"
+      },
+      true
+    ],
+    [
+      "version 0.9.99 < 1.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0"
+        }
+      },
+      {
+        "version": "0.9.99"
+      },
+      true
+    ],
+    [
+      "version 0.9.0 < 0.10.0",
+      {
+        "version": {
+          "$vlt": "0.10.0"
+        }
+      },
+      {
+        "version": "0.9.0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0.0 < 1.0.0-0.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0-0.0.0"
+        }
+      },
+      {
+        "version": "1.0.0-0.0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-9999 < 1.0.0--",
+      {
+        "version": {
+          "$vlt": "1.0.0--"
+        }
+      },
+      {
+        "version": "1.0.0-9999"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-99 < 1.0.0-100",
+      {
+        "version": {
+          "$vlt": "1.0.0-100"
+        }
+      },
+      {
+        "version": "1.0.0-99"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha < 1.0.0-alpha.1",
+      {
+        "version": {
+          "$vlt": "1.0.0-alpha.1"
+        }
+      },
+      {
+        "version": "1.0.0-alpha"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha.1 < 1.0.0-alpha.beta",
+      {
+        "version": {
+          "$vlt": "1.0.0-alpha.beta"
+        }
+      },
+      {
+        "version": "1.0.0-alpha.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-alpha.beta < 1.0.0-beta",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta"
+        }
+      },
+      {
+        "version": "1.0.0-alpha.beta"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta < 1.0.0-beta.2",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta.2"
+        }
+      },
+      {
+        "version": "1.0.0-beta"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta.2 < 1.0.0-beta.11",
+      {
+        "version": {
+          "$vlt": "1.0.0-beta.11"
+        }
+      },
+      {
+        "version": "1.0.0-beta.2"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-beta.11 < 1.0.0-rc.1",
+      {
+        "version": {
+          "$vlt": "1.0.0-rc.1"
+        }
+      },
+      {
+        "version": "1.0.0-beta.11"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-rc.1 < 1.0.0",
+      {
+        "version": {
+          "$vlt": "1.0.0"
+        }
+      },
+      {
+        "version": "1.0.0-rc.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0 < 1.0.0--1",
+      {
+        "version": {
+          "$vlt": "1.0.0--1"
+        }
+      },
+      {
+        "version": "1.0.0-0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-0 < 1.0.0-1",
+      {
+        "version": {
+          "$vlt": "1.0.0-1"
+        }
+      },
+      {
+        "version": "1.0.0-0"
+      },
+      true
+    ],
+    [
+      "version 1.0.0-1.0 < 1.0.0-1.-1",
+      {
+        "version": {
+          "$vlt": "1.0.0-1.-1"
+        }
+      },
+      {
+        "version": "1.0.0-1.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b.c < 1.2.3-a.b.c.d",
+      {
+        "version": {
+          "$vlt": "1.2.3-a.b.c.d"
+        }
+      },
+      {
+        "version": "1.2.3-a.b.c"
+      },
+      true
+    ],
+    [
+      "version 0.0.0 > 0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "0.0.0-foo"
+        }
+      },
+      {
+        "version": "0.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.1 > 0.0.0",
+      {
+        "version": {
+          "$vgt": "0.0.0"
+        }
+      },
+      {
+        "version": "0.0.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0 > 0.9.9",
+      {
+        "version": {
+          "$vgt": "0.9.9"
+        }
+      },
+      {
+        "version": "1.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.10.0 > 0.9.0",
+      {
+        "version": {
+          "$vgt": "0.9.0"
+        }
+      },
+      {
+        "version": "0.10.0"
+      },
+      true
+    ],
+    [
+      "version 0.99.0 > 0.10.0",
+      {
+        "version": {
+          "$vgt": "0.10.0"
+        }
+      },
+      {
+        "version": "0.99.0"
+      },
+      true
+    ],
+    [
+      "version 2.0.0 > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "2.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.0.0 > 0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "0.0.0-foo"
+        }
+      },
+      {
+        "version": "v0.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.0.1 > 0.0.0",
+      {
+        "version": {
+          "$vgt": "0.0.0"
+        }
+      },
+      {
+        "version": "v0.0.1"
+      },
+      true
+    ],
+    [
+      "version v1.0.0 > 0.9.9",
+      {
+        "version": {
+          "$vgt": "0.9.9"
+        }
+      },
+      {
+        "version": "v1.0.0"
+      },
+      true
+    ],
+    [
+      "version v0.10.0 > 0.9.0",
+      {
+        "version": {
+          "$vgt": "0.9.0"
+        }
+      },
+      {
+        "version": "v0.10.0"
+      },
+      true
+    ],
+    [
+      "version v0.99.0 > 0.10.0",
+      {
+        "version": {
+          "$vgt": "0.10.0"
+        }
+      },
+      {
+        "version": "v0.99.0"
+      },
+      true
+    ],
+    [
+      "version v2.0.0 > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "v2.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.0 > v0.0.0-foo",
+      {
+        "version": {
+          "$vgt": "v0.0.0-foo"
+        }
+      },
+      {
+        "version": "0.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.0.1 > v0.0.0",
+      {
+        "version": {
+          "$vgt": "v0.0.0"
+        }
+      },
+      {
+        "version": "0.0.1"
+      },
+      true
+    ],
+    [
+      "version 1.0.0 > v0.9.9",
+      {
+        "version": {
+          "$vgt": "v0.9.9"
+        }
+      },
+      {
+        "version": "1.0.0"
+      },
+      true
+    ],
+    [
+      "version 0.10.0 > v0.9.0",
+      {
+        "version": {
+          "$vgt": "v0.9.0"
+        }
+      },
+      {
+        "version": "0.10.0"
+      },
+      true
+    ],
+    [
+      "version 0.99.0 > v0.10.0",
+      {
+        "version": {
+          "$vgt": "v0.10.0"
+        }
+      },
+      {
+        "version": "0.99.0"
+      },
+      true
+    ],
+    [
+      "version 2.0.0 > v1.2.3",
+      {
+        "version": {
+          "$vgt": "v1.2.3"
+        }
+      },
+      {
+        "version": "2.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-asdf",
+      {
+        "version": {
+          "$vgt": "1.2.3-asdf"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-4",
+      {
+        "version": {
+          "$vgt": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 > 1.2.3-4-foo",
+      {
+        "version": {
+          "$vgt": "1.2.3-4-foo"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5-foo > 1.2.3-5",
+      {
+        "version": {
+          "$vgt": "1.2.3-5"
+        }
+      },
+      {
+        "version": "1.2.3-5-foo"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5 > 1.2.3-4",
+      {
+        "version": {
+          "$vgt": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3-5"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-5-foo > 1.2.3-5-Foo",
+      {
+        "version": {
+          "$vgt": "1.2.3-5-Foo"
+        }
+      },
+      {
+        "version": "1.2.3-5-foo"
+      },
+      true
+    ],
+    [
+      "version 3.0.0 > 2.7.2+asdf",
+      {
+        "version": {
+          "$vgt": "2.7.2+asdf"
+        }
+      },
+      {
+        "version": "3.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.10 > 1.2.3-a.5",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.5"
+        }
+      },
+      {
+        "version": "1.2.3-a.10"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b > 1.2.3-a.5",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.5"
+        }
+      },
+      {
+        "version": "1.2.3-a.b"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b > 1.2.3-a",
+      {
+        "version": {
+          "$vgt": "1.2.3-a"
+        }
+      },
+      {
+        "version": "1.2.3-a.b"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-a.b.c.10.d.5 > 1.2.3-a.b.c.5.d.100",
+      {
+        "version": {
+          "$vgt": "1.2.3-a.b.c.5.d.100"
+        }
+      },
+      {
+        "version": "1.2.3-a.b.c.10.d.5"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-r2 > 1.2.3-r100",
+      {
+        "version": {
+          "$vgt": "1.2.3-r100"
+        }
+      },
+      {
+        "version": "1.2.3-r2"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-r100 > 1.2.3-R2",
+      {
+        "version": {
+          "$vgt": "1.2.3-R2"
+        }
+      },
+      {
+        "version": "1.2.3-r100"
+      },
+      true
+    ],
+    [
+      "version a.b.c.d.e.f > 1.2.3",
+      {
+        "version": {
+          "$vgt": "1.2.3"
+        }
+      },
+      {
+        "version": "a.b.c.d.e.f"
+      },
+      true
+    ],
+    [
+      "version 10.0.0 > 9.0.0",
+      {
+        "version": {
+          "$vgt": "9.0.0"
+        }
+      },
+      {
+        "version": "10.0.0"
+      },
+      true
+    ],
+    [
+      "version 10000.0.0 > 9999.0.0",
+      {
+        "version": {
+          "$vgt": "9999.0.0"
+        }
+      },
+      {
+        "version": "10000.0.0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 == 1.2.3",
+      {
+        "version": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3 == v1.2.3",
+      {
+        "version": {
+          "$veq": "v1.2.3"
+        }
+      },
+      {
+        "version": "1.2.3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-0 == v1.2.3-0",
+      {
+        "version": {
+          "$veq": "v1.2.3-0"
+        }
+      },
+      {
+        "version": "1.2.3-0"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-1 == 1.2.3-1",
+      {
+        "version": {
+          "$veq": "1.2.3-1"
+        }
+      },
+      {
+        "version": "1.2.3-1"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-1 == v1.2.3-1",
+      {
+        "version": {
+          "$veq": "v1.2.3-1"
+        }
+      },
+      {
+        "version": "1.2.3-1"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta == 1.2.3-beta",
+      {
+        "version": {
+          "$veq": "1.2.3-beta"
+        }
+      },
+      {
+        "version": "1.2.3-beta"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta == v1.2.3-beta",
+      {
+        "version": {
+          "$veq": "v1.2.3-beta"
+        }
+      },
+      {
+        "version": "1.2.3-beta"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta+build == 1.2.3-beta+otherbuild",
+      {
+        "version": {
+          "$veq": "1.2.3-beta+otherbuild"
+        }
+      },
+      {
+        "version": "1.2.3-beta+build"
+      },
+      true
+    ],
+    [
+      "version 1.2.3-beta+build == v1.2.3-beta+otherbuild",
+      {
+        "version": {
+          "$veq": "v1.2.3-beta+otherbuild"
+        }
+      },
+      {
+        "version": "1.2.3-beta+build"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == 1.2.3",
+      {
+        "version": {
+          "$veq": "1.2.3"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == 1-2.3+build99",
+      {
+        "version": {
+          "$veq": "1-2.3+build99"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1-2-3 == v1.2.3",
+      {
+        "version": {
+          "$veq": "v1.2.3"
+        }
+      },
+      {
+        "version": "1-2-3"
+      },
+      true
+    ],
+    [
+      "version 1.2.3.4 == 1.2.3-4",
+      {
+        "version": {
+          "$veq": "1.2.3-4"
+        }
+      },
+      {
+        "version": "1.2.3.4"
+      },
+      true
+    ],
+    [
+      "$or pass but second condition fail",
+      {
+        "$or": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 1
+      },
+      false
+    ],
+    [
+      "$or and second condition both pass",
+      {
+        "$or": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "baz": 2
+      },
+      {
+        "foo": 1,
+        "bar": 2,
+        "baz": 2
+      },
+      true
+    ],
+    [
+      "$and condition pass but $or fail",
+      {
+        "$and": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "$or": [
+          {
+            "baz": 1
+          },
+          {
+            "empty": 1
+          }
+        ]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2
+      },
+      false
+    ],
+    [
+      "$and and $or both pass",
+      {
+        "$and": [
+          {
+            "foo": 1
+          },
+          {
+            "bar": 1
+          }
+        ],
+        "$or": [
+          {
+            "baz": 1
+          },
+          {
+            "empty": 1
+          }
+        ]
+      },
+      {
+        "foo": 1,
+        "bar": 1,
+        "baz": 2,
+        "empty": 1
+      },
+      true
+    ],
+    [
+      "$inGroup passes for member of known group id",
+      {
+        "id": {
+          "$inGroup": "group_id"
+        }
+      },
+      {
+        "id": 1
+      },
+      true,
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    [
+      "$inGroup fails for non-member of known group id",
+      {
+        "id": {
+          "$inGroup": "group_id"
+        }
+      },
+      {
+        "id": 5
+      },
+      false,
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    [
+      "$inGroup fails for unknown group id",
+      {
+        "id": {
+          "$inGroup": "unknowngroup_id"
+        }
+      },
+      {
+        "id": 1
+      },
+      false,
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    [
+      "$notInGroup fails for member of known group id",
+      {
+        "id": {
+          "$notInGroup": "group_id"
+        }
+      },
+      {
+        "id": 1
+      },
+      false,
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    [
+      "$notInGroup passes for non-member of known group id",
+      {
+        "id": {
+          "$notInGroup": "group_id"
+        }
+      },
+      {
+        "id": 5
+      },
+      true,
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    [
+      "$notInGroup passes for unknown group id",
+      {
+        "id": {
+          "$notInGroup": "unknowngroup_id"
+        }
+      },
+      {
+        "id": 1
+      },
+      true,
+      {
+        "group_id": [
+          1,
+          2,
+          3
+        ]
+      }
+    ],
+    [
+      "$inGroup passes for properly typed data",
+      {
+        "id": {
+          "$inGroup": "group_id"
+        }
+      },
+      {
+        "id": "2"
+      },
+      true,
+      {
+        "group_id": [
+          1,
+          "2",
+          3
+        ]
+      }
+    ],
+    [
+      "$inGroup fails for improperly typed data",
+      {
+        "id": {
+          "$inGroup": "group_id"
+        }
+      },
+      {
+        "id": "3"
+      },
+      false,
+      {
+        "group_id": [
+          1,
+          "2",
+          3
+        ]
+      }
     ]
+  ],
+  "hash": [
+    [
+      "",
+      "a",
+      1,
+      0.22
+    ],
+    [
+      "",
+      "b",
+      1,
+      0.077
+    ],
+    [
+      "b",
+      "a",
+      1,
+      0.946
+    ],
+    [
+      "ef",
+      "d",
+      1,
+      0.652
+    ],
+    [
+      "asdf",
+      "8952klfjas09ujk",
+      1,
+      0.549
+    ],
+    [
+      "",
+      "123",
+      1,
+      0.011
+    ],
+    [
+      "",
+      "___)((*\":&",
+      1,
+      0.563
+    ],
+    [
+      "seed",
+      "a",
+      2,
+      0.0505
+    ],
+    [
+      "seed",
+      "b",
+      2,
+      0.2696
+    ],
+    [
+      "foo",
+      "ab",
+      2,
+      0.2575
+    ],
+    [
+      "foo",
+      "def",
+      2,
+      0.2019
+    ],
+    [
+      "89123klj",
+      "8952klfjas09ujkasdf",
+      2,
+      0.124
+    ],
+    [
+      "90850943850283058242805",
+      "123",
+      2,
+      0.7516
+    ],
+    [
+      "()**(%$##$%#$#",
+      "___)((*\":&",
+      2,
+      0.0128
+    ],
+    [
+      "abc",
+      "def",
+      99,
+      null
+    ]
+  ],
+  "getBucketRange": [
+    [
+      "normal 50/50",
+      [
+        2,
+        1,
+        null
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ]
+    ],
+    [
+      "reduced coverage",
+      [
+        2,
+        0.5,
+        null
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ]
+    ],
+    [
+      "zero coverage",
+      [
+        2,
+        0,
+        null
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0.5,
+          0.5
+        ]
+      ]
+    ],
+    [
+      "4 variations",
+      [
+        4,
+        1,
+        null
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.25,
+          0.5
+        ],
+        [
+          0.5,
+          0.75
+        ],
+        [
+          0.75,
+          1
+        ]
+      ]
+    ],
+    [
+      "uneven weights",
+      [
+        2,
+        1,
+        [
+          0.4,
+          0.6
+        ]
+      ],
+      [
+        [
+          0,
+          0.4
+        ],
+        [
+          0.4,
+          1
+        ]
+      ]
+    ],
+    [
+      "uneven weights, 3 variations",
+      [
+        3,
+        1,
+        [
+          0.2,
+          0.3,
+          0.5
+        ]
+      ],
+      [
+        [
+          0,
+          0.2
+        ],
+        [
+          0.2,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ]
+    ],
+    [
+      "uneven weights, reduced coverage, 3 variations",
+      [
+        3,
+        0.2,
+        [
+          0.2,
+          0.3,
+          0.5
+        ]
+      ],
+      [
+        [
+          0,
+          0.04
+        ],
+        [
+          0.2,
+          0.26
+        ],
+        [
+          0.5,
+          0.6
+        ]
+      ]
+    ],
+    [
+      "negative coverage",
+      [
+        2,
+        -0.2,
+        null
+      ],
+      [
+        [
+          0,
+          0
+        ],
+        [
+          0.5,
+          0.5
+        ]
+      ]
+    ],
+    [
+      "coverage above 1",
+      [
+        2,
+        1.5,
+        null
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ]
+    ],
+    [
+      "weights sum below 1",
+      [
+        2,
+        1,
+        [
+          0.4,
+          0.1
+        ]
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ]
+    ],
+    [
+      "weights sum above 1",
+      [
+        2,
+        1,
+        [
+          0.7,
+          0.6
+        ]
+      ],
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ]
+    ],
+    [
+      "weights.length not equal to num variations",
+      [
+        4,
+        1,
+        [
+          0.4,
+          0.4,
+          0.2
+        ]
+      ],
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.25,
+          0.5
+        ],
+        [
+          0.5,
+          0.75
+        ],
+        [
+          0.75,
+          1
+        ]
+      ]
+    ],
+    [
+      "weights sum almost equals 1",
+      [
+        2,
+        1,
+        [
+          0.4,
+          0.5999
+        ]
+      ],
+      [
+        [
+          0,
+          0.4
+        ],
+        [
+          0.4,
+          0.9999
+        ]
+      ]
+    ]
+  ],
+  "feature": [
+    [
+      "unknown feature key",
+      {},
+      "my-feature",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "unknownFeature",
+        "ruleId": ""
+      }
+    ],
+    [
+      "defaults when empty",
+      {
+        "features": {
+          "feature": {}
+        }
+      },
+      "feature",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "uses defaultValue - number",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 1
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "uses custom values - string",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": "yes"
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "yes",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rule with rule id",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "id": "a",
+                "force": 1
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": "a"
+      }
+    ],
+    [
+      "force rules - force false",
+      {
+        "features": {
+          "feature": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "force": false
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": false,
+        "on": false,
+        "off": true,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage included",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rule - coverage with integer hash attribute",
+      {
+        "attributes": {
+          "id": 3
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage excluded",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "id": "a",
+                "force": 1,
+                "coverage": 0.5
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage missing hashAttribute",
+      {
+        "attributes": {},
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage 0",
+      {
+        "attributes": {
+          "id": "d0bc0a5a"
+        },
+        "features": {
+          "8d156": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "8d156",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - condition pass",
+      {
+        "attributes": {
+          "country": "US",
+          "browser": "firefox"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "US",
+                      "CA"
+                    ]
+                  },
+                  "browser": "firefox"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - condition fail",
+      {
+        "attributes": {
+          "country": "US",
+          "browser": "chrome"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "US",
+                      "CA"
+                    ]
+                  },
+                  "browser": "firefox"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - coverage with bad hash version",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 1.0,
+                "hashVersion": 99
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 includes user",
+      {
+        "attributes": {
+          "id": "user2"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 excludes user that v1 would include",
+      {
+        "attributes": {
+          "id": "user3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "ignores empty rules",
+      {
+        "features": {
+          "feature": {
+            "rules": [
+              {}
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "empty experiment rule - c",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "feature": {
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "c",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "c",
+          "variationId": 2,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "bucket": 0.863,
+          "key": "2",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
+    ],
+    [
+      "empty experiment rule - a",
+      {
+        "attributes": {
+          "id": "456"
+        },
+        "features": {
+          "feature": {
+            "rules": [
+              {
+                "id": "id",
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "a",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "a",
+          "variationId": 0,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "456",
+          "bucket": 0.178,
+          "key": "0",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": "id"
+      }
+    ],
+    [
+      "empty experiment rule - b",
+      {
+        "attributes": {
+          "id": "fds"
+        },
+        "features": {
+          "feature": {
+            "rules": [
+              {
+                "variations": [
+                  "a",
+                  "b",
+                  "c"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": "b",
+        "on": true,
+        "off": false,
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            "a",
+            "b",
+            "c"
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": "b",
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "id",
+          "hashValue": "fds",
+          "bucket": 0.514,
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "source": "experiment",
+        "ruleId": ""
+      }
+    ],
+    [
+      "creates experiments properly",
+      {
+        "attributes": {
+          "anonId": "123",
+          "premium": true
+        },
+        "features": {
+          "feature": {
+            "rules": [
+              {
+                "coverage": 0.99,
+                "hashAttribute": "anonId",
+                "seed": "feature",
+                "hashVersion": 2,
+                "name": "Test",
+                "phase": "1",
+                "ranges": [
+                  [
+                    0,
+                    0.1
+                  ],
+                  [
+                    0.1,
+                    1.0
+                  ]
+                ],
+                "meta": [
+                  {
+                    "key": "v0",
+                    "name": "variation 0"
+                  },
+                  {
+                    "key": "v1",
+                    "name": "variation 1"
+                  }
+                ],
+                "filters": [
+                  {
+                    "attribute": "anonId",
+                    "seed": "pricing",
+                    "ranges": [
+                      [
+                        0,
+                        1
+                      ]
+                    ]
+                  }
+                ],
+                "namespace": [
+                  "pricing",
+                  0,
+                  1
+                ],
+                "key": "hello",
+                "variations": [
+                  true,
+                  false
+                ],
+                "weights": [
+                  0.1,
+                  0.9
+                ],
+                "condition": {
+                  "premium": true
+                },
+                "foo": "bar"
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": false,
+        "on": false,
+        "off": true,
+        "source": "experiment",
+        "experiment": {
+          "coverage": 0.99,
+          "ranges": [
+            [
+              0,
+              0.1
+            ],
+            [
+              0.1,
+              1.0
+            ]
+          ],
+          "meta": [
+            {
+              "key": "v0",
+              "name": "variation 0"
+            },
+            {
+              "key": "v1",
+              "name": "variation 1"
+            }
+          ],
+          "filters": [
+            {
+              "attribute": "anonId",
+              "seed": "pricing",
+              "ranges": [
+                [
+                  0,
+                  1
+                ]
+              ]
+            }
+          ],
+          "name": "Test",
+          "phase": "1",
+          "seed": "feature",
+          "hashVersion": 2,
+          "hashAttribute": "anonId",
+          "namespace": [
+            "pricing",
+            0,
+            1
+          ],
+          "key": "hello",
+          "variations": [
+            true,
+            false
+          ],
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "condition": {
+            "premium": true
+          }
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": false,
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": true,
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "bucket": 0.5231,
+          "key": "v1",
+          "name": "variation 1",
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "rule orders - skip 1",
+      {
+        "attributes": {
+          "browser": "firefox"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "condition": {
+                  "browser": "chrome"
+                }
+              },
+              {
+                "force": 2,
+                "condition": {
+                  "browser": "firefox"
+                }
+              },
+              {
+                "force": 3,
+                "condition": {
+                  "browser": "safari"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "rule orders - skip 1,2",
+      {
+        "attributes": {
+          "browser": "safari"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "id": "1",
+                "condition": {
+                  "browser": "chrome"
+                }
+              },
+              {
+                "id": "2",
+                "force": 2,
+                "condition": {
+                  "browser": "firefox"
+                }
+              },
+              {
+                "id": "3",
+                "force": 3,
+                "condition": {
+                  "browser": "safari"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 3,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": "3"
+      }
+    ],
+    [
+      "rule orders - skip all",
+      {
+        "attributes": {
+          "browser": "ie"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "condition": {
+                  "browser": "chrome"
+                }
+              },
+              {
+                "force": 2,
+                "condition": {
+                  "browser": "firefox"
+                }
+              },
+              {
+                "force": 3,
+                "condition": {
+                  "browser": "safari"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "skips experiment on coverage",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "coverage": 0.01
+              },
+              {
+                "force": 3
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 3,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "skips experiment on namespace",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "namespace": [
+                  "pricing",
+                  0,
+                  0.01
+                ]
+              },
+              {
+                "force": 3
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 3,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "handles integer hashAttribute",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            0,
+            1
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "hashAttribute": "id",
+          "hashValue": 123,
+          "hashUsed": true,
+          "inExperiment": true,
+          "value": 1,
+          "variationId": 1,
+          "key": "1",
+          "bucket": 0.863,
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "skip experiment on missing hashAttribute",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "hashAttribute": "company"
+              },
+              {
+                "force": 3
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 3,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "include experiments when forced",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "forcedVariations": {
+          "feature": 1
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ]
+              },
+              {
+                "force": 3
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "key": "feature",
+          "variations": [
+            0,
+            1,
+            2,
+            3
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "value": 1,
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": false,
+          "hashAttribute": "id",
+          "hashValue": "123",
+          "key": "1",
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "Force rule with range, ignores coverage",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "coverage": 0.01,
+                "range": [
+                  0,
+                  0.99
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Force rule, hash version 2",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "hashVersion": 2,
+                "range": [
+                  0.96,
+                  0.97
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Force rule, skip due to range",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "range": [
+                  0,
+                  0.01
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Force rule, skip due to filter",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "filters": [
+                  {
+                    "seed": "seed",
+                    "ranges": [
+                      [
+                        0,
+                        0.01
+                      ]
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Force rule, use seed with range",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 2,
+                "range": [
+                  0,
+                  0.5
+                ],
+                "seed": "fjdslafdsa",
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 2,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Support passthrough variations",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "holdout",
+                "variations": [
+                  1,
+                  2
+                ],
+                "hashVersion": 2,
+                "ranges": [
+                  [
+                    0,
+                    0.01
+                  ],
+                  [
+                    0.01,
+                    1.0
+                  ]
+                ],
+                "meta": [
+                  {},
+                  {
+                    "passthrough": true
+                  }
+                ]
+              },
+              {
+                "key": "experiment",
+                "variations": [
+                  3,
+                  4
+                ],
+                "hashVersion": 2,
+                "ranges": [
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 3,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "key": "experiment",
+          "hashVersion": 2,
+          "variations": [
+            3,
+            4
+          ],
+          "ranges": [
+            [
+              0,
+              0.5
+            ],
+            [
+              0.5,
+              1.0
+            ]
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": "1",
+          "inExperiment": true,
+          "key": "0",
+          "value": 3,
+          "variationId": 0,
+          "bucket": 0.4413,
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "Support holdout groups",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "holdout",
+                "hashVersion": 2,
+                "variations": [
+                  1,
+                  2
+                ],
+                "ranges": [
+                  [
+                    0,
+                    0.99
+                  ],
+                  [
+                    0.99,
+                    1.0
+                  ]
+                ],
+                "meta": [
+                  {},
+                  {
+                    "passthrough": true
+                  }
+                ]
+              },
+              {
+                "key": "experiment",
+                "hashVersion": 2,
+                "variations": [
+                  3,
+                  4
+                ],
+                "ranges": [
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "hashVersion": 2,
+          "ranges": [
+            [
+              0,
+              0.99
+            ],
+            [
+              0.99,
+              1.0
+            ]
+          ],
+          "meta": [
+            {},
+            {
+              "passthrough": true
+            }
+          ],
+          "key": "holdout",
+          "variations": [
+            1,
+            2
+          ]
+        },
+        "experimentResult": {
+          "featureId": "feature",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": "1",
+          "inExperiment": true,
+          "key": "0",
+          "value": 1,
+          "variationId": 0,
+          "bucket": 0.8043,
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite flag off, block dependent flag",
+      {
+        "attributes": {
+          "id": "123",
+          "memberType": "basic",
+          "country": "Canada"
+        },
+        "features": {
+          "parentFlag": {
+            "defaultValue": "silver",
+            "rules": [
+              {
+                "condition": {
+                  "country": "Canada"
+                },
+                "force": "red"
+              },
+              {
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
+                "force": "green"
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": "green"
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite flag missing, block dependent flag",
+      {
+        "attributes": {
+          "id": "123",
+          "memberType": "basic",
+          "country": "Canada"
+        },
+        "features": {
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": "green"
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite flag on, evaluate dependent flag",
+      {
+        "attributes": {
+          "id": "123",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentFlag": {
+            "defaultValue": "silver",
+            "rules": [
+              {
+                "condition": {
+                  "country": "Canada"
+                },
+                "force": "red"
+              },
+              {
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
+                "force": "green"
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": "green"
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "success",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Multiple parallel prerequisite flags on, evaluate dependent flag",
+      {
+        "attributes": {
+          "id": "123",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentFlag1": {
+            "defaultValue": "silver",
+            "rules": [
+              {
+                "condition": {
+                  "country": "Canada"
+                },
+                "force": "red"
+              },
+              {
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
+                "force": "green"
+              }
+            ]
+          },
+          "parentFlag2": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "condition": {
+                  "id": "123"
+                },
+                "force": 2
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag1",
+                    "condition": {
+                      "value": "green"
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag2",
+                    "condition": {
+                      "value": {
+                        "$gt": 1
+                      }
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "success",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Multiple nested prerequisite flags on, evaluate dependent flag",
+      {
+        "attributes": {
+          "id": "123",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentFlag1": {
+            "defaultValue": "silver",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag2",
+                    "condition": {
+                      "value": {
+                        "$gt": 1
+                      }
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "country": "Canada"
+                },
+                "force": "red"
+              },
+              {
+                "condition": {
+                  "country": {
+                    "$in": [
+                      "USA",
+                      "Mexico"
+                    ]
+                  }
+                },
+                "force": "green"
+              }
+            ]
+          },
+          "parentFlag2": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "condition": {
+                  "id": "123"
+                },
+                "force": 2
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag1",
+                    "condition": {
+                      "value": "green"
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "success",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite experiment flag in target bucket, evaluate dependent flag",
+      {
+        "attributes": {
+          "id": "1234",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentExperimentFlag": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "variations": [
+                  0,
+                  1
+                ],
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "ranges": [
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
+                ]
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentExperimentFlag",
+                    "condition": {
+                      "value": 1
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "success",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite experiment flag in target bucket, evaluate skip dependent flag if not bucketed",
+      {
+        "attributes": {
+          "id": "1234",
+          "memberType": "basic",
+          "country": "USA"
+        },
+        "features": {
+          "parentExperimentFlag": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "variations": [
+                  0,
+                  1
+                ],
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "ranges": [
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
+                ]
+              }
+            ]
+          },
+          "childFlag": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentExperimentFlag",
+                    "condition": {
+                      "value": 0
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "memberType": "basic"
+                },
+                "force": "success"
+              }
+            ]
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "prerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Prerequisite cycle detected, break",
+      {
+        "attributes": {
+          "id": "123"
+        },
+        "features": {
+          "flag1": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "flag2",
+                    "condition": {
+                      "value": true
+                    },
+                    "gate": true
+                  }
+                ]
+              }
+            ]
+          },
+          "flag2": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "flag1",
+                    "condition": {
+                      "value": true
+                    },
+                    "gate": true
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "flag1",
+      {
+        "value": null,
+        "on": false,
+        "off": true,
+        "source": "cyclicPrerequisite",
+        "ruleId": ""
+      }
+    ],
+    [
+      "Multiple references to same prerequisite, do not break",
+      {
+        "attributes": {
+          "id": "123",
+          "browser": "edge"
+        },
+        "features": {
+          "childFlag": {
+            "defaultValue": true,
+            "rules": [
+              {
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": {
+                        "$ne": false
+                      }
+                    },
+                    "gate": true
+                  },
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": true
+                    },
+                    "gate": true
+                  }
+                ]
+              },
+              {
+                "condition": {
+                  "browser": "safari"
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": true
+                    }
+                  }
+                ],
+                "force": "C"
+              },
+              {
+                "condition": {
+                  "browser": {
+                    "$ne": "safari"
+                  }
+                },
+                "parentConditions": [
+                  {
+                    "id": "parentFlag",
+                    "condition": {
+                      "value": true
+                    }
+                  }
+                ],
+                "force": "T"
+              }
+            ]
+          },
+          "parentFlag": {
+            "defaultValue": true
+          }
+        }
+      },
+      "childFlag",
+      {
+        "value": "T",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "SavedGroups correctly pulled from context for force rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_force_rule": {
+            "defaultValue": false,
+            "rules": [
+              {
+                "force": true,
+                "condition": {
+                  "id": {
+                    "$inGroup": "group_id"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "savedGroups": {
+          "group_id": [
+            123,
+            456
+          ]
+        }
+      },
+      "inGroup_force_rule",
+      {
+        "value": true,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "SavedGroups correctly pulled from context for experiment rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_experiment_rule": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "condition": {
+                  "id": {
+                    "$inGroup": "group_id"
+                  }
+                },
+                "hashVersion": 2,
+                "variations": [
+                  1,
+                  2
+                ],
+                "ranges": [
+                  [
+                    0,
+                    0.5
+                  ],
+                  [
+                    0.5,
+                    1.0
+                  ]
+                ]
+              }
+            ]
+          }
+        },
+        "savedGroups": {
+          "group_id": [
+            123,
+            456
+          ]
+        }
+      },
+      "inGroup_experiment_rule",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "hashVersion": 2,
+          "condition": {
+            "id": {
+              "$inGroup": "group_id"
+            }
+          },
+          "variations": [
+            1,
+            2
+          ],
+          "ranges": [
+            [
+              0,
+              0.5
+            ],
+            [
+              0.5,
+              1.0
+            ]
+          ],
+          "key": "experiment"
+        },
+        "experimentResult": {
+          "featureId": "inGroup_experiment_rule",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": 123,
+          "inExperiment": true,
+          "key": "0",
+          "value": 1,
+          "variationId": 0,
+          "bucket": 0.1736,
+          "stickyBucketUsed": false
+        },
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  1,
+                  0
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  1,
+                  0
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0,
+                  1
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "multi-armed-bandit type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "multi-armed-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "standard type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "standard"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "unknown bandit fields on a non-CB rule are ignored",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "banditVersion": 9
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ]
+  ],
+  "run": [
+    [
+      "default weights - 1",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "default weights - 2",
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "default weights - 3",
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "default weights - 4",
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "default weights - 5",
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "default weights - 6",
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "default weights - 7",
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "default weights - 8",
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "default weights - 9",
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 1",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 2",
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 3",
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 4",
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 5",
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 6",
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 7",
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 8",
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "uneven weights - 9",
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.1,
+          0.9
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "coverage - 1",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "coverage - 2",
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "coverage - 3",
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "coverage - 4",
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "coverage - 5",
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "coverage - 6",
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "coverage - 7",
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "coverage - 8",
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "coverage - 9",
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0.4
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "three way test - 1",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      2,
+      true,
+      true
+    ],
+    [
+      "three way test - 2",
+      {
+        "attributes": {
+          "id": "2"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "three way test - 3",
+      {
+        "attributes": {
+          "id": "3"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "three way test - 4",
+      {
+        "attributes": {
+          "id": "4"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      2,
+      true,
+      true
+    ],
+    [
+      "three way test - 5",
+      {
+        "attributes": {
+          "id": "5"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "three way test - 6",
+      {
+        "attributes": {
+          "id": "6"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      2,
+      true,
+      true
+    ],
+    [
+      "three way test - 7",
+      {
+        "attributes": {
+          "id": "7"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "three way test - 8",
+      {
+        "attributes": {
+          "id": "8"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "three way test - 9",
+      {
+        "attributes": {
+          "id": "9"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "test name - my-test",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "test name - my-test-3",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test-3",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      true,
+      true
+    ],
+    [
+      "empty id",
+      {
+        "attributes": {
+          "id": ""
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "null id",
+      {
+        "attributes": {
+          "id": null
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "missing id",
+      {
+        "attributes": {}
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "missing attributes",
+      {},
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "single variation",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "negative forced variation",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": -8
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "high forced variation",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": 25
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "evaluates conditions - pass",
+      {
+        "attributes": {
+          "id": "1",
+          "browser": "firefox"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "condition": {
+          "browser": "firefox"
+        }
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "evaluates conditions - fail",
+      {
+        "attributes": {
+          "id": "1",
+          "browser": "chrome"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "condition": {
+          "browser": "firefox"
+        }
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "custom hashAttribute",
+      {
+        "attributes": {
+          "id": "2",
+          "companyId": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "hashAttribute": "companyId"
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "globally disabled",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "enabled": false
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "querystring force",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "url": "http://example.com?forced-test-qs=1#someanchor"
+      },
+      {
+        "key": "forced-test-qs",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      false
+    ],
+    [
+      "run active experiments",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "active": true,
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "skip inactive experiments",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "active": false,
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "querystring force with inactive",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "url": "http://example.com/?my-test=1"
+      },
+      {
+        "key": "my-test",
+        "active": false,
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      false
+    ],
+    [
+      "coverage take precendence over forced",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "force": 1,
+        "coverage": 0.01,
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "JSON values for experiments",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          {
+            "color": "blue",
+            "size": "small"
+          },
+          {
+            "color": "green",
+            "size": "large"
+          }
+        ]
+      },
+      {
+        "color": "green",
+        "size": "large"
+      },
+      true,
+      true
+    ],
+    [
+      "Force variation from context",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "forcedVariations": {
+          "my-test": 0
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      true,
+      false
+    ],
+    [
+      "Skips experiments in QA mode",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "qaMode": true
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Works in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "my-test": 1
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      false
+    ],
+    [
+      "Works in QA mode if forced in experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "qaMode": true
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "force": 1
+      },
+      1,
+      true,
+      false
+    ],
+    [
+      "Experiment namespace - pass",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "namespace": [
+          "namespace",
+          0.1,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Experiment namespace - fail",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "namespace": [
+          "namespace",
+          0,
+          0.1
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Experiment coverage - Works when 0",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "no-coverage",
+        "variations": [
+          0,
+          1
+        ],
+        "coverage": 0
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Filtered, included",
+      {
+        "attributes": {
+          "id": "1",
+          "anonId": "fsdafsda"
+        }
+      },
+      {
+        "key": "filtered",
+        "variations": [
+          0,
+          1
+        ],
+        "filters": [
+          {
+            "seed": "seed",
+            "ranges": [
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
+            ]
+          },
+          {
+            "seed": "seed",
+            "attribute": "anonId",
+            "ranges": [
+              [
+                0.8,
+                1.0
+              ]
+            ]
+          }
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Filtered, excluded",
+      {
+        "attributes": {
+          "id": "1",
+          "anonId": "fsdafsda"
+        }
+      },
+      {
+        "key": "filtered",
+        "variations": [
+          0,
+          1
+        ],
+        "filters": [
+          {
+            "seed": "seed",
+            "ranges": [
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
+            ]
+          },
+          {
+            "seed": "seed",
+            "attribute": "anonId",
+            "ranges": [
+              [
+                0.6,
+                0.8
+              ]
+            ]
+          }
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Filtered, ignore namespace",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "filtered",
+        "variations": [
+          0,
+          1
+        ],
+        "filters": [
+          {
+            "seed": "seed",
+            "ranges": [
+              [
+                0,
+                0.1
+              ],
+              [
+                0.2,
+                0.4
+              ]
+            ]
+          }
+        ],
+        "namespace": [
+          "test",
+          0,
+          0.001
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Ranges, ignore coverage and weights",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "ranges",
+        "variations": [
+          0,
+          1
+        ],
+        "ranges": [
+          [
+            0.99,
+            1.0
+          ],
+          [
+            0.0,
+            0.99
+          ]
+        ],
+        "coverage": 0.01,
+        "weights": [
+          0.99,
+          0.01
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Ranges, partial coverage",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "configs",
+        "variations": [
+          0,
+          1
+        ],
+        "ranges": [
+          [
+            0,
+            0.1
+          ],
+          [
+            0.9,
+            1.0
+          ]
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "Uses seed and hash version",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "key",
+        "seed": "foo",
+        "hashVersion": 2,
+        "variations": [
+          0,
+          1
+        ],
+        "ranges": [
+          [
+            0,
+            0.5
+          ],
+          [
+            0.5,
+            1.0
+          ]
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Uses seed with default weights/coverage",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "key",
+        "seed": "foo",
+        "hashVersion": 2,
+        "variations": [
+          0,
+          1
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Uses seed with weights/coverage",
+      {
+        "attributes": {
+          "id": "1"
+        }
+      },
+      {
+        "key": "key",
+        "seed": "foo",
+        "hashVersion": 2,
+        "variations": [
+          0,
+          1
+        ],
+        "weights": [
+          0.5,
+          0.5
+        ],
+        "coverage": 0.99
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Prerequisite condition passes",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "parentFlag": {
+            "defaultValue": true
+          }
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "parentConditions": [
+          {
+            "id": "parentFlag",
+            "condition": {
+              "value": true
+            }
+          }
+        ]
+      },
+      1,
+      true,
+      true
+    ],
+    [
+      "Prerequisite condition fails",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "parentFlag": {
+            "defaultValue": false
+          }
+        }
+      },
+      {
+        "key": "my-test",
+        "variations": [
+          0,
+          1
+        ],
+        "parentConditions": [
+          {
+            "id": "parentFlag",
+            "condition": {
+              "value": true
+            }
+          }
+        ]
+      },
+      0,
+      false,
+      false
+    ],
+    [
+      "SavedGroups correctly pulled from context for experiment",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "savedGroups": {
+          "group_id": [
+            "4",
+            "5",
+            "6"
+          ]
+        }
+      },
+      {
+        "key": "group-filtered-test",
+        "condition": {
+          "id": {
+            "$inGroup": "group_id"
+          }
+        },
+        "variations": [
+          0,
+          1,
+          2
+        ]
+      },
+      0,
+      true,
+      true
+    ]
+  ],
+  "chooseVariation": [
+    [
+      "even range, 0.2",
+      0.2,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      0
+    ],
+    [
+      "even range, 0.4",
+      0.4,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      0
+    ],
+    [
+      "even range, 0.6",
+      0.6,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      1
+    ],
+    [
+      "even range, 0.8",
+      0.8,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      1
+    ],
+    [
+      "even range, 0",
+      0,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      0
+    ],
+    [
+      "even range, 0.5",
+      0.5,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      1
+    ],
+    [
+      "reduced range, 0.2",
+      0.2,
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ],
+      0
+    ],
+    [
+      "reduced range, 0.4",
+      0.4,
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ],
+      -1
+    ],
+    [
+      "reduced range, 0.6",
+      0.6,
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ],
+      1
+    ],
+    [
+      "reduced range, 0.8",
+      0.8,
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ],
+      -1
+    ],
+    [
+      "reduced range, 0.25",
+      0.25,
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ],
+      -1
+    ],
+    [
+      "reduced range, 0.5",
+      0.5,
+      [
+        [
+          0,
+          0.25
+        ],
+        [
+          0.5,
+          0.75
+        ]
+      ],
+      1
+    ],
+    [
+      "zero range",
+      0.5,
+      [
+        [
+          0,
+          0.5
+        ],
+        [
+          0.5,
+          0.5
+        ],
+        [
+          0.5,
+          1
+        ]
+      ],
+      2
+    ]
+  ],
+  "getQueryStringOverride": [
+    [
+      "empty url",
+      "my-test",
+      "",
+      2,
+      null
+    ],
+    [
+      "no query string",
+      "my-test",
+      "http://example.com",
+      2,
+      null
+    ],
+    [
+      "empty query string",
+      "my-test",
+      "http://example.com?",
+      2,
+      null
+    ],
+    [
+      "no query string match",
+      "my-test",
+      "http://example.com?somequery",
+      2,
+      null
+    ],
+    [
+      "invalid query string",
+      "my-test",
+      "http://example.com??&&&?#",
+      2,
+      null
+    ],
+    [
+      "simple match 0",
+      "my-test",
+      "http://example.com?my-test=0",
+      2,
+      0
+    ],
+    [
+      "simple match 1",
+      "my-test",
+      "http://example.com?my-test=1",
+      2,
+      1
+    ],
+    [
+      "negative variation",
+      "my-test",
+      "http://example.com?my-test=-1",
+      2,
+      null
+    ],
+    [
+      "float",
+      "my-test",
+      "http://example.com?my-test=2.054",
+      2,
+      null
+    ],
+    [
+      "string",
+      "my-test",
+      "http://example.com?my-test=foo",
+      2,
+      null
+    ],
+    [
+      "variation too high",
+      "my-test",
+      "http://example.com?my-test=5",
+      2,
+      null
+    ],
+    [
+      "high numVariations",
+      "my-test",
+      "http://example.com?my-test=5",
+      6,
+      5
+    ],
+    [
+      "equal to numVariations",
+      "my-test",
+      "http://example.com?my-test=5",
+      5,
+      null
+    ],
+    [
+      "other query string before",
+      "my-test",
+      "http://example.com?foo=bar&my-test=1",
+      2,
+      1
+    ],
+    [
+      "other query string after",
+      "my-test",
+      "http://example.com?foo=bar&my-test=1&bar=baz",
+      2,
+      1
+    ],
+    [
+      "anchor",
+      "my-test",
+      "http://example.com?my-test=1#foo",
+      2,
+      1
+    ]
+  ],
+  "inNamespace": [
+    [
+      "user 1, namespace1, 1",
+      "1",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 1, namespace1, 2",
+      "1",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 1, namespace2, 1",
+      "1",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 1, namespace2, 2",
+      "1",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 2, namespace1, 1",
+      "2",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 2, namespace1, 2",
+      "2",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 2, namespace2, 1",
+      "2",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 2, namespace2, 2",
+      "2",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 3, namespace1, 1",
+      "3",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 3, namespace1, 2",
+      "3",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 3, namespace2, 1",
+      "3",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      true
+    ],
+    [
+      "user 3, namespace2, 2",
+      "3",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      false
+    ],
+    [
+      "user 4, namespace1, 1",
+      "4",
+      [
+        "namespace1",
+        0,
+        0.4
+      ],
+      false
+    ],
+    [
+      "user 4, namespace1, 2",
+      "4",
+      [
+        "namespace1",
+        0.4,
+        1
+      ],
+      true
+    ],
+    [
+      "user 4, namespace2, 1",
+      "4",
+      [
+        "namespace2",
+        0,
+        0.4
+      ],
+      true
+    ],
+    [
+      "user 4, namespace2, 2",
+      "4",
+      [
+        "namespace2",
+        0.4,
+        1
+      ],
+      false
+    ]
+  ],
+  "getEqualWeights": [
+    [
+      -1,
+      []
+    ],
+    [
+      0,
+      []
+    ],
+    [
+      1,
+      [
+        1
+      ]
+    ],
+    [
+      2,
+      [
+        0.5,
+        0.5
+      ]
+    ],
+    [
+      3,
+      [
+        0.33333333,
+        0.33333333,
+        0.33333333
+      ]
+    ],
+    [
+      4,
+      [
+        0.25,
+        0.25,
+        0.25,
+        0.25
+      ]
+    ]
+  ],
+  "decrypt": [
+    [
+      "Valid feature",
+      "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznZ6SX28Yjg==",
+      "{\"feature\":{\"defaultValue\":true}}"
+    ],
+    [
+      "Broken JSON",
+      "SVZIM2oKD1JoHNIeeoW3Uw==.AGbRiGAHf2f6/ziVr9UTIy+bVFmVli6+bHZ2jnCm9N991ITv1ROvOEjxjLSmgEpv",
+      "UQD0Qqw7fM1bhfKKPH8TGw==",
+      "{\"feature\":{\"defaultValue\":true?5%"
+    ],
+    [
+      "Wrong key",
+      "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznZ6SX39Yjg==",
+      null
+    ],
+    [
+      "Invalid key length",
+      "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznSX39Yjg==",
+      null
+    ],
+    [
+      "Invalid key characters",
+      "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/%!(pFDznZ6SX39Yjg==",
+      null
+    ],
+    [
+      "Invalid body",
+      "m5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q0!*&()f3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznZ6SX28Yjg==",
+      null
+    ],
+    [
+      "Invalid iv length",
+      "m5ylFM6ndyOPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznZ6SX28Yjg==",
+      null
+    ],
+    [
+      "Invalid iv",
+      "m5ylFM6*&(OJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznZ6SX28Yjg==",
+      null
+    ],
+    [
+      "Missing delimiter",
+      "m5ylFM6ndyOJA2OPadubkw==Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj",
+      "Zvwv/+uhpFDznZ6SX28Yjg==",
+      null
+    ],
+    [
+      "Corrupted payload",
+      "fsa*(&(SF*&F&SF^SD&*FS&*6fsdkajfd",
+      "Zvwv/+uhpFDznZ6SX28Yjg==",
+      null
+    ]
+  ],
+  "stickyBucket": [
+    [
+      "use fallbackAttribute when missing hashAttribute",
+      {
+        "attributes": {
+          "anonymousId": "123"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [
+                  0,
+                  1,
+                  2,
+                  3
+                ],
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId"
+              }
+            ]
+          }
+        }
+      },
+      [],
+      "feature",
+      {
+        "bucket": 0.863,
+        "featureId": "feature",
+        "hashAttribute": "anonymousId",
+        "hashUsed": true,
+        "hashValue": "123",
+        "inExperiment": true,
+        "key": "3",
+        "stickyBucketUsed": false,
+        "value": 3,
+        "variationId": 3
+      },
+      {
+        "anonymousId||123": {
+          "assignments": {
+            "feature__0": "3"
+          },
+          "attributeName": "anonymousId",
+          "attributeValue": "123"
+        }
+      }
+    ],
+    [
+      "performs evaluation without sticky bucket",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        },
+        "stickyBucketAssignmentDocs": {}
+      },
+      [],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "evaluates based on stored sticky bucket",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": true,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__0": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "does not consume a sticky bucket not belonging to the user",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d456",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "upgrades a sticky bucket doc from a fallbackAttribute to a hashAttribute",
+      {
+        "attributes": {
+          "id": "i123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.9943,
+        "featureId": "exp1",
+        "hashAttribute": "id",
+        "hashUsed": true,
+        "hashValue": "i123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": true,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "anonymousId||ses123": {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123"
+        },
+        "id||i123": {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "favors a sticky bucket doc based on hashAttribute over fallbackAttribute",
+      {
+        "attributes": {
+          "id": "i123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "anonymousId",
+                "hashVersion": 2,
+                "bucketVersion": 0,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123",
+          "assignments": {
+            "feature-exp__0": "2"
+          }
+        },
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.9943,
+        "featureId": "exp1",
+        "hashAttribute": "id",
+        "hashUsed": true,
+        "hashValue": "i123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": true,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "anonymousId||ses123": {
+          "assignments": {
+            "feature-exp__0": "2"
+          },
+          "attributeName": "anonymousId",
+          "attributeValue": "ses123"
+        },
+        "id||i123": {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when the bucketVersion changes",
+      {
+        "attributes": {
+          "id": "i123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.9943,
+        "featureId": "exp1",
+        "hashAttribute": "id",
+        "hashUsed": true,
+        "hashValue": "i123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": false,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "id||i123": {
+          "assignments": {
+            "feature-exp__0": "1",
+            "feature-exp__3": "2"
+          },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "stops test enrollment when and existing sticky bucket is blocked by version",
+      {
+        "attributes": {
+          "id": "i123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      ],
+      "exp1",
+      null,
+      {
+        "id||i123": {
+          "assignments": {
+            "feature-exp__0": "1"
+          },
+          "attributeName": "id",
+          "attributeValue": "i123"
+        }
+      }
+    ],
+    [
+      "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": true,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "skips assignment when sticky bucket version < experiment.minBucketVersion",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__2": "2"
+          }
+        }
+      ],
+      "exp1",
+      null,
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__2": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version > experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 3,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__4": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "1",
+            "feature-exp__4": "2"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "resets sticky bucketing when bucket version < experiment.bucketVersion (invalid version)",
+      {
+        "attributes": {
+          "deviceId": "d123",
+          "anonymousId": "ses123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 4,
+                "minBucketVersion": 3,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "deviceId",
+          "attributeValue": "d123",
+          "assignments": {
+            "feature-exp__3": "2"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.6468,
+        "featureId": "exp1",
+        "hashAttribute": "deviceId",
+        "hashUsed": true,
+        "hashValue": "d123",
+        "inExperiment": true,
+        "key": "1",
+        "stickyBucketUsed": false,
+        "value": "red",
+        "variationId": 1
+      },
+      {
+        "deviceId||d123": {
+          "assignments": {
+            "feature-exp__3": "2",
+            "feature-exp__4": "1"
+          },
+          "attributeName": "deviceId",
+          "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "disables sticky bucketing when disabled by experiment",
+      {
+        "attributes": {
+          "id": "i123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 1,
+                "disableStickyBucketing": true,
+                "condition": {
+                  "country": "USA"
+                },
+                "variations": [
+                  "control",
+                  "red",
+                  "blue"
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "coverage": 1,
+                "weights": [
+                  0.3334,
+                  0.3333,
+                  0.3333
+                ],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.9943,
+        "featureId": "exp1",
+        "hashAttribute": "id",
+        "hashUsed": true,
+        "hashValue": "i123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": false,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "id||i123": {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": {
+            "feature-exp__0": "1"
+          }
+        }
+      }
+    ]
+  ],
+  "urlRedirect": [
+    [
+      "redirects correctly without query strings",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "url": "http://www.example.com/home",
+        "experiments": [
+          {
+            "key": "my-experiment",
+            "urlPatterns": [
+              {
+                "type": "simple",
+                "include": true,
+                "pattern": "http://www.example.com/home"
+              }
+            ],
+            "weights": [
+              0.1,
+              0.9
+            ],
+            "variations": [
+              {},
+              {
+                "urlRedirect": "http://www.example.com/home-new"
+              }
+            ]
+          }
+        ]
+      },
+      [
+        {
+          "inExperiment": true,
+          "urlRedirect": "http://www.example.com/home-new",
+          "urlWithParams": "http://www.example.com/home-new"
+        }
+      ]
+    ],
+    [
+      "redirects with query string on original url and persistQueryString enabled",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "url": "http://www.example.com/home?color=blue&food=sushi",
+        "experiments": [
+          {
+            "key": "my-experiment",
+            "urlPatterns": [
+              {
+                "type": "simple",
+                "include": true,
+                "pattern": "http://www.example.com/home"
+              }
+            ],
+            "weights": [
+              0.1,
+              0.9
+            ],
+            "variations": [
+              {},
+              {
+                "urlRedirect": "http://www.example.com/home-new"
+              }
+            ],
+            "persistQueryString": true
+          }
+        ]
+      },
+      [
+        {
+          "inExperiment": true,
+          "urlRedirect": "http://www.example.com/home-new",
+          "urlWithParams": "http://www.example.com/home-new?color=blue&food=sushi"
+        }
+      ]
+    ],
+    [
+      "merges query strings on original url & redirect url with param conflicts correctly when persistQueryString enabled",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "url": "http://www.example.com/home?color=blue&food=sushi&title=original",
+        "experiments": [
+          {
+            "key": "my-experiment",
+            "urlPatterns": [
+              {
+                "type": "simple",
+                "include": true,
+                "pattern": "http://www.example.com/home"
+              }
+            ],
+            "weights": [
+              0.1,
+              0.9
+            ],
+            "variations": [
+              {},
+              {
+                "urlRedirect": "http://www.example.com/home-new?name=test&color=red&food=lasagna"
+              }
+            ],
+            "persistQueryString": true
+          }
+        ]
+      },
+      [
+        {
+          "inExperiment": true,
+          "urlRedirect": "http://www.example.com/home-new?name=test&color=red&food=lasagna",
+          "urlWithParams": "http://www.example.com/home-new?name=test&color=red&food=lasagna&title=original"
+        }
+      ]
+    ],
+    [
+      "only performs a redirect for first eligible experiment when there are multiple eligible experiments",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "url": "http://www.example.com/home",
+        "experiments": [
+          {
+            "key": "my-experiment",
+            "urlPatterns": [
+              {
+                "type": "simple",
+                "include": true,
+                "pattern": "http://www.example.com/"
+              }
+            ],
+            "weights": [
+              0.1,
+              0.9
+            ],
+            "variations": [
+              {},
+              {
+                "urlRedirect": "http://www.example.com/home-new"
+              }
+            ]
+          },
+          {
+            "key": "my-experiment-2",
+            "urlPatterns": [
+              {
+                "type": "simple",
+                "include": true,
+                "pattern": "http://www.example.com/home"
+              }
+            ],
+            "weights": [
+              0.1,
+              0.9
+            ],
+            "variations": [
+              {},
+              {
+                "urlRedirect": "http://www.example.com/home-new-new"
+              }
+            ]
+          },
+          {
+            "key": "my-experiment-3",
+            "urlPatterns": [
+              {
+                "type": "simple",
+                "include": true,
+                "pattern": "http://www.example.com/home"
+              }
+            ],
+            "weights": [
+              0.1,
+              0.9
+            ],
+            "variations": [
+              {},
+              {
+                "urlRedirect": "http://www.example.com/home-es"
+              }
+            ]
+          }
+        ]
+      },
+      [
+        {
+          "inExperiment": true,
+          "urlRedirect": "http://www.example.com/home-new-new",
+          "urlWithParams": "http://www.example.com/home-new-new"
+        }
+      ]
+    ]
+  ],
+  "contextualBandit": [
+    [
+      "single catch-all leaf routes and sets CB result fields",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "anything"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "matches the first (specific) leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "falls through to the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $in matches",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free",
+          "cartValue": 100
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": [
+                      "free",
+                      "basic"
+                    ]
+                  }
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $gte matches second leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "cartValue": 600
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": [
+                      "free",
+                      "basic"
+                    ]
+                  }
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "first-match-wins when multiple leaf conditions match",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "pro"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "country": "US"
+                },
+                "weights": [
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "missing attribute used by a leaf condition falls into the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule outer condition fails, a following force rule applies",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "condition": {
+                  "country": "US"
+                },
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              },
+              {
+                "force": "forced"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "forced",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition fails - CB rule skipped",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage excludes user even though a leaf matched",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.01,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "three-arm CB leaf routes with positional weights",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "c0",
+                  "c1",
+                  "c2"
+                ],
+                "weights": [
+                  0.34,
+                  0.33,
+                  0.33
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  0,
+                  0,
+                  1
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0.34,
+                  0.33,
+                  0.33
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "c2",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "c0",
+            "c1",
+            "c2"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0,
+            0,
+            1
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            },
+            {
+              "key": "2"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0,
+              0,
+              1
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "2",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 2,
+          "value": "c2",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            0,
+            0,
+            1
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule as a later rule in the list",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "first",
+                "seed": "first",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "CA"
+                }
+              },
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 2",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "2",
+          "stickyBucketUsed": false,
+          "bucket": 0.9374,
+          "leafId": 1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 3",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.5,
+                  0.5
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "3",
+          "stickyBucketUsed": false,
+          "bucket": 0.8606,
+          "leafId": 1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.1,
+                  0.9
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.1,
+              0.9
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            0.1,
+            0.9
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 4",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  0.1,
+                  0.9
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.1,
+            0.9
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              0.1,
+              0.9
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "4",
+          "stickyBucketUsed": false,
+          "bucket": 0.4818,
+          "leafId": 1,
+          "variationWeights": [
+            0.1,
+            0.9
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB empty hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": "",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB null hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": null,
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB missing hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB buckets on a custom hashAttribute",
+      {
+        "attributes": {
+          "anonId": "123",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "anonId",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "anonId",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "stickyBucketUsed": false,
+          "bucket": 0.0484,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "forcedVariations from context overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "querystring force overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "url": "https://example.com/?bandit-exp=1",
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB skipped in QA mode",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "bandit-exp": 0
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB rule when globally disabled",
+      {
+        "enabled": false,
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "JSON variation values with CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": {
+              "color": "none"
+            },
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "green"
+                  }
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": {
+          "color": "blue"
+        },
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            {
+              "color": "blue"
+            },
+            {
+              "color": "green"
+            }
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": {
+            "color": "blue"
+          },
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "single-variation CB rule is invalid - not in experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control"
+                ],
+                "weights": [
+                  1
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition passes - CB routes",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "condition": {
+            "country": "US"
+          },
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [
+                  0,
+                  1
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 0.5,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "8",
+          "stickyBucketUsed": false,
+          "bucket": 0.011,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "dangling contextualBanditRef uses marginal weights with no CB metadata",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "empty contexts array uses marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "banditVersion omitted from definition is absent from result",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [
+                  1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            1,
+            0
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [
+              1,
+              0
+            ]
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [
+            1,
+            0
+          ]
+        }
+      }
+    ],
+    [
+      "required attribute present but no leaf matches - fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  "control",
+                  "treatment"
+                ],
+                "weights": [
+                  0.5,
+                  0.5
+                ],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [
+                  1,
+                  0
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            "control",
+            "treatment"
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [
+            0.5,
+            0.5
+          ],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [
+              0.5,
+              0.5
+            ],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [
+            0.5,
+            0.5
+          ],
+          "banditVersion": 7
+        }
+      }
+    ]
+  ]
 }

--- a/GrowthBookTests/Source/local-cases.json
+++ b/GrowthBookTests/Source/local-cases.json
@@ -1,0 +1,53 @@
+{
+  "_note": "Cases this fork keeps that the canonical GrowthBook spec does not carry. Kept in a separate file so bumping Source/json.json stays a verbatim copy of upstream and cannot silently drop them, which is exactly what happened during the 0.8.0 dry run. The $notRegex/$notRegexi operators are absent from packages/sdk-js/test/cases.json and from mongrule.ts, but growthbook#172 keeps them in this SDK for older stored configs.",
+  "evalCondition": [
+    [
+      "$notRegex - pass",
+      {
+        "userAgent": {
+          "$notRegex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      true
+    ],
+    [
+      "$notRegex - fail",
+      {
+        "userAgent": {
+          "$notRegex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$notRegexi - pass",
+      {
+        "userAgent": {
+          "$notRegexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      true
+    ],
+    [
+      "$notRegexi - fail",
+      {
+        "userAgent": {
+          "$notRegexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ]
+  ]
+}

--- a/GrowthBookTests/TestHelper.swift
+++ b/GrowthBookTests/TestHelper.swift
@@ -46,6 +46,20 @@ class TestHelper {
         return array?.arrayValue
     }
 
+    /// Condition cases this fork keeps that the canonical spec does not carry.
+    ///
+    /// They live in their own file so that `Source/json.json` stays a verbatim copy of upstream:
+    /// bumping the corpus is then a file swap that cannot silently drop them — which is exactly what
+    /// the 0.8.0 dry run did before this split.
+    func getLocalEvalConditionData() -> [JSON]? {
+        loadJSON(named: "local-cases", failIfMissing: true)?.dictionaryValue["evalCondition"]?.arrayValue
+    }
+
+    func getContextualBanditData() -> [JSON]? {
+        let array = testData?.dictionaryValue["contextualBandit"]
+        return array?.arrayValue
+    }
+
     func getRunExperimentData() -> [JSON]? {
         let array = testData?.dictionaryValue["run"]
         return array?.arrayValue
@@ -94,18 +108,29 @@ class TestHelper {
     /// testing none of the spec. Both bundles are consulted now, and a miss fails loudly instead of
     /// degrading to a no-op.
     private func loadTestData() -> JSON? {
+        loadJSON(named: "json", failIfMissing: true)
+    }
+
+    /// Reads a fixture file from whichever bundle carries it.
+    ///
+    /// `failIfMissing` is on for the conformance corpus, because every spec-driven test depends on
+    /// it and a silent miss reports success without evaluating anything.
+    private func loadJSON(named name: String, failIfMissing: Bool = false) -> JSON? {
         for bundle in Self.candidateBundles {
             guard
-                let path = bundle.path(forResource: "json", ofType: "json"),
+                let path = bundle.path(forResource: name, ofType: "json"),
                 let data = FileManager.default.contents(atPath: path),
-                let testData = try? JSON(data: data)
+                let json = try? JSON(data: data)
             else { continue }
 
-            return testData
+            return json
         }
 
-        XCTFail("Could not load the conformance fixtures (GrowthBookTests/Source/json.json). "
-                + "Every spec-driven test depends on them, so they must never be missing.")
+        if failIfMissing {
+            XCTFail("Could not load fixtures (GrowthBookTests/Source/\(name).json). "
+                    + "Spec-driven tests depend on them, so a missing file must fail rather than "
+                    + "quietly reduce the case set.")
+        }
         return nil
     }
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,56 @@ If you would like to implement Sticky Bucketing while using Remote Evaluation, y
 
 
 
+## Contextual Bandits
+
+Contextual bandits reallocate experiment traffic toward the best-performing variation *per user segment*. All of the optimisation happens on the GrowthBook backend — the SDK only consumes the ready weights, so no configuration is required. Support is automatic as soon as your payload contains contextual bandits.
+
+The feature payload gains a `contextualBandits` map (or `encryptedContextualBandits` when the endpoint is encrypted), keyed by bandit ref:
+
+```json
+{
+  "features": { "...": {} },
+  "contextualBandits": {
+    "bandit_abc123": {
+      "banditVersion": 4,
+      "contexts": [
+        { "leafId": 0, "condition": { "country": "US" }, "weights": [0.7, 0.3] },
+        { "leafId": 1, "condition": { "country": "CA" }, "weights": [0.2, 0.8] }
+      ]
+    }
+  }
+}
+```
+
+A feature rule opts in with `contextualBanditRef` and carries its variations under `contextualVariations`. At evaluation time the SDK walks the bandit's `contexts` in order, picks the first leaf whose `condition` matches the user's attributes, applies that leaf's `weights`, and then buckets the user through the normal hashing mechanism.
+
+The selection is reported on `ExperimentResult` so it can be attributed in your tracking callback:
+
+```swift
+var sdkInstance: GrowthBookSDK = GrowthBookBuilder(
+    apiHost: <GrowthBook/API_KEY>,
+    clientKey: <GrowthBook/ClientKey>,
+    attributes: <[String: Any]>,
+    trackingCallback: { experiment, experimentResult in
+        // nil unless the experiment is a contextual bandit
+        let leafId = experimentResult.leafId
+        let weights = experimentResult.variationWeights
+        let banditVersion = experimentResult.banditVersion
+    },
+    refreshHandler: { error in })
+    .initializer()
+```
+
+`leafId`, `variationWeights` and `banditVersion` are only set when the user was actually hash-bucketed into the experiment — a forced variation, a QA-mode assignment or a user filtered out by coverage leaves them `nil`.
+
+**Fallback behaviour**
+
+- No leaf condition matches the user → `leafId` is `-1` and the rule's own (aggregate) weights are used, or equal weights if the rule has none.
+- `contextualBanditRef` points at a definition missing from the payload → the rule is evaluated as a plain experiment with its own weights, and no bandit metadata is reported.
+
+Aggregate (non-contextual) bandits need nothing from this: they are delivered as ordinary experiments with server-computed weights and work through the existing bucketing and sticky bucketing paths.
+
+
 ## Sticky Bucketing
 
 Sticky bucketing ensures that users see the same experiment variant, even when user session, user login status, or experiment parameters change. See the [Sticky Bucketing docs](/app/sticky-bucketing) for more information. If your organization and experiment supports sticky bucketing, you must implement an instance of the `StickyBucketService` to use Sticky Bucketing. For simple bucket persistence using the browser's LocalStorage (can be polyfilled for other environments).

--- a/Sources/CommonMain/ContextManager.swift
+++ b/Sources/CommonMain/ContextManager.swift
@@ -174,7 +174,7 @@ import Foundation
   ///
   /// This method creates:
   /// - `ClientOptions` from `globalConfig`
-  /// - `GlobalContext` from `evalData.features` and `evalData.savedGroups`
+  /// - `GlobalContext` from `evalData.features`, `evalData.savedGroups` and `evalData.contextualBandits`
   /// - `UserContext` from `evalData` (attributes, forced variations, etc.)
   /// - A fresh `StackContext` (reset state)
   ///
@@ -195,10 +195,12 @@ import Foundation
       pluginRegistry: globalConfig.pluginRegistry
     )
     
-    // GlobalContext is created from evalData.features and evalData.savedGroups
+    // GlobalContext is created from evalData.features, evalData.savedGroups and
+    // evalData.contextualBandits
     let globalContext = GlobalContext(
       features: evalData.features,
-      savedGroups: evalData.savedGroups
+      savedGroups: evalData.savedGroups,
+      contextualBandits: evalData.contextualBandits
     )
     
     // UserContext is created from evalData

--- a/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/ExperimentEvaluator.swift
@@ -224,7 +224,15 @@ class ExperimentEvaluator {
         if let passthrough = meta?.passthrough {
             result.passthrough = passthrough
         }
-        
+
+        // Surface the contextual bandit selection for tracking, but only for a real exposure:
+        // a forced, filtered-out or QA-mode assignment did not use the bandit's weights.
+        if let contextualBandit = experiment.contextualBandit, hashUsed, inExperiment {
+            result.leafId = contextualBandit.leafId
+            result.variationWeights = contextualBandit.variationWeights
+            result.banditVersion = contextualBandit.banditVersion
+        }
+
         return result
     }
     

--- a/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
+++ b/Sources/CommonMain/Evaluators/FeatureEvaluator.swift
@@ -154,11 +154,14 @@ class FeatureEvaluator {
                                         
                     return forcedFeatureResult
                 } else {
-                    
-                    guard let variations = rule.variations else {
+
+                    // Contextual bandit rules carry their variations under `contextualVariations`
+                    // so that SDKs without bandit support skip the rule entirely. Read them first,
+                    // regardless of whether a ref is present.
+                    guard let variations = rule.contextualVariations ?? rule.variations else {
                         continue
                     }
-                    
+
                     // Otherwise, convert the rule to an Experiment object
                     let exp = Experiment(key: rule.key ?? featureKey,
                                          variations: variations,
@@ -179,9 +182,23 @@ class FeatureEvaluator {
                                          name: rule.name,
                                          phase: rule.phase
                                          )
-                    
+
+                    // Resolve the contextual bandit (if any) before bucketing — it overrides the
+                    // rule's weights with the backend-computed weights for the user's segment.
+                    if let contextualBanditRef = rule.contextualBanditRef {
+                        applyContextualBandit(to: exp, ref: contextualBanditRef)
+                    }
+
                     // Run the experiment.
                     let result = ExperimentEvaluator().evaluateExperiment(context: context, experiment: exp, featureId: featureKey)
+
+                    // The bandit is attached before evaluation; keep it only when the user was
+                    // actually hash-bucketed in, not force-assigned or filtered out. This keeps the
+                    // Experiment exposed on FeatureResult consistent with the ExperimentResult.
+                    if exp.contextualBandit != nil && !((result.hashUsed ?? false) && result.inExperiment) {
+                        exp.contextualBandit = nil
+                    }
+
                     if result.inExperiment && !(result.passthrough ?? false) {
                         // If result.inExperiment is false, skip this rule and continue to the next one.
                         let experimentFeatureResult =  prepareResult(value: result.value, source: FeatureSource.experiment, experiment: exp, result: result, ruleId: rule.id)
@@ -199,6 +216,56 @@ class FeatureEvaluator {
         return defaultFeatureResult
     }
     
+    /// Applies a contextual bandit definition to an experiment before bucketing: selects the leaf
+    /// whose condition matches the user and overrides the experiment's weights with that leaf's
+    /// weights, recording the selection on `Experiment.contextualBandit`.
+    ///
+    /// If the reference is missing from the payload the experiment is left untouched, so the rule's
+    /// own (aggregate) weights apply. If a definition is present but no leaf matches, a fallback
+    /// marker (`ContextualBandit.fallbackLeafId`) is recorded and the experiment's existing or equal
+    /// weights are used.
+    private func applyContextualBandit(to experiment: Experiment, ref: String) {
+        guard let definitionJson = context.globalContext.contextualBandits?.dictionaryValue[ref],
+              definitionJson.dictionary != nil else {
+            logger.debug("Contextual bandit ref not found in payload, using aggregate weights: \(ref)")
+            return
+        }
+
+        let definition = ContextualBanditDefinition(json: definitionJson.dictionaryValue)
+
+        if let leaf = selectContextualBanditLeaf(from: definition.contexts) {
+            experiment.weights = leaf.weights
+            experiment.contextualBandit = ContextualBandit(
+                leafId: leaf.leafId,
+                variationWeights: leaf.weights,
+                banditVersion: definition.banditVersion
+            )
+            return
+        }
+
+        let fallbackWeights = experiment.weights
+            ?? Utils.getEqualWeights(numVariations: experiment.variations.count)
+        experiment.contextualBandit = ContextualBandit(
+            leafId: ContextualBandit.fallbackLeafId,
+            variationWeights: fallbackWeights,
+            banditVersion: definition.banditVersion
+        )
+    }
+
+    /// Returns the first leaf whose condition matches the user's attributes, or `nil` if none do.
+    /// A leaf with no condition matches every user.
+    private func selectContextualBanditLeaf(from contexts: [ContextualBanditContext]?) -> ContextualBanditContext? {
+        guard let contexts, !contexts.isEmpty else { return nil }
+
+        return contexts.first { leaf in
+            ConditionEvaluator().isEvalCondition(
+                attributes: context.userContext.attributes,
+                conditionObj: leaf.condition ?? JSON([String: JSON]()),
+                savedGroups: context.globalContext.savedGroups
+            )
+        }
+    }
+
     /// This is a helper method to create a FeatureResult object.
     ///
     /// Besides the passed-in arguments, there are two derived values - on and off, which are just the value cast to booleans.

--- a/Sources/CommonMain/Features/FeaturesDataModel.swift
+++ b/Sources/CommonMain/Features/FeaturesDataModel.swift
@@ -9,8 +9,10 @@ import Foundation
     var encryptedSavedGroups: String?
     var experiments: [Experiment]?
     var encryptedExperiments: String?
-    
-    init(features: Features? = nil, encryptedFeatures: String? = nil, dateUpdated: String? = nil, savedGroups: JSON? = nil, encryptedSavedGroups: String? = nil, experiments: [Experiment]? = nil, encryptedExperiments: String? = nil) {
+    var contextualBandits: JSON?
+    var encryptedContextualBandits: String?
+
+    init(features: Features? = nil, encryptedFeatures: String? = nil, dateUpdated: String? = nil, savedGroups: JSON? = nil, encryptedSavedGroups: String? = nil, experiments: [Experiment]? = nil, encryptedExperiments: String? = nil, contextualBandits: JSON? = nil, encryptedContextualBandits: String? = nil) {
         self.features = features
         self.encryptedFeatures = encryptedFeatures
         self.dateUpdated = dateUpdated
@@ -18,5 +20,7 @@ import Foundation
         self.encryptedSavedGroups = encryptedSavedGroups
         self.experiments = experiments
         self.encryptedExperiments = encryptedExperiments
+        self.contextualBandits = contextualBandits
+        self.encryptedContextualBandits = encryptedContextualBandits
     }
 }

--- a/Sources/CommonMain/Features/FeaturesViewModel.swift
+++ b/Sources/CommonMain/Features/FeaturesViewModel.swift
@@ -7,6 +7,8 @@ protocol FeaturesFlowDelegate: AnyObject {
     func featuresFetchFailed(error: SDKError, isRemote: Bool)
     func savedGroupsFetchFailed(error: SDKError, isRemote: Bool)
     func savedGroupsFetchedSuccessfully(savedGroups: JSON, isRemote: Bool)
+    func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool)
+    func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool)
     func featuresUpdateIsComplete(error: SDKError?, isRemote: Bool)
 }
 
@@ -113,6 +115,17 @@ class FeaturesViewModel {
                 }
             } else if let savedGroups = try? JSONDecoder().decode(JSON.self, from: savedGroupsData) {
                 delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: isRemote)
+            }
+        }
+
+        if let contextualBanditsData = manager.getContent(fileName: Constants.contextualBanditsCache) {
+            if let encryptionKey, !encryptionKey.isEmpty {
+                if let encryptedString = String(data: contextualBanditsData, encoding: .utf8),
+                   let contextualBandits = Crypto().getContextualBanditsFromEncryptedFeatures(encryptedString: encryptedString, encryptionKey: encryptionKey) {
+                    delegate?.contextualBanditsFetchedSuccessfully(contextualBandits: contextualBandits, isRemote: isRemote)
+                }
+            } else if let contextualBandits = try? JSONDecoder().decode(JSON.self, from: contextualBanditsData) {
+                delegate?.contextualBanditsFetchedSuccessfully(contextualBandits: contextualBandits, isRemote: isRemote)
             }
         }
         return occurredError
@@ -237,6 +250,29 @@ class FeaturesViewModel {
                     manager.saveContent(fileName: Constants.savedGroupsCache, content: savedGroupsData)
                 }
                 delegate?.savedGroupsFetchedSuccessfully(savedGroups: savedGroups, isRemote: true)
+            }
+
+            if let encryptedContextualBandits = jsonPetitions.encryptedContextualBandits, !encryptedContextualBandits.isEmpty, let encryptionKey = encryptionKey, !encryptionKey.isEmpty {
+                let crypto = Crypto()
+                if let contextualBandits = crypto.getContextualBanditsFromEncryptedFeatures(encryptedString: encryptedContextualBandits, encryptionKey: encryptionKey) {
+                    if let encryptedContextualBanditsData = encryptedContextualBandits.data(using: .utf8) {
+                        manager.saveContent(fileName: Constants.contextualBanditsCache, content: encryptedContextualBanditsData)
+                    } else {
+                        logger.error("Failed encode contextual bandits")
+                    }
+                    delegate?.contextualBanditsFetchedSuccessfully(contextualBandits: contextualBandits, isRemote: true)
+                } else {
+                    let error: SDKError = .failedEncryptedContextualBandits
+                    delegate?.contextualBanditsFetchFailed(error: error, isRemote: true)
+                    occurredError = error
+                    logger.error("Failed get contextual bandits from encrypted contextual bandits")
+                    return
+                }
+            } else if let contextualBandits = jsonPetitions.contextualBandits {
+                if let contextualBanditsData = try? JSONEncoder().encode(contextualBandits) {
+                    manager.saveContent(fileName: Constants.contextualBanditsCache, content: contextualBanditsData)
+                }
+                delegate?.contextualBanditsFetchedSuccessfully(contextualBandits: contextualBandits, isRemote: true)
             }
         } else {
             let error: SDKError = .failedParsedData

--- a/Sources/CommonMain/GrowthBookSDK.swift
+++ b/Sources/CommonMain/GrowthBookSDK.swift
@@ -294,6 +294,10 @@ protocol GrowthBookProtocol: AnyObject {
         // unrecognised or corrupted payload must not suppress the fallback network fetch.
         var initialFeatures: Features = [:]
         var hasPreloadedPayload = false
+        // Contextual bandit definitions travel in the same envelope as the features. They are
+        // applied independently of hasPreloadedPayload: a payload can legitimately carry bandits
+        // while the features themselves come from cache or network.
+        var initialContextualBandits: JSON? = nil
 
         if let featuresData = growthBookBuilderModel.features {
             let decoder = JSONDecoder()
@@ -303,6 +307,10 @@ protocol GrowthBookProtocol: AnyObject {
             // so without this check the else-if fallback for raw-map payloads is unreachable.
             if let featuresModel = try? decoder.decode(FeaturesDataModel.self, from: featuresData),
                featuresModel.features != nil || featuresModel.encryptedFeatures != nil {
+                initialContextualBandits = parsePreloadedContextualBandits(
+                    from: featuresModel,
+                    encryptionKey: growthBookBuilderModel.encryptionKey
+                )
                 if let features = featuresModel.features {
                     initialFeatures = features
                     hasPreloadedPayload = true
@@ -347,6 +355,7 @@ protocol GrowthBookProtocol: AnyObject {
             stickyBucketIdentifierAttributes: nil,
             features: initialFeatures,
             savedGroups: nil,
+            contextualBandits: initialContextualBandits,
             url: nil,
             forcedFeatureValues: growthBookBuilderModel.forcedFeatureValues
         )
@@ -375,6 +384,31 @@ protocol GrowthBookProtocol: AnyObject {
         let preloadedFeatures: Features? = hasPreloadedPayload ? initialFeatures : nil
         return GrowthBookSDK(contextManager: contextManager, refreshHandler: refreshHandler, logLevel: growthBookBuilderModel.logLevel, networkDispatcher: networkDispatcher, features: preloadedFeatures, cachingManager: cachingManager, ttlSeconds: ttlSeconds)
     }
+
+    /// Extracts the `contextualBandits` section from a preloaded (offline-mode) payload, decrypting
+    /// it first when the payload uses `encryptedContextualBandits`.
+    ///
+    /// Returns `nil` when the payload carries no bandits or when decryption fails — a missing
+    /// definition makes contextual bandit rules fall back to aggregate/equal weights rather than
+    /// failing evaluation.
+    private func parsePreloadedContextualBandits(from model: FeaturesDataModel, encryptionKey: String?) -> JSON? {
+        if let encryptedContextualBandits = model.encryptedContextualBandits,
+           !encryptedContextualBandits.isEmpty {
+            guard let encryptionKey, !encryptionKey.isEmpty else {
+                logger.error("Preloaded payload has encryptedContextualBandits but no encryption key was provided")
+                return nil
+            }
+            guard let contextualBandits = Crypto().getContextualBanditsFromEncryptedFeatures(
+                encryptedString: encryptedContextualBandits,
+                encryptionKey: encryptionKey
+            ) else {
+                logger.error("Failed to decrypt contextual bandits from preloaded payload")
+                return nil
+            }
+            return contextualBandits
+        }
+        return model.contextualBandits
+    }
 }
 
 /// The main export of the libraries is a simple GrowthBook wrapper class that takes a Context object in the constructor.
@@ -397,6 +431,14 @@ protocol GrowthBookProtocol: AnyObject {
     /// True once the session's initial features have been applied.
     /// Set once and never reset — used as the stableSession latch.
     private var sessionEstablished: Bool = false
+    /// True once the session's contextual bandit definitions have been applied.
+    ///
+    /// Bandits need a latch of their own rather than reusing `sessionEstablished`: on a network
+    /// fetch the features callback fires first and would already have latched, which would block
+    /// the bandits arriving in the very same payload. Bandit weights decide which variation a user
+    /// is bucketed into, so under stableSession they must be frozen for the session just like the
+    /// features are.
+    private var banditsEstablished: Bool = false
 
     deinit {
         contextManager.getGlobalConfig().pluginRegistry.close()
@@ -417,6 +459,16 @@ protocol GrowthBookProtocol: AnyObject {
         self.cachingManager = cachingManager
         self.ttlSeconds = ttlSeconds
         super.init()
+
+        // Latch the bandits before featureVM is constructed — its init reads the cache and can
+        // already deliver a bandits callback. A payload supplied to the builder defines the
+        // session's bandits, so under stableSession later payloads must not replace them.
+        // Safe to set without withLock: the object has not yet escaped to other threads.
+        if contextManager.getGlobalConfig().stableSession,
+           contextManager.getEvaluationData().contextualBandits != nil {
+            banditsEstablished = true
+        }
+
         self.featureVM = FeaturesViewModel(delegate: self, dataSource: FeaturesDataSource(dispatcher: networkDispatcher), cachingManager: cachingManager, ttlSeconds: ttlSeconds, preloadedFeatures: features)
 
         let evalData = contextManager.getEvaluationData()
@@ -496,6 +548,7 @@ protocol GrowthBookProtocol: AnyObject {
             stickyBucketIdentifierAttributes: context.stickyBucketIdentifierAttributes,
             features: features ?? context.features,
             savedGroups: savedGroups ?? context.savedGroups,
+            contextualBandits: context.contextualBandits,
             url: context.url,
             forcedFeatureValues: context.forcedFeatureValues
         )
@@ -564,6 +617,7 @@ protocol GrowthBookProtocol: AnyObject {
                 backgroundSync: globalConfig.backgroundSync,
                 remoteEval: globalConfig.remoteEval,
                 savedGroups: evalData.savedGroups,
+                contextualBandits: evalData.contextualBandits,
                 url: evalData.url,
                 forcedFeatureValues: evalData.forcedFeatureValues
             )
@@ -710,6 +764,33 @@ protocol GrowthBookProtocol: AnyObject {
         withLock {
             self.contextManager.updateEvalData { data in
                 data.savedGroups = savedGroups
+            }
+        }
+    }
+
+    func contextualBanditsFetchFailed(error: SDKError, isRemote: Bool) {}
+
+    func contextualBanditsFetchedSuccessfully(contextualBandits: JSON, isRemote: Bool) {
+        withLock {
+            let stableSession = contextManager.getGlobalConfig().stableSession
+
+            // Applying new bandit weights mid-session would re-bucket users, which is exactly what
+            // stableSession exists to prevent. Cache-only from the second payload onwards.
+            if stableSession && banditsEstablished {
+                if isRemote {
+                    logger.info("stableSession: new contextual bandits received from network — cached for next session, not applied now")
+                } else {
+                    logger.debug("stableSession: ignoring cached contextual bandits — session bandits already established")
+                }
+                return
+            }
+
+            self.contextManager.updateEvalData { data in
+                data.contextualBandits = contextualBandits
+            }
+
+            if stableSession {
+                banditsEstablished = true
             }
         }
     }

--- a/Sources/CommonMain/Model/Context.swift
+++ b/Sources/CommonMain/Model/Context.swift
@@ -35,7 +35,9 @@ import Foundation
     var features: Features
     /// Target the same group of users across multiple features and experiments with Saved Groups
     public var savedGroups: JSON?
-    
+    /// Contextual bandit definitions from the feature payload, keyed by bandit ref
+    public var contextualBandits: JSON?
+
     public var url: String? = nil
     
     public var forcedFeatureValues: JSON? = nil
@@ -56,6 +58,7 @@ import Foundation
          backgroundSync: Bool = false,
          remoteEval: Bool = false,
          savedGroups: JSON? = nil,
+         contextualBandits: JSON? = nil,
          url: String? = nil,
          forcedFeatureValues: JSON? = nil) {
         self.apiHost = apiHost
@@ -74,6 +77,7 @@ import Foundation
         self.backgroundSync = backgroundSync
         self.remoteEval = remoteEval
         self.savedGroups = savedGroups
+        self.contextualBandits = contextualBandits
         self.url = url
         self.forcedFeatureValues = forcedFeatureValues
     }

--- a/Sources/CommonMain/Model/ContextualBandit.swift
+++ b/Sources/CommonMain/Model/ContextualBandit.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// A single leaf of a `ContextualBanditDefinition`: a targeting `condition` paired with the
+/// backend-computed variation `weights` to apply when that condition matches the user.
+///
+/// Part of the read-only contextual bandit payload — leaves are decoded from the feature API
+/// response and never mutated during evaluation.
+public struct ContextualBanditContext: Codable {
+    /// Identifier of this leaf within the bandit definition. Surfaced on `ExperimentResult` so
+    /// exposures can be attributed back to the segment that produced the weights.
+    public let leafId: Int?
+    /// Targeting condition evaluated against the user's attributes. A `nil` or empty condition
+    /// matches every user.
+    public let condition: JSON?
+    /// Variation weights to apply when this leaf matches. Must align with the experiment's
+    /// variation count and, like any weights, sum to 1.
+    public let weights: [Float]?
+
+    init(leafId: Int? = nil, condition: JSON? = nil, weights: [Float]? = nil) {
+        self.leafId = leafId
+        self.condition = condition
+        self.weights = weights
+    }
+
+    init(json: [String: JSON]) {
+        leafId = json["leafId"]?.int
+        condition = json["condition"]
+        if let weights = json["weights"]?.array {
+            self.weights = JSON.convertToArrayFloat(jsonArray: weights)
+        } else {
+            self.weights = nil
+        }
+    }
+}
+
+/// A contextual bandit definition shipped in the feature payload under `contextualBandits`,
+/// keyed by the `contextualBanditRef` a feature rule points at.
+///
+/// A contextual bandit assigns per-segment variation weights: each `ContextualBanditContext`
+/// ("leaf") carries a targeting condition and the weights to use when it matches. The weights
+/// themselves are computed on the GrowthBook backend — the SDK only selects the matching leaf
+/// and applies its weights before bucketing.
+public struct ContextualBanditDefinition: Codable {
+    /// Monotonic version of the backend-computed weights, echoed onto `ExperimentResult` so
+    /// exposures can be attributed to the weight generation that produced them.
+    public let banditVersion: Int?
+    /// Ordered leaves. Leaves are evaluated top-to-bottom and the first whose condition matches
+    /// the user wins; if none match, the SDK falls back to aggregate/equal weights.
+    public let contexts: [ContextualBanditContext]?
+
+    init(banditVersion: Int? = nil, contexts: [ContextualBanditContext]? = nil) {
+        self.banditVersion = banditVersion
+        self.contexts = contexts
+    }
+
+    init(json: [String: JSON]) {
+        banditVersion = json["banditVersion"]?.int
+        contexts = json["contexts"]?.array?.map { ContextualBanditContext(json: $0.dictionaryValue) }
+    }
+}
+
+/// The outcome of resolving a `ContextualBanditDefinition` for a given user: the selected leaf and
+/// the weights that were applied to the `Experiment`.
+///
+/// Attached to the experiment during evaluation and, when the user is hash-bucketed into the
+/// experiment, copied onto `ExperimentResult` for tracking.
+///
+/// A `leafId` of `-1` means no leaf matched and the experiment fell back to its aggregate or
+/// equal weights.
+public struct ContextualBandit: Codable {
+    /// Sentinel `leafId` recorded when a definition was found but no leaf matched the user.
+    public static let fallbackLeafId = -1
+
+    /// The matched leaf's id, or `-1` when no leaf matched and fallback weights were used.
+    public let leafId: Int?
+    /// The weights actually applied to the experiment for this user.
+    public let variationWeights: [Float]?
+    /// The bandit version of the definition that produced these weights.
+    public let banditVersion: Int?
+
+    init(leafId: Int?, variationWeights: [Float]?, banditVersion: Int?) {
+        self.leafId = leafId
+        self.variationWeights = variationWeights
+        self.banditVersion = banditVersion
+    }
+}

--- a/Sources/CommonMain/Model/EvaluationData.swift
+++ b/Sources/CommonMain/Model/EvaluationData.swift
@@ -50,7 +50,9 @@ import Foundation
   var features: Features
   /// Target the same group of users across multiple features and experiments with Saved Groups
   public var savedGroups: JSON?
-  
+  /// Contextual bandit definitions from the feature payload, keyed by bandit ref
+  public var contextualBandits: JSON?
+
   public var url: String? = nil
 
   public var forcedFeatureValues: JSON? = nil
@@ -63,6 +65,7 @@ import Foundation
     stickyBucketIdentifierAttributes: [String]? = nil,
     features: Features = [:],
     savedGroups: JSON? = nil,
+    contextualBandits: JSON? = nil,
     url: String? = nil,
     forcedFeatureValues: JSON? = nil) {
       self.streamingHost = streamingHost
@@ -72,6 +75,7 @@ import Foundation
       self.stickyBucketIdentifierAttributes = stickyBucketIdentifierAttributes
       self.features = features
       self.savedGroups = savedGroups
+      self.contextualBandits = contextualBandits
       self.url = url
       self.forcedFeatureValues = forcedFeatureValues
     }

--- a/Sources/CommonMain/Model/Experiment.swift
+++ b/Sources/CommonMain/Model/Experiment.swift
@@ -46,6 +46,12 @@ import Foundation
     public let phase: String?
     /// Custom fields defined in the GrowthBook UI
     public let customFields: [String: JSON]?
+    /// The contextual bandit leaf selected for this user, when the originating feature rule
+    /// referenced a contextual bandit. Set during evaluation, not part of the API payload.
+    ///
+    /// Cleared again when the user was not hash-bucketed into the experiment, so a selection is
+    /// only ever exposed alongside an actual exposure.
+    public var contextualBandit: ContextualBandit?
 
     public init(key: String,
                 variations: [Any] = [],
@@ -234,6 +240,13 @@ import Foundation
     public let featureId: String?
     /// If sticky bucketing was used to assign a variation
     public let stickyBucketUsed: Bool?
+    /// The contextual bandit leaf whose weights were applied, or `-1` if a definition was found but
+    /// no leaf matched. `nil` when the experiment is not a contextual bandit.
+    public var leafId: Int?
+    /// The variation weights the contextual bandit applied for this user.
+    public var variationWeights: [Float]?
+    /// The version of the backend-computed weights that produced this assignment.
+    public var banditVersion: Int?
 
     public init(inExperiment: Bool,
          variationId: Int,
@@ -274,5 +287,10 @@ import Foundation
         hashUsed = json["hashUsed"]?.boolValue
         featureId = json["featureId"]?.stringValue
         stickyBucketUsed = json["stickyBucketUsed"]?.boolValue
+        leafId = json["leafId"]?.int
+        banditVersion = json["banditVersion"]?.int
+        if let variationWeights = json["variationWeights"]?.array {
+            self.variationWeights = JSON.convertToArrayFloat(jsonArray: variationWeights)
+        }
     }
 }

--- a/Sources/CommonMain/Model/Feature.swift
+++ b/Sources/CommonMain/Model/Feature.swift
@@ -69,6 +69,12 @@ public struct FeatureRule: Codable, Sendable {
     public let phase: String?
     /// Array of tracking calls to fire
     public let tracks: [Track]?
+    /// Reference into the payload's `contextualBandits` map. When set, this rule is a contextual
+    /// bandit: its variations are carried in `contextualVariations` (so SDKs without bandit support
+    /// skip it) and its weights are resolved per-user from the referenced definition.
+    public let contextualBanditRef: String?
+    /// Variations for a contextual bandit rule. Used in place of `variations` when present.
+    public let contextualVariations: [JSON]?
 
     init(id: String? = "", condition: Condition? = nil,
          coverage: Float? = nil,
@@ -91,7 +97,9 @@ public struct FeatureRule: Codable, Sendable {
          seed: String? = nil,
          name: String? = nil,
          phase: String? = nil,
-         tracks: [Track]? = nil) {
+         tracks: [Track]? = nil,
+         contextualBanditRef: String? = nil,
+         contextualVariations: [JSON]? = nil) {
         self.id = id
         self.condition = condition
         self.coverage = coverage
@@ -115,9 +123,11 @@ public struct FeatureRule: Codable, Sendable {
         self.name = name
         self.phase = phase
         self.tracks = tracks
+        self.contextualBanditRef = contextualBanditRef
+        self.contextualVariations = contextualVariations
     }
-    
-    init(json: [String: JSON]) {        
+
+    init(json: [String: JSON]) {
         id = json["id"]?.stringValue ?? ""
         
         condition = json["condition"]
@@ -185,6 +195,10 @@ public struct FeatureRule: Codable, Sendable {
         tracks = json["tracks"]?.map({ key, value in
             Track(json: value.dictionaryValue)
         })
+
+        contextualBanditRef = json["contextualBanditRef"]?.string
+
+        contextualVariations = json["contextualVariations"]?.array
     }
 }
 

--- a/Sources/CommonMain/Model/GlobalContext.swift
+++ b/Sources/CommonMain/Model/GlobalContext.swift
@@ -4,15 +4,20 @@ import Foundation
     var features: Features
     public var experiments: [Experiment]?
     public var savedGroups: JSON?
+    /// Contextual bandit definitions from the feature payload, keyed by bandit ref. Read during
+    /// evaluation to resolve contextual bandit feature rules. May be `nil` or empty.
+    public var contextualBandits: JSON?
 
     init(
         features: Features = [:],
         experiments: [Experiment]? = nil,
-        savedGroups: JSON? = nil
+        savedGroups: JSON? = nil,
+        contextualBandits: JSON? = nil
     ) {
         self.features = features
         self.experiments = experiments
         self.savedGroups = savedGroups
+        self.contextualBandits = contextualBandits
     }
 }
 

--- a/Sources/CommonMain/Utils/Constants.swift
+++ b/Sources/CommonMain/Utils/Constants.swift
@@ -8,6 +8,8 @@ public enum Constants {
     public static let featureCache = "FeatureCache"
     
     public static let savedGroupsCache = "SavedGroupsCache"
+
+    public static let contextualBanditsCache = "ContextualBanditsCache"
 }
 
 /// Type Alias for Feature in GrowthBook
@@ -86,6 +88,7 @@ public enum SDKErrorCode: String {
     case failedMissingKey
     case failedEncryptedFeatures
     case failedEncryptedSavedGroups
+    case failedEncryptedContextualBandits
     case failedParsedEncryptedData
     case failedToFetchData
     case invalidAPIURL
@@ -98,6 +101,7 @@ public enum SDKErrorCode: String {
     static let failedMissingKey = SDKError(code: .failedMissingKey)
     static let failedEncryptedFeatures = SDKError(code: .failedEncryptedFeatures)
     static let failedEncryptedSavedGroups = SDKError(code: .failedEncryptedSavedGroups)
+    static let failedEncryptedContextualBandits = SDKError(code: .failedEncryptedContextualBandits)
     static let failedParsedEncryptedData = SDKError(code: .failedParsedEncryptedData)
     static let failedToFetchData = SDKError(code: .failedToFetchData)
     static let invalidAPIURL = SDKError(code: .invalidAPIURL)

--- a/Sources/CommonMain/Utils/Crypto.swift
+++ b/Sources/CommonMain/Utils/Crypto.swift
@@ -137,6 +137,17 @@ class Crypto: CryptoProtocol {
     }
     
     func getSavedGroupsFromEncryptedFeatures(encryptedString: String, encryptionKey: String) -> JSON? {
+        decryptToJSON(encryptedString: encryptedString, encryptionKey: encryptionKey)
+    }
+
+    func getContextualBanditsFromEncryptedFeatures(encryptedString: String, encryptionKey: String) -> JSON? {
+        decryptToJSON(encryptedString: encryptedString, encryptionKey: encryptionKey)
+    }
+
+    /// Decrypts an `iv.cipherText` payload and decodes the plaintext as an arbitrary JSON value.
+    /// Shared by the `savedGroups` and `contextualBandits` payload sections, both of which are
+    /// opaque JSON objects rather than typed models.
+    private func decryptToJSON(encryptedString: String, encryptionKey: String) -> JSON? {
         let decoder = JSONDecoder()
         let arrayEncryptedString = encryptedString.components(separatedBy: ".")
         guard let iv = arrayEncryptedString.first,
@@ -147,12 +158,12 @@ class Crypto: CryptoProtocol {
               let plainTextBuffer = try? decrypt(key: keyBase64.map{$0},
                                                  iv: ivBase64.map{$0},
                                                  cypherText: cipherTextBase64.map{$0}),
-              let savedGroups = try? decoder.decode(JSON.self, from: Data(plainTextBuffer))
+              let json = try? decoder.decode(JSON.self, from: Data(plainTextBuffer))
         else { return nil }
-                
-        return savedGroups
+
+        return json
     }
-    
+
 }
 
 struct CryptoError: Error {

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -293,7 +293,11 @@ public class Utils {
             let feature = features[id]
             if let rules = feature?.rules {
                 for rule in rules {
-                    if rule.variations != nil {
+                    // A contextual bandit rule carries its variations under contextualVariations, so
+                    // checking `variations` alone would leave its hash and fallback attributes
+                    // unregistered and the sticky bucket service would never be asked for that
+                    // experiment's assignment documents.
+                    if rule.variations != nil || rule.contextualVariations != nil {
                         attributes.insert(rule.hashAttribute ?? "id")
                         if let fallbackAttribute = rule.fallbackAttribute {
                             attributes.insert(fallbackAttribute)

--- a/Sources/CommonMain/Utils/Utils.swift
+++ b/Sources/CommonMain/Utils/Utils.swift
@@ -451,7 +451,9 @@ public class Utils {
                                     url: context.url,
                                     trackingClosure: context.trackingClosure)
         
-        let globalContext = GlobalContext(features: context.features, savedGroups: context.savedGroups)
+        let globalContext = GlobalContext(features: context.features,
+                                          savedGroups: context.savedGroups,
+                                          contextualBandits: context.contextualBandits)
         
         // should create manual force features
             let userContext = UserContext(attributes: context.attributes, stickyBucketAssignmentDocs: context.stickyBucketAssignmentDocs, forcedVariations: context.forcedVariations, forcedFeatureValues: context.forcedFeatureValues)


### PR DESCRIPTION
## What

  - **Models** — `contextualBandits` on the payload, `contextualBandit` on `Experiment`,
    `contextualVariations` on `FeatureRule`, plus the result fields (`leafId`,
  - **Evaluation** — bandit refs are resolved during feature and experiment evaluation;
    when no definition is available the rule falls back to aggregate weights rather than
    failing.
  - **Sticky bucketing** — bandit rules are registered in the identifier scan, so a
    bandit experiment participates in sticky bucketing like any other.
  - **Legacy bridge** — `Utils.initializeEvalContext` carries the bandits across when
    building an `EvalContext` from the legacy `Context`. Without this, everything routed
    through that bridge evaluated bandit rules with no definitions and silently reported
    no bandit metadata; found while writing the spec runner.
  
  ## Conformance

  The corpus moves from 0.7.1 to 0.8.0 and a `contextualBandit` runner is added:

  - `contextualBandit` — 35 cases, plus 7 bandit cases inside `feature`
  - `evalCondition` — 233 → 248 cases
  - `stickyBucket` — 4 → 13 cases
  
  None of the added cases had ever run in this SDK. They all pass, so the bump exposes
  no existing debt — it makes the claim of conformance checkable instead of asserted.

  Verified by sabotage rather than by observing green: corrupting one expected value
  makes the runner report "1 of 35 contextual bandit cases failed". The runner compares
  a field only when the case declares it, so cases that omit `banditVersion` assert its
  absence instead of passing by accident. 
  
  ## A note on the corpus swap
  
Four `$notRegex`/`$notRegexi` condition cases live in this repo but not in the
  canonical spec (`packages/sdk-js/test/cases.json` has none, and `mongrule.ts` does not
  implement them at all); they are kept here at your request in the #172 review. They
  now live in `Source/local-cases.json`, which the condition suite reads alongside the
  corpus, so `Source/json.json` stays a verbatim copy of upstream and a future bump is a
  clean file swap rather than something that can quietly drop their coverage.

  ## Verification
  
  - `swift test` — 588 passing (the conformance suite really runs under SwiftPM since #177)
  - new test file and fixture registered in the Xcode project; `plutil -lint` passes
  - Swift 6 language mode: one new error of an existing family 
    (`contextualVariations: JSON` in `Sendable`-conforming `FeatureRule`, the 13th such
    case in `Feature.swift`). It is cleared by #167, which makes `JSON` `@unchecked
    Sendable` — verified: this branch merged with #167 builds with zero Swift 6 errors
    and no conflicts.
